### PR TITLE
Fix synergy eval loader usage

### DIFF
--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -150,10 +150,13 @@ def teacher_adaptive_update(
         ep_loss = teacher_loss_sum / count
 
         # synergy_eval
-        if "testloader" in cfg and cfg["testloader"] is not None:
+        # Use the explicit `testloader` argument rather than looking for it
+        # inside `cfg`. This ensures the evaluation loader is correctly used
+        # even when `cfg` does not contain a `testloader` entry.
+        if testloader is not None:
             synergy_test_acc = eval_synergy(
                 teacher_wrappers, mbm, synergy_head,
-                loader=cfg["testloader"],
+                loader=testloader,
                 device=cfg["device"],
                 feat_key=cfg.get("feat_key", "feat_2d")  # 예: "feat_4d"
             )


### PR DESCRIPTION
## Summary
- use testloader arg directly in `teacher_adaptive_update`

## Testing
- `python -m py_compile modules/trainer_teacher.py`
- `python -m py_compile main.py eval.py modules/*.py models/*.py models/students/*.py models/teachers/*.py utils/*.py methods/*.py data/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6843ac9739a88321bff7bfdf9ec5271b