### PR TITLE
Fix LayerNorm freeze bug and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,13 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
    ```bash
    git clone https://github.com/YourName/ASMB-KD.git
    cd ASMB-KD
-
-	2.	Install dependencies:
-
+```
+2. **Install dependencies**:
+```bash
 pip install -r requirements.txt
+```
 
-
-
-⸻
+---
 
 Usage
 
@@ -54,7 +53,7 @@ python eval.py --eval_mode synergy \
 
 	•	Prints Train/Test accuracy, optionally logs to CSV if configured.
 
-⸻
+---
 ```plaintext
 Folder Structure
 
@@ -133,14 +132,14 @@ Folder Structure
 	• scripts/: Shell scripts for multiple or batch experiments
 
 ```
-⸻
+---
 
 Results
 
 Experiment outputs (CSV, logs, etc.) reside in the results/ folder.
 You can run analysis/compare_ablation.py or analysis/plot_results.ipynb to analyze or visualize them.
 
-⸻
+---
 
 License
 
@@ -153,7 +152,7 @@ Copyright (c) 2024 Suyoung Yang
 Permission is hereby granted, free of charge, ...
 
 
-⸻
+---
 
 Citation
 
@@ -167,7 +166,7 @@ If you use this framework, please cite:
 }
 
 
-⸻
+---
 
 Contact
 

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -127,8 +127,11 @@ def partial_freeze_teacher_swin(
                 param.requires_grad = True
 
     if not freeze_ln:
-        # LN unfreeze
-        model.apply(freeze_ln_params)
+        # Unfreeze LayerNorm parameters
+        for m in model.modules():
+            if isinstance(m, nn.LayerNorm):
+                for p in m.parameters():
+                    p.requires_grad = True
 
 def partial_freeze_student_resnet(
     model: nn.Module,
@@ -230,4 +233,7 @@ def partial_freeze_student_swin(
                 param.requires_grad = True
 
     if not freeze_ln:
-        model.apply(freeze_ln_params)
+        for m in model.modules():
+            if isinstance(m, nn.LayerNorm):
+                for p in m.parameters():
+                    p.requires_grad = True


### PR DESCRIPTION
## Summary
- fix bug that incorrectly froze LayerNorm when it should unfreeze
- clean up installation instructions in README
- normalize section separators

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e037c9788321b58b25af9cb05ac1