### PR TITLE
Fix CLI for teacher checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Usage
 
 1) Multi-Stage Distillation (main.py)
 
-python main.py --config configs/partial_freeze.yaml --device cuda
-
+python main.py --config configs/partial_freeze.yaml --device cuda \
+--teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth
 	•	Adjust hyperparameters in configs/*.yaml (partial freeze, learning rates, etc.).
+	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
 
 2) Evaluation (eval.py)
 

--- a/main.py
+++ b/main.py
@@ -75,6 +75,8 @@ def parse_args():
     # (2) sweep 할 때 바꿀 필드들 ▶ YAML 값을 CLI-인자가 **덮어쓰도록** 할 목적
     parser.add_argument("--teacher1_type", type=str)
     parser.add_argument("--teacher2_type", type=str)
+    parser.add_argument("--teacher1_ckpt", type=str)
+    parser.add_argument("--teacher2_ckpt", type=str)
     parser.add_argument("--num_stages",   type=int)
     parser.add_argument("--synergy_ce_alpha", type=float)    # α
     parser.add_argument("--student_type", type=str)


### PR DESCRIPTION
## Summary
- add CLI args to load teacher checkpoints
- document teacher checkpoint options in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e414d5d08321b4cef83ec9feed54