### PR TITLE
Centralize hyperparameter overrides in run scripts

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,8 @@ def parse_args():
     parser.add_argument("--epochs",     type=int)            # 예: teacher_iters
     parser.add_argument("--results_dir", type=str)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--override", type=str,
+                        help="comma-separated KEY=VAL pairs to override config")
     return parser.parse_args()
 
 def load_config(cfg_path):
@@ -144,7 +146,12 @@ def main():
 
     # 2) load config from YAML
     base_cfg = load_config(args.config)
-    cfg = {**base_cfg, **vars(args)}
+    cli_cfg = vars(args)
+    override_str = cli_cfg.pop("override", None)
+    cfg = {**base_cfg, **cli_cfg}
+    if override_str:
+        from utils.misc import parse_override_str
+        cfg.update(parse_override_str(override_str))
 
     logger = ExperimentLogger(cfg, exp_name="asmb_experiment")
 

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -52,6 +52,10 @@ def parse_args():
     parser.add_argument("--finetune_weight_decay", type=float)
     # ↓ run_many.sh 에서 CutMix 알파도 변경할 수 있도록
     parser.add_argument("--cutmix_alpha", type=float)
+
+    # (공통) config 값을 key=value 형태로 덮어쓰기
+    parser.add_argument("--override", type=str,
+                        help="comma-separated KEY=VAL pairs to override config")
     
     return parser.parse_args()
 
@@ -129,7 +133,11 @@ def main():
 
     # argparse 값이 None 이면 YAML 값을 유지, 아니면 덮어쓰기
     cli_cfg  = {k: v for k, v in vars(args).items() if v is not None}
-    cfg      = {**base_cfg, **cli_cfg}
+    override_str = cli_cfg.pop("override", None)
+    cfg = {**base_cfg, **cli_cfg}
+    if override_str:
+        from utils.misc import parse_override_str
+        cfg.update(parse_override_str(override_str))
     device = cfg.get("device", "cuda")
     if device == "cuda" and not torch.cuda.is_available():
         print("[Warning] No CUDA => Using CPU")

--- a/scripts/run_many.sh
+++ b/scripts/run_many.sh
@@ -15,6 +15,8 @@ FT_LR=0.001            # --finetune_lr
 FT_WD=0.0005           # --finetune_weight_decay
 FT_BATCH=128           # --batch_size  (fine-tune & distill 공통 사용)
 CUTMIX_ALPHA=1.0       # --cutmix_alpha
+# 추가 YAML 덮어쓰기용 파라미터 (선택)
+FT_OVERRIDE=""         # 예) "fine_tune_partial_freeze=true"
 
 # (B) ASMB Distillation
 T_LR=2e-4              # --teacher_lr  (adaptive update)
@@ -22,6 +24,7 @@ S_LR=1e-2              # --student_lr
 N_STAGE_LIST="2 3"     # for STAGE in …
 SC_ALPHA_LIST="0.3 0.6"
 STUDENT_LIST="resnet_adapter efficientnet_adapter swin_adapter"
+DISTILL_OVERRIDE=""    # 예) "ce_alpha=0.5,kd_alpha=0.5"
 ###############################################################################
 
 mkdir -p checkpoints results
@@ -45,7 +48,8 @@ for T2 in efficientnet_b2 swin_tiny; do
         --finetune_lr ${FT_LR} \
         --finetune_weight_decay ${FT_WD} \
         --cutmix_alpha ${CUTMIX_ALPHA} \
-        --finetune_ckpt_path "${CKPT}"
+        --finetune_ckpt_path "${CKPT}" \
+        ${FT_OVERRIDE:+--override "$FT_OVERRIDE"}
     fi
   done
 
@@ -70,7 +74,8 @@ for T2 in efficientnet_b2 swin_tiny; do
           --student_lr ${S_LR} \
           --batch_size ${FT_BATCH} \
           --results_dir "${OUTDIR}" \
-          --seed 42
+          --seed 42 \
+          ${DISTILL_OVERRIDE:+--override "$DISTILL_OVERRIDE"}
       done
     done
   done

--- a/scripts/run_sweep.sh
+++ b/scripts/run_sweep.sh
@@ -2,9 +2,13 @@
 
 # Example: sweep teacher_lr & synergy_ce_alpha
 
-for teacher_lr in 0.0001 0.0002 0.0005
+TEACHER_LR_LIST="0.0001 0.0002 0.0005"
+SC_ALPHA_LIST="0.2 0.3 0.5"
+DISTILL_OVERRIDE=""    # 예) "student_lr=0.01,student_epochs_per_stage=15"
+
+for teacher_lr in ${TEACHER_LR_LIST}
 do
-  for sc_alpha in 0.2 0.3 0.5
+  for sc_alpha in ${SC_ALPHA_LIST}
   do
     echo "=========================================="
     echo "[RUN] teacher_lr=$teacher_lr synergy_ce_alpha=$sc_alpha"
@@ -14,6 +18,7 @@ do
       --config configs/default.yaml \
       --teacher_lr $teacher_lr \
       --synergy_ce_alpha $sc_alpha \
-      --device cuda
+      --device cuda \
+      ${DISTILL_OVERRIDE:+--override "$DISTILL_OVERRIDE"}
   done
 done

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -4,6 +4,7 @@ import os
 import torch
 import random
 import numpy as np
+import yaml
 
 def set_random_seed(seed=42):
     """
@@ -49,3 +50,23 @@ def cutmix_data(inputs, targets, alpha=1.0):
     # ... (이전에도 썼던 cutmix 코드)
     # ...
     return inputs_clone, target_a, target_b, lam
+
+
+def parse_override_str(override: str):
+    """Parse comma-separated KEY=VAL pairs into a dictionary."""
+    overrides = {}
+    if not override:
+        return overrides
+    for pair in override.split(','):
+        if '=' not in pair:
+            continue
+        key, val = pair.split('=', 1)
+        key = key.strip()
+        val = val.strip()
+        if not key:
+            continue
+        try:
+            overrides[key] = yaml.safe_load(val)
+        except Exception:
+            overrides[key] = val
+    return overrides


### PR DESCRIPTION
## Summary
- allow any config option to be overridden via `--override` argument
- implement parser in `utils.misc.parse_override_str`
- update `main.py` and `fine_tuning.py` to apply overrides
- expose additional override variables in `run_many.sh` and `run_sweep.sh`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f4122c9c8321ab7a1c624ca33991