### PR TITLE
Add automatic teacher fine-tuning

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -12,6 +12,11 @@ teacher2_type: "efficientnet_b2"
 teacher1_pretrained: true
 teacher2_pretrained: true
 
+# Fine-tune settings (used when checkpoints are absent)
+finetune_epochs: 50
+finetune_lr: 0.001
+finetune_weight_decay: 0.0005
+
 teacher_lr: 0.0001           # 통합 Teacher 학습률
 teacher_weight_decay: 0.0003
 teacher_adapt_epochs: 5      # Teacher Adaptive Update epochs


### PR DESCRIPTION
## Summary
- add a helper in `main.py` to automatically fine-tune teachers if a checkpoint is missing
- expose fine-tune related CLI arguments
- update `configs/default.yaml` with default fine-tuning hyperparameters

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68440bd95290832199e104b2df6c8d21