### PR TITLE
Add MBM dropout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **Multi-Stage Distillation**: Teacher ↔ Student updates in a phased (block-wise) manner  
 - **ASMB** (Adaptive Synergy Manifold Bridging): Uses a Manifold Bridging Module (MBM) to fuse two Teacher feature maps into synergy logits  
 - **Partial Freeze**: Freeze backbone parameters, adapt BN/Heads/MBM for efficiency  
-- **Multiple KD Methods**: FitNet, CRD, AT, DKD, VanillaKD, plus custom `asmb.py`  
+- **Multiple KD Methods**: FitNet, CRD, AT, DKD, VanillaKD, plus custom `asmb.py`
 - **CIFAR-100 / ImageNet100** dataset support
 - **Configurable Data Augmentation**: toggle with `--data_aug` (1/0)
+- **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
+  Manifold Bridging Module
 
 ---
 
@@ -62,6 +64,12 @@ Use the `--data_aug` flag to control dataset transforms. When set to `1` (defaul
 ```bash
 python main.py --config configs/default.yaml --data_aug 0
 ```
+
+### MBM Dropout
+
+The `mbm_dropout` value in `configs/*.yaml` controls dropout inside the
+Manifold Bridging Module MLP. Start with `0.0` and increase to around
+`0.1`&ndash;`0.3` if the synergy model begins to overfit.
 
 
 ---

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -42,6 +42,7 @@ use_partial_freeze: true
 mbm_in_dim: 3456
 mbm_hidden_dim: 1024
 mbm_out_dim: 2048
+mbm_dropout: 0.0
 
 cutmix_alpha: 1.0
 

--- a/main.py
+++ b/main.py
@@ -319,6 +319,7 @@ def main():
 
     mbm_hidden_dim = cfg.get("mbm_hidden_dim", 512)
     mbm_out_dim    = cfg.get("mbm_out_dim", 512)
+    mbm_dropout    = cfg.get("mbm_dropout", 0.0)
 
     # 만약 4D 채널을 쓰려면 teacher가 get_feat_channels()도 제공해야 함
     # ex) t1_ch = teacher1.get_feat_channels()
@@ -332,6 +333,7 @@ def main():
         in_dim=mbm_in_dim,
         hidden_dim=mbm_hidden_dim,
         out_dim=mbm_out_dim,
+        dropout=mbm_dropout,
 
         # 4D params (예시 주석)
         # in_ch_4d=in_ch_4d,

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -13,6 +13,7 @@ class ManifoldBridgingModule(nn.Module):
         in_dim:      int,
         hidden_dim:  int,
         out_dim:     int,
+        dropout:     float = 0.0,
         # in_ch_4d:  Optional[int] = None,  # 4D 경로를 쓰게 되면 추가
         # out_ch_4d: Optional[int] = None
     ):
@@ -22,8 +23,10 @@ class ManifoldBridgingModule(nn.Module):
         self.mlp = nn.Sequential(
             nn.Linear(in_dim, hidden_dim),
             nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
             nn.Linear(hidden_dim, hidden_dim),
             nn.ReLU(inplace=True),
+            nn.Dropout(dropout),
             nn.Linear(hidden_dim, out_dim)
         )
 


### PR DESCRIPTION
## Summary
- add `dropout` parameter to `ManifoldBridgingModule`
- insert dropout layers in the MBM MLP
- expose `mbm_dropout` in default config
- pass this config value when constructing MBM
- document MBM dropout setting and tuning instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442d025628832186beeb2173b32141