### PR TITLE
Add MixUp and label smoothing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Use the `--data_aug` flag to control dataset transforms. When set to `1` (defaul
 python main.py --config configs/default.yaml --data_aug 0
 ```
 
+### MixUp & Label Smoothing
+
+Enable MixUp by setting `mixup_alpha` > 0 in the config or via the CLI. The
+cross-entropy loss also supports label smoothing through the
+`label_smoothing` option.
+
+```bash
+python main.py --config configs/default.yaml \
+  --mixup_alpha 0.2 --label_smoothing 0.1
+```
+
 
 ---
 ```plaintext

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -44,6 +44,8 @@ mbm_hidden_dim: 1024
 mbm_out_dim: 2048
 
 cutmix_alpha: 1.0
+mixup_alpha: 0.0
+label_smoothing: 0.0
 
 log_filename: "train.log"
 save_checkpoint: true

--- a/main.py
+++ b/main.py
@@ -100,6 +100,8 @@ def parse_args():
     parser.add_argument("--finetune_ckpt1", type=str)
     parser.add_argument("--finetune_ckpt2", type=str)
     parser.add_argument("--data_aug", type=int, help="1: use augmentation, 0: disable")
+    parser.add_argument("--mixup_alpha", type=float)
+    parser.add_argument("--label_smoothing", type=float)
     return parser.parse_args()
 
 def load_config(cfg_path):

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -3,11 +3,23 @@
 import torch
 import torch.nn.functional as F
 
-def ce_loss_fn(student_logits, labels):
+def ce_loss_fn(student_logits, labels, label_smoothing: float = 0.0):
+    """Standard cross-entropy loss for classification.
+
+    Parameters
+    ----------
+    student_logits : Tensor
+        Model predictions of shape ``(N, C)``.
+    labels : Tensor
+        Ground-truth integer labels.
+    label_smoothing : float, optional
+        Amount of label smoothing to apply. ``0.0`` disables smoothing.
     """
-    Standard cross-entropy loss for classification.
-    """
-    return F.cross_entropy(student_logits, labels)
+    return F.cross_entropy(
+        student_logits,
+        labels,
+        label_smoothing=label_smoothing,
+    )
 
 def kd_loss_fn(student_logits, teacher_logits, T=4.0, reduction="batchmean"):
     """


### PR DESCRIPTION
## Summary
- implement `mixup_data` and `mixup_criterion` utilities
- support label smoothing in `ce_loss_fn`
- expose `mixup_alpha` and `label_smoothing` via config and CLI
- apply MixUp augmentation in student distillation when enabled
- document new training options in README

## Testing
- `python -m py_compile modules/losses.py modules/trainer_student.py utils/misc.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68442d00a1508321bb17161feb6c53f5