### PR TITLE
Add small_input option for ResNet fine‑tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **MixUp & Label Smoothing**: enable with `--mixup_alpha` and `--label_smoothing`
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
+- **CIFAR-friendly ResNet stem**: use `--small_input 1` when fine-tuning to
+  replace the 7x7 conv with a 3x3 version and disable max-pooling
 
 ---
 

--- a/configs/fine_tune.yaml
+++ b/configs/fine_tune.yaml
@@ -2,6 +2,7 @@
 
 device: "cuda"
 dataset_name: "cifar100"
+small_input: true        # use 3x3 conv stem when dataset uses 32x32 images
 
 # Teacher
 teacher_name: "resnet101"


### PR DESCRIPTION
## Summary
- allow `create_resnet101` to adapt its stem for 32x32 images via `small_input`
- expose `--small_input` flag in `scripts/fine_tuning.py`
- default to using the smaller stem for CIFAR-100 in config
- document the new option in README

## Testing
- `python -m py_compile models/teachers/teacher_resnet.py scripts/fine_tuning.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844359338e48321924acfe000f39a70