### PR TITLE
Add features_classifier partial freeze

### DIFF
--- a/configs/partial_freeze.yaml
+++ b/configs/partial_freeze.yaml
@@ -15,12 +15,12 @@ teacher1_freeze_scope: "layer4_fc"  # partial_freeze_teacher_resnet에서 layer4
 teacher2_type: "efficientnet_b2"
 teacher2_pretrained: true
 teacher2_freeze_bn: true            # BN까지 동결
-teacher2_freeze_scope: "classifier_only"
+teacher2_freeze_scope: "classifier_only"  # or "features_classifier" to unfreeze features + classifier (+ mbm)
 
 # 4) Student 관련
 student_type: "resnet_adapter"
 student_freeze_bn: false            # BN unfreeze
-student_freeze_scope: "fc_only"
+student_freeze_scope: "fc_only"      # EfficientNet 사용 시 "features_classifier" 도 가능
 student_use_adapter: false          # adapter_ 파라미터 해제 여부
 
 # 기타

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -91,6 +91,16 @@ def partial_freeze_teacher_efficientnet(
             if "classifier." in name:
                 param.requires_grad = True
 
+    elif freeze_scope == "features_classifier":
+        # features. + classifier. (+ mbm.)
+        for name, param in model.named_parameters():
+            if (
+                "features." in name
+                or "classifier." in name
+                or "mbm." in name
+            ):
+                param.requires_grad = True
+
     else:
         # default: classifier. + mbm. unfreeze
         for name, param in model.named_parameters():
@@ -180,13 +190,20 @@ def partial_freeze_student_efficientnet(
     freeze_scope: str = None
 ):
     """
-    Student (EfficientNet-B2)
+    Student (EfficientNet-B2) partial freeze
+      - freeze_scope 예시:
+         "classifier_only", "features_classifier", etc.
     """
     freeze_all_params(model)
 
     if freeze_scope == "classifier_only":
         for name, param in model.named_parameters():
             if "classifier." in name:
+                param.requires_grad = True
+
+    elif freeze_scope == "features_classifier":
+        for name, param in model.named_parameters():
+            if "features." in name or "classifier." in name:
                 param.requires_grad = True
     else:
         # default => classifier. (기존)


### PR DESCRIPTION
## Summary
- support `features_classifier` option for EfficientNet partial freeze
- document the new value in the example config

## Testing
- `python -m py_compile modules/partial_freeze.py`
- `pytest -q`
- `flake8 modules/partial_freeze.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844536d6ca48321af9c5e044dd553b3