### PR TITLE
Add smart progress bar helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **MixUp & Label Smoothing**: enable with `--mixup_alpha` and `--label_smoothing`
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
+- **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs
   (and remove max-pool for ResNet)

--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from tqdm import tqdm
+from utils.progress import smart_tqdm
 
 def cutmix_data(inputs, targets, alpha=1.0):
     """
@@ -63,7 +63,7 @@ def train_one_epoch_cutmix(teacher_model, loader, optimizer, alpha=1.0, device="
     total_loss = 0.0
     correct, total = 0, 0
 
-    for batch_idx, (x, y) in enumerate(tqdm(loader, desc="[CutMix Train]")):
+    for batch_idx, (x, y) in enumerate(smart_tqdm(loader, desc="[CutMix Train]")):
         x, y = x.to(device), y.to(device)
 
         # 1) cutmix
@@ -193,7 +193,7 @@ def standard_ce_finetune(
 
     for ep in range(1, epochs + 1):
         teacher_model.train()
-        for x, y in tqdm(train_loader, desc=f"[CE FineTune ep={ep}]"):
+        for x, y in smart_tqdm(train_loader, desc=f"[CE FineTune ep={ep}]"):
             x, y = x.to(device), y.to(device)
             optimizer.zero_grad()
             _, logits, _ = teacher_model(x)

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import copy
-from tqdm import tqdm
+from utils.progress import smart_tqdm
 
 from modules.losses import kd_loss_fn, ce_loss_fn
 from utils.misc import mixup_data, mixup_criterion
@@ -73,7 +73,7 @@ def student_distillation_update(
         cnt = 0
         student_model.train()
 
-        for x, y in tqdm(trainloader, desc=f"[StudentDistill ep={ep+1}]"):
+        for x, y in smart_tqdm(trainloader, desc=f"[StudentDistill ep={ep+1}]"):
             x, y = x.to(cfg["device"]), y.to(cfg["device"])
 
             if cfg.get("mixup_alpha", 0.0) > 0.0:

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import copy
-from tqdm import tqdm
+from utils.progress import smart_tqdm
 
 from modules.losses import kd_loss_fn, ce_loss_fn
 from torch.optim.lr_scheduler import StepLR
@@ -95,7 +95,7 @@ def teacher_adaptive_update(
         teacher_loss_sum = 0.0
         count = 0
 
-        for batch in tqdm(trainloader, desc=f"[TeacherAdaptive ep={ep+1}]"):
+        for batch in smart_tqdm(trainloader, desc=f"[TeacherAdaptive ep={ep+1}]"):
             x, y = batch
             x, y = x.to(cfg["device"]), y.to(cfg["device"])
 

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,0 +1,28 @@
+from tqdm import tqdm
+import sys
+
+__all__ = ["smart_tqdm"]
+
+
+def smart_tqdm(iterable, desc=None, **kwargs):
+    """A thin wrapper around :class:`tqdm.tqdm`.
+
+    Parameters
+    ----------
+    iterable : iterable
+        The iterable to wrap.
+    desc : str, optional
+        Description for the progress bar.
+    **kwargs : Any
+        Additional ``tqdm`` keyword arguments.
+
+    Returns
+    -------
+    iterator
+        ``tqdm`` iterator with sensible defaults.
+    """
+    kwargs.setdefault("file", sys.stdout)
+    kwargs.setdefault("leave", False)
+    if "disable" not in kwargs:
+        kwargs["disable"] = not sys.stdout.isatty()
+    return tqdm(iterable, desc=desc, **kwargs)


### PR DESCRIPTION
## Summary
- add `smart_tqdm` wrapper to suppress progress bars in non-interactive runs
- switch training modules to use `smart_tqdm`
- document automatic progress bar disabling in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684458e02da883219c8d30a2b4cd2b94