### PR TITLE
Fix small input support for Swin student

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ python main.py --mixup_alpha 0.2 --label_smoothing 0.1
 Models fine-tuned with `--small_input 1` replace their conv stems for small
 images. When distilling or evaluating such checkpoints you must pass the same
 `--small_input 1` flag to `main.py` or `eval.py` so the architectures match.
+The flag now also configures the student Swin adapter to expect 32×32 inputs.
 
 ### Teacher Fine-Tuning
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ from models.teachers.teacher_resnet import create_resnet101
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
 from models.teachers.teacher_swin import create_swin_t
 
-def create_student_by_name(student_name: str, pretrained: bool = True):
+def create_student_by_name(student_name: str, pretrained: bool = True,
+                           small_input: bool = False):
     """
     Returns a student model that follows the common interface
     (feature_dict, logits, ce_loss).
@@ -58,7 +59,8 @@ def create_student_by_name(student_name: str, pretrained: bool = True):
         from models.students.student_swin_adapter import (
             create_swin_adapter_student,
         )
-        return create_swin_adapter_student(pretrained=pretrained)
+        return create_swin_adapter_student(pretrained=pretrained,
+                                           small_input=small_input)
 
     else:
         raise ValueError(f"[create_student_by_name] unknown student_name={student_name}")# MBM
@@ -102,8 +104,11 @@ def parse_args():
     parser.add_argument("--data_aug", type=int, help="1: use augmentation, 0: disable")
     parser.add_argument("--mixup_alpha", type=float)
     parser.add_argument("--label_smoothing", type=float)
-    parser.add_argument("--small_input", type=int,
-                        help="1 to use CIFAR-friendly stems for teachers")
+    parser.add_argument(
+        "--small_input",
+        type=int,
+        help="1 to use CIFAR-friendly stems (teachers + Swin student)",
+    )
     return parser.parse_args()
 
 def load_config(cfg_path):
@@ -310,6 +315,7 @@ def main():
     student_model = create_student_by_name(
         student_name,
         pretrained=cfg.get("student_pretrained", True),
+        small_input=small_input,
     ).to(device)
 
     if cfg.get("student_ckpt"):

--- a/models/students/student_swin_adapter.py
+++ b/models/students/student_swin_adapter.py
@@ -13,14 +13,17 @@ class StudentSwinAdapter(nn.Module):
       3) final fc => logit
       => returns (feature_dict, logit, ce_loss)
     """
-    def __init__(self, pretrained=True, adapter_dim=64, num_classes=100):
+    def __init__(self, pretrained=True, adapter_dim=64, num_classes=100,
+                 small_input: bool = False):
         super().__init__()
         self.criterion_ce = nn.CrossEntropyLoss()
 
         # 1) load Swin Tiny from timm
+        img_sz = 32 if small_input else 224
         self.swin = timm.create_model(
-            "swin_tiny_patch4_window7_224", 
-            pretrained=pretrained
+            "swin_tiny_patch4_window7_224",
+            pretrained=pretrained,
+            img_size=img_sz,
         )
         
         # 2) remove default classifier => (N, in_features)
@@ -72,12 +75,14 @@ class StudentSwinAdapter(nn.Module):
         return feature_dict, logit, ce_loss
 
 
-def create_swin_adapter_student(pretrained=True, adapter_dim=64, num_classes=100):
+def create_swin_adapter_student(pretrained=True, adapter_dim=64, num_classes=100,
+                                small_input: bool = False):
     """
     Creates the Student Swin model w/ adapter => (dict, logit, ce_loss)
     """
     return StudentSwinAdapter(
         pretrained=pretrained,
         adapter_dim=adapter_dim,
-        num_classes=num_classes
+        num_classes=num_classes,
+        small_input=small_input,
     )


### PR DESCRIPTION
## Summary
- allow Swin student adapter to accept 32×32 inputs
- plumb `small_input` flag from CLI to student creation
- document the flag change in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d8a0aa548321a27c65437b75c874