### PR TITLE
Add flexible MBM with optional paths

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -44,6 +44,8 @@ mbm_in_dim: 3456
 mbm_hidden_dim: 1024
 mbm_out_dim: 2048
 mbm_dropout: 0.0
+mbm_use_4d: false
+mbm_attn_heads: 0
 
 cutmix_alpha: 1.0
 mixup_alpha: 0.0

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -22,6 +22,7 @@ class TeacherEfficientNetWrapper(nn.Module):
 
         # 추가: EffNet-B2의 글로벌 피처 차원(1408)
         self.feat_dim = 1408
+        self.feat_channels = 1408
     
     def forward(self, x, y=None):
         # 1) 4D feature from backbone.features
@@ -53,6 +54,10 @@ class TeacherEfficientNetWrapper(nn.Module):
         EffNet-B2 => 1408
         """
         return self.feat_dim
+
+    def get_feat_channels(self):
+        """Channel dimension of the 4D feature."""
+        return self.feat_channels
 
 def create_efficientnet_b2(
     num_classes: int = 100,

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -21,7 +21,8 @@ class TeacherResNetWrapper(nn.Module):
         self.criterion_ce = nn.CrossEntropyLoss()
 
         # 추가: ResNet101의 글로벌 피처 차원 (기본 2048)
-        self.feat_dim = 2048  
+        self.feat_dim = 2048
+        self.feat_channels = 2048
     
     def forward(self, x, y=None):
         # 1) stem
@@ -61,6 +62,10 @@ class TeacherResNetWrapper(nn.Module):
         ResNet101 => 2048
         """
         return self.feat_dim
+
+    def get_feat_channels(self):
+        """Channel dimension of the 4D feature."""
+        return self.feat_channels
 
 def create_resnet101(num_classes=100, pretrained=True, small_input=False):
     """

--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -23,6 +23,7 @@ class TeacherSwinWrapper(nn.Module):
         # Swin Tiny의 head.in_features => 768 (기본)
         #   (모델마다 다를 수 있음)
         self.feat_dim = self.backbone.head.in_features
+        self.feat_channels = self.feat_dim
 
     
     def forward(self, x, y=None):
@@ -54,6 +55,10 @@ class TeacherSwinWrapper(nn.Module):
         Swin Tiny => usually 768
         """
         return self.feat_dim
+
+    def get_feat_channels(self):
+        """Channel dimension of the 4D feature."""
+        return self.feat_channels
 
 def create_swin_t(num_classes=100, pretrained=True):
     """


### PR DESCRIPTION
## Summary
- support MLP/conv/attention fusion options in ManifoldBridgingModule
- implement `build_from_teachers` helper
- extend teacher wrappers with `get_feat_channels`
- update training scripts and evaluation to new MBM API
- expose new config flags `mbm_use_4d` and `mbm_attn_heads`

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459fe945208321b31c3117817acd11