### PR TITLE
Harmonize teacher outputs

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -94,8 +94,8 @@ class SynergyEnsemble(nn.Module):
 
     def forward(self, x):
         with torch.no_grad():
-            f1_dict, _, _ = self.teacher1(x)
-            f2_dict, _, _ = self.teacher2(x)
+            f1_dict = self.teacher1(x)
+            f2_dict = self.teacher2(x)
 
         f1_2d = f1_dict["feat_2d"]
         f2_2d = f2_dict["feat_2d"]

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -61,11 +61,13 @@ class ASMBDistiller(nn.Module):
         """
         # 1) teacher feats
         with torch.no_grad():
-            f1, _, _ = self.teacher1(x)
-            f2, _, _ = self.teacher2(x)
+            t1 = self.teacher1(x)
+            t2 = self.teacher2(x)
+            feats_2d = [t1["feat_2d"], t2["feat_2d"]]
+            feats_4d = [t1.get("feat_4d"), t2.get("feat_4d")]
 
         # 2) mbm => synergy
-        fsyn = self.mbm(f1, f2)
+        fsyn = self.mbm(feats_2d, feats_4d)
         zsyn = self.synergy_head(fsyn)
 
         # 3) student
@@ -193,8 +195,10 @@ class ASMBDistiller(nn.Module):
                     # student logit
                     _, s_logit, _ = self.student(x)
                     # teacher feats
-                    f1, _, _ = self.teacher1(x)  # but teacher backbones are partial freeze
-                    f2, _, _ = self.teacher2(x)
+                    t1 = self.teacher1(x)
+                    t2 = self.teacher2(x)
+                    f1 = [t1["feat_2d"], t2["feat_2d"]]
+                    f2 = [t1.get("feat_4d"), t2.get("feat_4d")]
 
                 # synergy
                 fsyn = self.mbm(f1, f2)
@@ -270,8 +274,10 @@ class ASMBDistiller(nn.Module):
 
                 with torch.no_grad():
                     # teacher feats
-                    f1, _, _ = self.teacher1(x)
-                    f2, _, _ = self.teacher2(x)
+                    t1 = self.teacher1(x)
+                    t2 = self.teacher2(x)
+                    f1 = [t1["feat_2d"], t2["feat_2d"]]
+                    f2 = [t1.get("feat_4d"), t2.get("feat_4d")]
                     fsyn = self.mbm(f1, f2)
                     zsyn = self.synergy_head(fsyn)
 

--- a/methods/at.py
+++ b/methods/at.py
@@ -38,7 +38,7 @@ def at_loss_dict(teacher_dict, student_dict, layer_key="feat_4d_layer3", p=2):
 class ATDistiller(nn.Module):
     """
     Example of AT Distiller using the dict-based teacher/student outputs.
-    1) teacher(x)->(t_dict, t_logits)
+    1) teacher(x)->dict_out
     2) student(x)->(s_dict, s_logits)
     3) at_loss_dict(...) => single_layer_at_loss
     4) total_loss = CE + alpha*AT
@@ -55,7 +55,7 @@ class ATDistiller(nn.Module):
     def forward(self, x, y):
         # 1) teacher
         with torch.no_grad():
-            t_dict, t_logit, _ = self.teacher(x)
+            t_dict = self.teacher(x)
         # 2) student
         s_dict, s_logit, _ = self.student(x)
 

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -22,8 +22,8 @@ class CRDLoss(nn.Module):
 class CRDDistiller(nn.Module):
     """
     CRD Distiller (dict-based):
-      - teacher(x)->(t_dict, t_logit, ...)
-      - student(x)->(s_dict, s_logit, ...)
+      - teacher(x) -> dict_out (must contain the feature used)
+      - student(x) -> (s_dict, s_logit, ...)
       - CRD = InfoNCE(s_dict[feat_key], t_dict[feat_key])
       - CE = cross entropy with s_logit
       - total_loss = alpha * CRD + (1 - alpha) * CE
@@ -41,7 +41,7 @@ class CRDDistiller(nn.Module):
     def forward(self, x, y):
         # 1) teacher
         with torch.no_grad():
-            t_dict, _, _ = self.teacher(x)  # (dict, logit, ce_loss)
+            t_dict = self.teacher(x)
         # 2) student
         s_dict, s_logit, _ = self.student(x)
 

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -9,7 +9,7 @@ class DKDDistiller(nn.Module):
     """
     Decoupled Knowledge Distillation (DKD) Distiller
     dict-based Teacher/Student:
-      teacher(x)->(t_dict, t_logit, _),
+      teacher(x)->dict_out (must contain "logit"),
       student(x)->(s_dict, s_logit, _)
     => total_loss = CE + warmup_factor * DKD
     """
@@ -41,7 +41,7 @@ class DKDDistiller(nn.Module):
 
     def forward(self, x, y, epoch=1):
         """
-        1) teacher => (t_dict, t_logit)
+        1) teacher => dict_out
         2) student => (s_dict, s_logit)
         3) CE + DKD
            - DKD는 warmup_factor= min(epoch/self.warmup, 1.0)
@@ -49,7 +49,9 @@ class DKDDistiller(nn.Module):
         """
         # teacher
         with torch.no_grad():
-            t_dict, t_logit, _ = self.teacher(x)
+            t_out = self.teacher(x)
+            t_dict = t_out
+            t_logit = t_out["logit"]
         # student
         s_dict, s_logit, _ = self.student(x)
 

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -37,13 +37,14 @@ class FitNetDistiller(nn.Module):
 
     def forward(self, x, y):
         """
-        1) teacher => (t_dict, t_logit)
+        1) teacher => dict_out
         2) student => (s_dict, s_logit)
         3) MSE( t_dict[hint_key], s_dict[guided_key] ) + CE
         """
         # Teacher (no_grad)
         with torch.no_grad():
-            t_dict, t_logit, _ = self.teacher(x)  # (feat_dict, logit, ce_loss(opt))
+            t_out = self.teacher(x)
+            t_dict = t_out
 
         # Student
         s_dict, s_logit, _ = self.student(x)      # (feat_dict, logit, ce_loss(opt))

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -9,10 +9,9 @@ from modules.losses import kd_loss_fn, ce_loss_fn
 
 class VanillaKDDistiller(nn.Module):
     """
-    Distiller for 'vanilla KD' (Hinton et al. 2015),
-    assuming teacher(x)->(t_dict, t_logit, [ce_loss]),
-              student(x)->(s_dict, s_logit, [ce_loss])
-    but we only use the logits for CE + KD
+    Distiller for 'vanilla KD' (Hinton et al. 2015).
+    The teacher forward returns a dict containing a "logit" entry and
+    optional features. Only logits are used here.
     total_loss = alpha * CE + (1 - alpha) * KD
     """
     def __init__(
@@ -30,12 +29,13 @@ class VanillaKDDistiller(nn.Module):
 
     def forward(self, x, y):
         """
-        1) teacher => (dict, t_logit, _), but only t_logit is used
+        1) teacher => dict_out (use "logit" field)
         2) student => (dict, s_logit, _)
         3) CE + KD
         """
         with torch.no_grad():
-            t_dict, t_logit, _ = self.teacher(x)  # we don't use t_dict here
+            t_out = self.teacher(x)
+            t_logit = t_out["logit"]
         s_dict, s_logit, _ = self.student(x)     # we don't use s_dict either
 
         # CE

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -8,7 +8,7 @@ from torchvision.models import efficientnet_b2, EfficientNet_B2_Weights
 class TeacherEfficientNetWrapper(nn.Module):
     """
     Teacher 모델(EfficientNet-B2) forward:
-     => (feature_dict, logit, ce_loss) 반환
+     => dict 반환 {"feat_4d", "feat_2d", "logit", "ce_loss"}
     feature_dict 예시:
       {
         "feat_4d": [N, 1408, H, W],   # backbone.features(x)
@@ -42,11 +42,12 @@ class TeacherEfficientNetWrapper(nn.Module):
             ce_loss = self.criterion_ce(logit, y)
 
         # Dict로 묶어서 반환
-        feature_dict = {
+        return {
             "feat_4d": f4d,       # [N, 1408, h, w]
             "feat_2d": fpool,     # [N, 1408]
+            "logit": logit,
+            "ce_loss": ce_loss,
         }
-        return feature_dict, logit, ce_loss
 
     def get_feat_dim(self):
         """

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -8,7 +8,7 @@ from torchvision.models import resnet101, ResNet101_Weights
 class TeacherResNetWrapper(nn.Module):
     """
     Teacher 모델(ResNet101) forward:
-     => (feature_dict, logit, ce_loss) 형태로 반환
+     => dict 반환 {"feat_4d", "feat_2d", "logit", "ce_loss"}
     feature_dict 예시:
       {
         "feat_4d": [N, 2048, H, W],   # layer4까지의 4D 출력
@@ -50,11 +50,12 @@ class TeacherResNetWrapper(nn.Module):
             ce_loss = self.criterion_ce(logit, y)
 
         # Dict
-        feature_dict = {
+        return {
             "feat_4d": f4d,      # [N, 2048, H, W]
             "feat_2d": feat_2d,  # [N, 2048]
+            "logit": logit,
+            "ce_loss": ce_loss,
         }
-        return feature_dict, logit, ce_loss
 
     def get_feat_dim(self):
         """

--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -8,7 +8,7 @@ from torchvision.models import swin_t, Swin_T_Weights
 class TeacherSwinWrapper(nn.Module):
     """
     Teacher 모델(Swin Tiny) forward:
-     => (feature_dict, logit, ce_loss) 반환
+     => dict 반환 {"feat_4d", "feat_2d", "logit", "ce_loss"}
     feature_dict 예시:
       {
         "feat_4d": [N, C, H, W],  # backbone.forward_features(x)
@@ -44,11 +44,12 @@ class TeacherSwinWrapper(nn.Module):
             ce_loss = self.criterion_ce(logit, y)
 
         # Dict
-        feature_dict = {
+        return {
             "feat_4d": f4d,  # [N, C, H, W]
             "feat_2d": f2d,  # [N, C]
+            "logit": logit,
+            "ce_loss": ce_loss,
         }
-        return feature_dict, logit, ce_loss
         
     def get_feat_dim(self):
         """

--- a/modules/disagreement.py
+++ b/modules/disagreement.py
@@ -9,7 +9,8 @@ def compute_disagreement_rate(teacher1, teacher2, loader, device="cuda"):
     ``teacher1`` and ``teacher2`` both make an incorrect prediction.
 
     teacher1, teacher2: nn.Module (teacher wrappers)
-        Their forward(x) should return (feat, logit, loss) or similar.
+        Their forward(x) should return a dict containing at least the
+        keys "feat_2d", "feat_4d" and "logit".
     loader: DataLoader
     device: "cuda" or "cpu"
 
@@ -24,10 +25,9 @@ def compute_disagreement_rate(teacher1, teacher2, loader, device="cuda"):
     for x, y in loader:
         x, y = x.to(device), y.to(device)
 
-        # forward each teacher, get their logits
-        # assume forward(...) => (feat, logit, ce_loss)
-        _, logit1, _ = teacher1(x)
-        _, logit2, _ = teacher2(x)
+        # forward each teacher, get their logits from the returned dict
+        logit1 = teacher1(x)["logit"]
+        logit2 = teacher2(x)["logit"]
 
         # argmax predictions
         pred1 = logit1.argmax(dim=1)

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -82,9 +82,9 @@ def student_distillation_update(
             # (A) Teacher synergy logit
             with torch.no_grad():
                 # Teacher #1
-                t1_dict, _, _ = teacher_wrappers[0](x_mixed)
+                t1_dict = teacher_wrappers[0](x_mixed)
                 # Teacher #2
-                t2_dict, _, _ = teacher_wrappers[1](x_mixed)
+                t2_dict = teacher_wrappers[1](x_mixed)
 
                 f1_2d = t1_dict["feat_2d"]
                 f2_2d = t2_dict["feat_2d"]

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -22,8 +22,8 @@ def eval_synergy(teacher_wrappers, mbm, synergy_head, loader, device="cuda"):
     for x, y in loader:
         x, y = x.to(device), y.to(device)
 
-        t1_dict, _, _ = teacher_wrappers[0](x)
-        t2_dict, _, _ = teacher_wrappers[1](x)
+        t1_dict = teacher_wrappers[0](x)
+        t2_dict = teacher_wrappers[1](x)
 
         f1_2d = t1_dict["feat_2d"]
         f2_2d = t2_dict["feat_2d"]
@@ -106,7 +106,7 @@ def teacher_adaptive_update(
             feats_2d = []
             feats_4d = []
             for tw in teacher_wrappers:
-                t_dict, _, _ = tw(x)
+                t_dict = tw(x)
                 feats_2d.append(t_dict["feat_2d"])
                 feats_4d.append(t_dict.get("feat_4d"))
 

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -124,8 +124,8 @@ def standard_ce_finetune(model, train_loader, test_loader,
         for x, y in train_loader:
             x, y = x.to(device), y.to(device)
             optim.zero_grad()
-            _, logits, _ = model(x)          # teacher wrapper: (dict, logit, ce)
-            loss = crit(logits, y)
+            out = model(x)
+            loss = crit(out["logit"], y)
             loss.backward()
             optim.step()
         acc = eval_teacher(model, test_loader, device)


### PR DESCRIPTION
## Summary
- switch teacher wrappers to return a dict including features, logit and loss
- expose feature information in callers (trainer, distillers, utility scripts)
- adjust fine‐tuning utilities and evaluation helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845a1ce1a9c8321aac6fc3a190ee676