### PR TITLE
Add MBM unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    paths: ['**.py', '.github/workflows/**']
+  pull_request:
+    paths: ['**.py', '.github/workflows/**']
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -v

--- a/tests/test_mbm.py
+++ b/tests/test_mbm.py
@@ -1,0 +1,46 @@
+import torch
+from models.mbm import ManifoldBridgingModule
+
+
+def test_mbm_2d_only():
+    N = 2
+    feat_dims = [10, 20]
+    mbm = ManifoldBridgingModule(feat_dims=feat_dims, hidden_dim=32, out_dim=16)
+    feats_2d = [torch.randn(N, d) for d in feat_dims]
+    out = mbm(feats_2d)
+    assert out.shape == (N, 16)
+
+
+def test_mbm_4d_only():
+    N = 2
+    mbm = ManifoldBridgingModule(
+        feat_dims=[1],
+        hidden_dim=8,
+        out_dim=4,
+        use_4d=True,
+        in_ch_4d=3,
+        out_ch_4d=5,
+    )
+    # disable 2D path to test 4D path alone
+    mbm.use_2d = False
+    feats_4d = [torch.randn(N, 3, 4, 4)]
+    out = mbm([], feats_4d)
+    assert out.shape == (N, 4)
+
+
+def test_mbm_mixed_with_attention():
+    N = 2
+    feat_dims = [8, 8]
+    mbm = ManifoldBridgingModule(
+        feat_dims=feat_dims,
+        hidden_dim=16,
+        out_dim=12,
+        use_4d=True,
+        in_ch_4d=6,
+        out_ch_4d=6,
+        attn_heads=2,
+    )
+    feats_2d = [torch.randn(N, d) for d in feat_dims]
+    feats_4d = [torch.randn(N, 3, 4, 4), torch.randn(N, 3, 4, 4)]
+    out = mbm(feats_2d, feats_4d)
+    assert out.shape == (N, 12)


### PR DESCRIPTION
## Summary
- add unit tests covering ManifoldBridgingModule
- add GitHub Actions workflow to run pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6845a5d950648321a7b7ae7397884318