### PR TITLE
Implement dropout-aware SynergyHead

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -44,6 +44,7 @@ mbm_in_dim: 3456
 mbm_hidden_dim: 1024
 mbm_out_dim: 2048
 mbm_dropout: 0.0
+synergy_head_dropout: 0.0
 mbm_use_4d: false
 mbm_attn_heads: 0
 


### PR DESCRIPTION
## Summary
- implement `SynergyHead` as an FC-ReLU-(Dropout)-FC `nn.Sequential`
- configure dropout via `synergy_head_dropout` in config
- pass the parameter when building models

## Testing
- `python -` (failed to run due to missing `torch` dependency)


------
https://chatgpt.com/codex/tasks/task_e_6845a6c019a4832187ed2a02f6c3485d