### PR TITLE
Remove unused teacher_adapt_alpha_ce option

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -20,7 +20,6 @@ mbm_lr_factor: 5.0           # MBM/Head LR 배수
 
 synergy_ce_alpha: 0.3
 teacher_adapt_alpha_kd: 0.2  # Teacher adaptive 시 KL 비중
-teacher_adapt_alpha_ce: 0.5  # (추가) 만약 Teacher adaptive에서 CE 비중이 따로 필요하다면
 
 reg_lambda: 1e-5   # Teacher param reg
 


### PR DESCRIPTION
## Summary
- remove the unused `teacher_adapt_alpha_ce` setting from the default configuration

## Testing
- `grep -R teacher_adapt_alpha_ce -n || true`

------
https://chatgpt.com/codex/tasks/task_e_6845b9ec7e608321bd6e62ed95828ee9