### PR TITLE
Add disagreement weighting option

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -38,6 +38,12 @@ feat_kd_alpha: 0.25       # λ_feat   (논문 α_feat)
 feat_kd_key: "feat_2d"    # 어느 딕셔너리 key를 쓸지 (feat_4d 도 가능)
 feat_kd_norm: "none"      # "none" | "l2"  (예: 벡터 정규화 후 MSE)
 
+# disagreement-based sample weighting
+use_disagree_weight: false
+disagree_mode: "pred"       # "pred" | "both_wrong"
+disagree_lambda_high: 1.0
+disagree_lambda_low: 1.0
+
 num_stages: 2
 
 teacher_iters: 10

--- a/main.py
+++ b/main.py
@@ -113,6 +113,10 @@ def parse_args():
     parser.add_argument("--feat_kd_alpha", type=float)
     parser.add_argument("--feat_kd_key", type=str)
     parser.add_argument("--feat_kd_norm", type=str)
+    parser.add_argument("--use_disagree_weight", type=int)
+    parser.add_argument("--disagree_mode", type=str)
+    parser.add_argument("--disagree_lambda_high", type=float)
+    parser.add_argument("--disagree_lambda_low", type=float)
     return parser.parse_args()
 
 def load_config(cfg_path):

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -3,7 +3,7 @@
 import torch
 import torch.nn.functional as F
 
-def ce_loss_fn(student_logits, labels, label_smoothing: float = 0.0):
+def ce_loss_fn(student_logits, labels, label_smoothing: float = 0.0, reduction: str = "mean"):
     """Standard cross-entropy loss for classification.
 
     Parameters
@@ -19,6 +19,7 @@ def ce_loss_fn(student_logits, labels, label_smoothing: float = 0.0):
         student_logits,
         labels,
         label_smoothing=label_smoothing,
+        reduction=reduction,
     )
 
 def kd_loss_fn(student_logits, teacher_logits, T=4.0, reduction="batchmean"):

--- a/tests/test_disagreement_weights.py
+++ b/tests/test_disagreement_weights.py
@@ -1,0 +1,11 @@
+import torch
+from modules.disagreement import sample_weights_from_disagreement
+
+
+def test_weight_shape_and_nonneg():
+    logit1 = torch.randn(4, 10)
+    logit2 = torch.randn(4, 10)
+    labels = torch.randint(0, 10, (4,))
+    w = sample_weights_from_disagreement(logit1, logit2, labels)
+    assert w.shape == labels.shape
+    assert torch.all(w >= 0)


### PR DESCRIPTION
## Summary
- add disagreement-based sample weighting implementation
- support per-sample loss weighting in trainer
- expose CLI options and defaults for disagree weights
- allow CE loss reduction parameter
- test shape/non-negativity of disagreement weights

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6845c080e58083219ef21cb57dd9f753