### PR TITLE
Apply label smoothing to teacher CE losses

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -31,7 +31,8 @@ class ASMBDistiller(nn.Module):
         reg_lambda=1e-4,
         mbm_reg_lambda=1e-4,
         num_stages=2,
-        device="cuda"
+        device="cuda",
+        config=None
     ):
         super().__init__()
         self.teacher1 = teacher1
@@ -48,6 +49,7 @@ class ASMBDistiller(nn.Module):
         self.mbm_reg_lambda = mbm_reg_lambda
         self.num_stages = num_stages
         self.device = device
+        self.config = config if config is not None else {}
 
         # 기본 Loss
         self.ce_loss_fn = nn.CrossEntropyLoss()
@@ -207,7 +209,11 @@ class ASMBDistiller(nn.Module):
                 # (i) -KL(s_logit, zsyn)
                 kl_val = kd_loss_fn(zsyn, s_logit, T=self.T)  # 여기선 sign 주의
                 # (ii) synergy CE
-                ce_val = ce_loss_fn(zsyn, y)
+                ce_val = ce_loss_fn(
+                    zsyn,
+                    y,
+                    label_smoothing=self.config.get("label_smoothing", 0.0)
+                )
                 synergy_ce = self.synergy_ce_alpha * ce_val
 
                 # 정규화

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -103,7 +103,11 @@ def teacher_adaptive_update(
 
             # (D) loss 계산 (KL + synergyCE)
             loss_kd         = kd_loss_fn(zsyn, s_logit, T=cfg.get("temperature", 4.0))
-            loss_ce         = ce_loss_fn(zsyn, y)
+            loss_ce         = ce_loss_fn(
+                zsyn,
+                y,
+                label_smoothing=cfg.get("label_smoothing", 0.0),
+            )
             synergy_ce_loss = cfg["synergy_ce_alpha"] * loss_ce
 
             # 기본 KD+CE


### PR DESCRIPTION
## Summary
- apply label smoothing inside `teacher_adaptive_update`
- expose an optional config dictionary for `ASMBDistiller`
- propagate label smoothing to `_teacher_adaptive_update`

## Testing
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68468f603b78832199125015bb896eff