### PR TITLE
Add CutMix distillation param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **Multiple KD Methods**: FitNet, CRD, AT, DKD, VanillaKD, plus custom `asmb.py`
 - **CIFAR-100 / ImageNet100** dataset support
 - **Configurable Data Augmentation**: toggle with `--data_aug` (1/0)
-- **MixUp & Label Smoothing**: enable with `--mixup_alpha` and `--label_smoothing`
+- **MixUp, CutMix & Label Smoothing**: enable with `--mixup_alpha`,
+  `--cutmix_alpha_distill` and `--label_smoothing`
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
@@ -82,12 +83,12 @@ Use the `--data_aug` flag to control dataset transforms. When set to `1` (defaul
 python main.py --config configs/default.yaml --data_aug 0
 ```
 
-### MixUp & Label Smoothing
+### MixUp, CutMix & Label Smoothing
 
-Control MixUp augmentation and label smoothing via CLI flags:
+Control MixUp or CutMix augmentation and label smoothing via CLI flags:
 
 ```bash
-python main.py --mixup_alpha 0.2 --label_smoothing 0.1
+python main.py --mixup_alpha 0.2 --cutmix_alpha_distill 0.5 --label_smoothing 0.1
 ```
 
 ### Small Input Checkpoints

--- a/scripts/hparams.sh
+++ b/scripts/hparams.sh
@@ -21,6 +21,7 @@ T_WD=0.0003
 S_WD=0.0005
 CE_ALPHA=0.5
 KD_ALPHA=0.5
+CUTMIX_ALPHA_DISTILL=0.0   # CutMix alpha used during distillation
 # Temperature scheduling
 TEMPERATURE_SCHEDULE="fixed"
 TAU_START=4.0

--- a/scripts/run_many.sh
+++ b/scripts/run_many.sh
@@ -86,6 +86,7 @@ for T2 in efficientnet_b2 swin_tiny; do
           teacher2_bn_head_only=${TEACHER2_BN_HEAD_ONLY} \
           batch_size=${BATCH_SIZE} \
           mixup_alpha=${MIXUP_ALPHA} \
+          cutmix_alpha_distill=${CUTMIX_ALPHA_DISTILL} \
           label_smoothing=${LABEL_SMOOTHING}
 
         python main.py \
@@ -108,6 +109,7 @@ for T2 in efficientnet_b2 swin_tiny; do
           --seed 42 \
           --data_aug ${DATA_AUG} \
           --mixup_alpha ${MIXUP_ALPHA} \
+          --cutmix_alpha_distill ${CUTMIX_ALPHA_DISTILL} \
           --label_smoothing ${LABEL_SMOOTHING}
       done
     done

--- a/scripts/run_sweep.sh
+++ b/scripts/run_sweep.sh
@@ -56,6 +56,7 @@ for teacher_lr in 0.0001 0.0002 0.0005; do
       teacher2_bn_head_only=${TEACHER2_BN_HEAD_ONLY} \
       batch_size=${BATCH_SIZE} \
       mixup_alpha=${MIXUP_ALPHA} \
+      cutmix_alpha_distill=${CUTMIX_ALPHA_DISTILL} \
       label_smoothing=${LABEL_SMOOTHING}
 
     python main.py \
@@ -64,6 +65,7 @@ for teacher_lr in 0.0001 0.0002 0.0005; do
       --device ${DEVICE} \
       --data_aug ${DATA_AUG} \
       --mixup_alpha ${MIXUP_ALPHA} \
+      --cutmix_alpha_distill ${CUTMIX_ALPHA_DISTILL} \
       --teacher1_use_adapter ${TEACHER1_USE_ADAPTER} \
       --teacher1_bn_head_only ${TEACHER1_BN_HEAD_ONLY} \
       --teacher2_use_adapter ${TEACHER2_USE_ADAPTER} \


### PR DESCRIPTION
## Summary
- expose `CUTMIX_ALPHA_DISTILL` hyperparameter in `hparams.sh`
- pass the value to `generate_config.py` and `main.py`
- document CutMix in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846a09ed46083218ee106083e7ff74f