### PR TITLE
Add AMP training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,38 @@ Control MixUp or CutMix augmentation and label smoothing via CLI flags:
 python main.py --mixup_alpha 0.2 --cutmix_alpha_distill 0.5 --label_smoothing 0.1
 ```
 
+### Automatic Mixed Precision (AMP)
+
+Add the following keys to your config to enable AMP:
+
+```yaml
+use_amp: true
+amp_dtype: float16  # or bfloat16
+grad_scaler_init_scale: 1024
+```
+
+Example usage:
+
+```python
+from utils.misc import get_amp_components
+
+autocast_ctx, scaler = get_amp_components(cfg)
+with autocast_ctx:
+    out = model(x)
+    loss = criterion(out, target)
+if scaler:
+    scaler.scale(loss).backward()
+    scaler.step(optimizer)
+    scaler.update()
+else:
+    loss.backward()
+    optimizer.step()
+```
+
+```bash
+python main.py --use_amp 1 --amp_dtype bfloat16
+```
+
 ### Small Input Checkpoints
 
 Models fine-tuned with `--small_input 1` replace their conv stems for small

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,6 +7,10 @@ dataset_name: "cifar100"
 small_input: true
 data_root: "./data"
 batch_size: 128
+use_amp: false
+amp_dtype: float16
+grad_scaler_init_scale: 1024
+
 
 teacher1_type: "resnet101"
 teacher2_type: "efficientnet_b2"

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -57,7 +57,10 @@ def parse_args():
     parser.add_argument("--data_aug", type=int)
     parser.add_argument("--small_input", type=int)
     parser.add_argument("--dropout_p", type=float)
-    
+    parser.add_argument("--use_amp", type=int)
+    parser.add_argument("--amp_dtype", type=str)
+    parser.add_argument("--grad_scaler_init_scale", type=int)
+
     return parser.parse_args()
 
 def load_config(cfg_path):

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -1,0 +1,13 @@
+import contextlib
+import torch
+from utils.misc import get_amp_components
+
+def test_amp_disabled():
+    ctx, scaler = get_amp_components({"use_amp": False})
+    assert isinstance(ctx, contextlib.AbstractContextManager)
+    assert scaler is None
+
+def test_amp_enabled():
+    cfg = {"use_amp": True, "amp_dtype": "float16"}
+    ctx, scaler = get_amp_components(cfg)
+    assert scaler is not None


### PR DESCRIPTION
## Summary
- expose AMP config in YAML and CLI
- implement get_amp_components utility
- update training and evaluation loops for autocast
- log AMP settings in ExperimentLogger
- document AMP usage
- add simple unit test for AMP helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846afc9267483219f9a0f23e4fa658b