### PR TITLE
Add tests CI and skip when torch missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ environment name, set the `CONDA_ENV` variable accordingly. You can also
 skip activation entirely by exporting `USE_CONDA=0` before running the
 scripts.
 
+## Testing
+
+Install the dependencies (including **PyTorch**) and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```
+
+PyTorch must be available for the unit tests to run.
+
 ---
 
 Usage

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -1,5 +1,6 @@
 import contextlib
-import torch
+import pytest
+pytest.importorskip("torch")
 from utils.misc import get_amp_components
 
 def test_amp_disabled():

--- a/tests/test_disagreement_weights.py
+++ b/tests/test_disagreement_weights.py
@@ -1,6 +1,7 @@
 # tests/test_disagreement_weights.py
 
-import torch
+import pytest
+torch = pytest.importorskip("torch")
 from modules.disagreement import sample_weights_from_disagreement
 
 

--- a/tests/test_feat_kd.py
+++ b/tests/test_feat_kd.py
@@ -1,7 +1,8 @@
 # tests/test_feat_kd.py
 
+import pytest
+torch = pytest.importorskip("torch")
 from torch import randn
-import torch
 
 def test_mse_nonzero():
     a = randn(8, 128, requires_grad=True)


### PR DESCRIPTION
## Summary
- skip tests when PyTorch is not available
- document how to run unit tests
- add GitHub Actions workflow to run pytest automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ba7a3fe083218f09b6576a0328dd