### PR TITLE
Add attention-based MBM integration

### DIFF
--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -7,6 +7,10 @@ class LightweightAttnMBM(nn.Module):
 
     Projects teacher features to key/value tokens and computes a
     single fusion embedding using multi-head attention.
+    If a query tensor is provided, it is used for the attention query;
+    otherwise the original behaviour (query from concatenated teacher
+    features or learnable vector) is kept for backward compatibility.
+    The forward now returns both the fused feature and attention map.
     """
     def __init__(self, feat_dims: List[int], out_dim: int, r: int = 4,
                  n_head: int = 1, learnable_q: bool = False) -> None:
@@ -28,20 +32,53 @@ class LightweightAttnMBM(nn.Module):
         self.attn = nn.MultiheadAttention(self.embed_dim, n_head, batch_first=True)
         self.out_proj = nn.Linear(self.embed_dim, out_dim)
 
-    def forward(self, feats_2d: List[torch.Tensor], feats_4d=None) -> torch.Tensor:
-        batch_size = feats_2d[0].size(0)
+    def forward(
+        self,
+        query_or_feats: torch.Tensor | List[torch.Tensor],
+        feats_2d: List[torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass.
 
-        if self.learnable_q:
-            q = self.q.expand(batch_size, -1, -1)
+        Parameters
+        ----------
+        query_or_feats : Tensor or List[Tensor]
+            If Tensor, treated as the query features from the student. If a
+            list, the original behaviour is used and `feats_2d` is ignored.
+        feats_2d : List[Tensor], optional
+            Teacher features used as key/value tokens when query is provided.
+
+        Returns
+        -------
+        syn_feat : Tensor
+            The fused feature.
+        attn : Tensor
+            Attention weights from the multi-head attention layer.
+        """
+
+        if isinstance(query_or_feats, list):
+            # backward compatible: original API mbm(feats_2d)
+            feats = query_or_feats
+            batch_size = feats[0].size(0)
+            if self.learnable_q:
+                q = self.q.expand(batch_size, -1, -1)
+            else:
+                q = self.q_proj(torch.cat(feats, dim=1)).unsqueeze(1)
         else:
-            cat = torch.cat(feats_2d, dim=1)
-            q = self.q_proj(cat).unsqueeze(1)
+            assert feats_2d is not None, "Teacher features must be provided"
+            batch_size = query_or_feats.size(0)
+            if self.learnable_q:
+                q = self.q.expand(batch_size, -1, -1)
+            else:
+                q = self.q_proj(query_or_feats).unsqueeze(1)
+            feats = feats_2d
 
-        keys = [proj(f).unsqueeze(1) for f, proj in zip(feats_2d, self.k_proj)]
-        values = [proj(f).unsqueeze(1) for f, proj in zip(feats_2d, self.v_proj)]
+        keys = [proj(f).unsqueeze(1) for f, proj in zip(feats, self.k_proj)]
+        values = [proj(f).unsqueeze(1) for f, proj in zip(feats, self.v_proj)]
         k = torch.cat(keys, dim=1)
         v = torch.cat(values, dim=1)
 
-        attn_out, _ = self.attn(q, k, v)
+        attn_out, attn = self.attn(q, k, v)
         out = self.out_proj(attn_out.squeeze(1))
-        return out
+        if isinstance(query_or_feats, list):
+            return out
+        return out, attn


### PR DESCRIPTION
## Summary
- extend `LightweightAttnMBM` to support query input and return attention
- integrate LA MBM in teacher and student trainers
- log attention weights and optional feature distillation losses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846eda4080883219e8b8b5fb1167842