### PR TITLE
Add MBM CLI options and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Usage
 1) Multi-Stage Distillation (main.py)
 
 python main.py --config configs/partial_freeze.yaml --device cuda \
---teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth
+  --teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth \
+  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0
 	•	Adjust hyperparameters in configs/*.yaml (partial freeze, learning rates, etc.).
 	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
         •       Optimizers and schedulers are instantiated once before stages and reset before each stage.
@@ -83,7 +84,8 @@ python eval.py --eval_mode synergy \
   --teacher1_ckpt teacher1.pth \
   --teacher2_ckpt teacher2.pth \
   --mbm_ckpt mbm.pth \
-  --head_ckpt synergy_head.pth
+  --head_ckpt synergy_head.pth \
+  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0
 
 	•	Prints Train/Test accuracy, optionally logs to CSV if configured.
 

--- a/eval.py
+++ b/eval.py
@@ -64,6 +64,12 @@ def parse_args():
                         help="1 for CIFAR-style conv stem in teachers")
     parser.add_argument("--use_amp", type=int)
     parser.add_argument("--amp_dtype", type=str)
+
+    # MBM options (overrides YAML)
+    parser.add_argument("--mbm_type", type=str)
+    parser.add_argument("--mbm_r", type=int)
+    parser.add_argument("--mbm_n_head", type=int)
+    parser.add_argument("--mbm_learnable_q", type=int)
     return parser.parse_args()
 
 def load_config(path):
@@ -124,6 +130,10 @@ def main():
     logger = ExperimentLogger(cfg, exp_name="eval_experiment")
     logger.update_metric("use_amp", cfg.get("use_amp", False))
     logger.update_metric("amp_dtype", cfg.get("amp_dtype", "float16"))
+    logger.update_metric("mbm_type", cfg.get("mbm_type", "MLP"))
+    logger.update_metric("mbm_r", cfg.get("mbm_r"))
+    logger.update_metric("mbm_n_head", cfg.get("mbm_n_head"))
+    logger.update_metric("mbm_learnable_q", cfg.get("mbm_learnable_q"))
 
     # 4) Data
     dataset_name = cfg.get("dataset_name", "cifar100")

--- a/main.py
+++ b/main.py
@@ -127,6 +127,12 @@ def parse_args():
     parser.add_argument("--use_amp", type=int)
     parser.add_argument("--amp_dtype", type=str)
     parser.add_argument("--grad_scaler_init_scale", type=int)
+
+    # MBM options
+    parser.add_argument("--mbm_type", type=str)
+    parser.add_argument("--mbm_r", type=int)
+    parser.add_argument("--mbm_n_head", type=int)
+    parser.add_argument("--mbm_learnable_q", type=int)
     return parser.parse_args()
 
 def load_config(cfg_path):
@@ -214,6 +220,10 @@ def main():
     logger = ExperimentLogger(cfg, exp_name="asmb_experiment")
     logger.update_metric("use_amp", cfg.get("use_amp", False))
     logger.update_metric("amp_dtype", cfg.get("amp_dtype", "float16"))
+    logger.update_metric("mbm_type", cfg.get("mbm_type", "MLP"))
+    logger.update_metric("mbm_r", cfg.get("mbm_r"))
+    logger.update_metric("mbm_n_head", cfg.get("mbm_n_head"))
+    logger.update_metric("mbm_learnable_q", cfg.get("mbm_learnable_q"))
 
     device = cfg.get("device", "cuda")
     if device == "cuda" and not torch.cuda.is_available():

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -129,6 +129,10 @@ class ExperimentLogger:
             "test_acc",
             "batch_size",
             "total_time_sec",
+            "mbm_type",
+            "mbm_r",
+            "mbm_n_head",
+            "mbm_learnable_q",
         ]
 
         epoch_cols = [


### PR DESCRIPTION
## Summary
- allow overriding MBM type and hyperparameters via command line
- record MBM configuration in `ExperimentLogger`
- mention MBM flags in README usage examples

## Testing
- `pytest -q` *(fails: 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6846effdd7b883219fe6bfd5316f7785