### PR TITLE
Handle tuple/dict outputs in evaluate_acc

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -88,7 +88,13 @@ def evaluate_acc(model, loader, device="cuda", cfg=None):
         x, y = x.to(device), y.to(device)
         with autocast_ctx:
             out = model(x)
-            preds = out.argmax(dim=1)
+            if isinstance(out, tuple):
+                logits = out[1]
+            elif isinstance(out, dict):
+                logits = out["logit"]
+            else:
+                logits = out
+            preds = logits.argmax(dim=1)
         correct += (preds == y).sum().item()
         total   += y.size(0)
     return 100.0 * correct / total


### PR DESCRIPTION
## Summary
- improve `evaluate_acc` to handle tuple and dict outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6847017c591c83218c703ff0143cb41f