### PR TITLE
Fix typing hints in la_mbm

### DIFF
--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from typing import List
+from typing import List, Optional, Union, Tuple
 
 class LightweightAttnMBM(nn.Module):
     """Lightweight attention-based MBM.
@@ -34,9 +34,9 @@ class LightweightAttnMBM(nn.Module):
 
     def forward(
         self,
-        query_or_feats: torch.Tensor | List[torch.Tensor],
-        feats_2d: List[torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        query_or_feats: Union[torch.Tensor, List[torch.Tensor]],
+        feats_2d: Optional[List[torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Forward pass.
 
         Parameters


### PR DESCRIPTION
## Summary
- update type hints in `LightweightAttnMBM` to use `typing.Union` and `typing.Optional`

## Testing
- `python -m py_compile models/la_mbm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470b4648c4832184f145beb35b7d4b