### PR TITLE
Add query_dim option for LightweightAttnMBM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   `--cutmix_alpha_distill` and `--label_smoothing`
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
+- **Custom MBM Query Dim**: set `mbm_query_dim` to specify the dimension of
+  student features used as the attention query in `LightweightAttnMBM`
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs
@@ -66,7 +68,8 @@ Usage
 
 python main.py --config configs/partial_freeze.yaml --device cuda \
   --teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth \
-  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0
+  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0 \
+  --mbm_query_dim 512
 	•	Adjust hyperparameters in configs/*.yaml (partial freeze, learning rates, etc.).
 	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
         •       Optimizers and schedulers are instantiated once before stages and reset before each stage.
@@ -85,7 +88,8 @@ python eval.py --eval_mode synergy \
   --teacher2_ckpt teacher2.pth \
   --mbm_ckpt mbm.pth \
   --head_ckpt synergy_head.pth \
-  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0
+  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0 \
+  --mbm_query_dim 512
 
 	•	Prints Train/Test accuracy, optionally logs to CSV if configured.
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -81,6 +81,7 @@ mbm_type: "LA"        # "MLP" for old behaviour
 mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: false
+mbm_query_dim: 0      # 0 -> use sum(feat_dims); set to student feat dim to override
 
 cutmix_alpha: 1.0
 cutmix_alpha_distill: 0.0

--- a/eval.py
+++ b/eval.py
@@ -203,7 +203,10 @@ def main():
             teacher2.load_state_dict(t2_ck)
 
         # 4) MBM and synergy head
-        mbm, synergy_head = build_from_teachers([teacher1, teacher2], cfg)
+        mbm_query_dim = cfg.get("mbm_query_dim")
+        mbm, synergy_head = build_from_teachers(
+            [teacher1, teacher2], cfg, query_dim=mbm_query_dim
+        )
         mbm = mbm.to(device)
         synergy_head = synergy_head.to(device)
 

--- a/main.py
+++ b/main.py
@@ -388,7 +388,10 @@ def main():
         )
 
     # 6) MBM and synergy head
-    mbm, synergy_head = build_from_teachers([teacher1, teacher2], cfg)
+    mbm_query_dim = cfg.get("mbm_query_dim")
+    mbm, synergy_head = build_from_teachers(
+        [teacher1, teacher2], cfg, query_dim=mbm_query_dim
+    )
     mbm = mbm.to(device)
     synergy_head = synergy_head.to(device)
 

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -92,7 +92,11 @@ class SynergyHead(nn.Sequential):
             nn.Linear(in_dim, num_classes),
         )
 
-def build_from_teachers(teachers: List[nn.Module], cfg: dict) -> Tuple[ManifoldBridgingModule, SynergyHead]:
+def build_from_teachers(
+    teachers: List[nn.Module],
+    cfg: dict,
+    query_dim: Optional[int] = None,
+) -> Tuple[ManifoldBridgingModule, SynergyHead]:
     feat_dims = [t.get_feat_dim() for t in teachers]
     in_dim = sum(feat_dims)
 
@@ -112,6 +116,7 @@ def build_from_teachers(teachers: List[nn.Module], cfg: dict) -> Tuple[ManifoldB
             r=cfg.get("mbm_r", 4),
             n_head=cfg.get("mbm_n_head", 1),
             learnable_q=cfg.get("mbm_learnable_q", False),
+            query_dim=cfg.get("mbm_query_dim", query_dim),
         )
     else:
         mbm = ManifoldBridgingModule(

--- a/tests/test_la_mbm.py
+++ b/tests/test_la_mbm.py
@@ -1,0 +1,15 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from models.la_mbm import LightweightAttnMBM
+
+
+def test_custom_query_dim_forward():
+    mbm = LightweightAttnMBM([16, 16], out_dim=32, r=2, query_dim=8)
+    q = torch.randn(4, 8)
+    feats = [torch.randn(4, 16), torch.randn(4, 16)]
+    out, attn = mbm(q, feats)
+    assert out.shape == (4, 32)
+    assert attn.shape[0] == 4
+


### PR DESCRIPTION
## Summary
- support custom query dimension for `LightweightAttnMBM`
- forward `mbm_query_dim` through `build_from_teachers`
- document the option in README and default config
- test basic forward pass with custom `query_dim`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470e562a0c8321bcf78edc0031073d