### PR TITLE
Support nonpositive mbm_query_dim

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
 - **Custom MBM Query Dim**: set `mbm_query_dim` to specify the dimension of
-  student features used as the attention query in `LightweightAttnMBM`
+  student features used as the attention query in `LightweightAttnMBM`.
+  Passing `0` (or any non-positive value) defaults to the summed teacher
+  feature dimension for backward compatibility.
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -81,7 +81,7 @@ mbm_type: "LA"        # "MLP" for old behaviour
 mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: false
-mbm_query_dim: 0      # 0 -> use sum(feat_dims); set to student feat dim to override
+mbm_query_dim: 0      # <=0 -> use sum(feat_dims); set to student feat dim to override
 
 cutmix_alpha: 1.0
 cutmix_alpha_distill: 0.0

--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -14,8 +14,9 @@ class LightweightAttnMBM(nn.Module):
     features or learnable vector) is kept for backward compatibility.
     The forward now returns both the fused feature and attention map.
     `query_dim` optionally specifies the dimension of the student
-    query features. When omitted, the concatenated teacher feature
-    dimension is used for backward compatibility.
+    query features. When omitted or set to a non-positive value,
+    the concatenated teacher feature dimension is used for backward
+    compatibility.
     """
     def __init__(
         self,
@@ -27,6 +28,9 @@ class LightweightAttnMBM(nn.Module):
         query_dim: Optional[int] = None,
     ) -> None:
         super().__init__()
+        if query_dim is not None and query_dim <= 0:
+            query_dim = None
+
         self.learnable_q = learnable_q
         self.embed_dim = max(1, out_dim // r)
         self.n_tokens = len(feat_dims)

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -110,13 +110,16 @@ def build_from_teachers(
 
     mbm_type = cfg.get("mbm_type", "MLP")
     if mbm_type == "LA":
+        qdim = cfg.get("mbm_query_dim", query_dim)
+        if qdim is not None and qdim <= 0:
+            qdim = None
         mbm = LightweightAttnMBM(
             feat_dims=feat_dims,
             out_dim=cfg.get("mbm_out_dim", 512),
             r=cfg.get("mbm_r", 4),
             n_head=cfg.get("mbm_n_head", 1),
             learnable_q=cfg.get("mbm_learnable_q", False),
-            query_dim=cfg.get("mbm_query_dim", query_dim),
+            query_dim=qdim,
         )
     else:
         mbm = ManifoldBridgingModule(

--- a/tests/test_la_mbm.py
+++ b/tests/test_la_mbm.py
@@ -13,3 +13,12 @@ def test_custom_query_dim_forward():
     assert out.shape == (4, 32)
     assert attn.shape[0] == 4
 
+
+def test_zero_query_dim_uses_teacher_dim():
+    mbm = LightweightAttnMBM([16, 16], out_dim=32, r=2, query_dim=0)
+    q = torch.randn(2, 32)  # sum of teacher dims = 32
+    feats = [torch.randn(2, 16), torch.randn(2, 16)]
+    out, attn = mbm(q, feats)
+    assert out.shape == (2, 32)
+    assert attn.shape[0] == 2
+


### PR DESCRIPTION
## Summary
- sanitize `query_dim` in `LightweightAttnMBM` constructor
- default nonpositive `mbm_query_dim` to sum of teacher dims
- clarify behaviour in README and default config
- add regression test for `query_dim=0`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684710ed0dc48321acb1ef641982b54c