### PR TITLE
Check mbm query dim

### DIFF
--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -86,6 +86,10 @@ class LightweightAttnMBM(nn.Module):
             if self.learnable_q:
                 q = self.q.expand(batch_size, -1, -1)
             else:
+                if query_or_feats.size(1) != self.q_proj.in_features:
+                    raise ValueError(
+                        "mbm_query_dim must equal the student feature dimension"
+                    )
                 q = self.q_proj(query_or_feats).unsqueeze(1)
             feats = feats_2d
 

--- a/tests/test_la_mbm.py
+++ b/tests/test_la_mbm.py
@@ -22,3 +22,11 @@ def test_zero_query_dim_uses_teacher_dim():
     assert out.shape == (2, 32)
     assert attn.shape[0] == 2
 
+
+def test_query_dim_mismatch_raises():
+    mbm = LightweightAttnMBM([16, 16], out_dim=32, r=2, query_dim=8)
+    q = torch.randn(1, 10)
+    feats = [torch.randn(1, 16), torch.randn(1, 16)]
+    with pytest.raises(ValueError):
+        mbm(q, feats)
+


### PR DESCRIPTION
## Summary
- enforce dimension match for student queries in `LightweightAttnMBM`
- test that mismatched query dim raises a `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847159584ac8321a67178c2193f8c42