### PR TITLE
Add setup script for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ scripts.
 
 ## Testing
 
-Install the dependencies (including **PyTorch**) and run `pytest`:
+Install **PyTorch** and the remaining dependencies using the helper script and
+then run `pytest`:
 
 ```bash
-pip install -r requirements.txt
-pip install pytest
+bash scripts/setup_tests.sh
 pytest
 ```
 

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# scripts/setup_tests.sh
+# Install PyTorch and other dependencies required for running the unit tests.
+
+set -e
+python -m pip install --upgrade pip
+
+# Install PyTorch CPU build by default
+pip install --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision
+
+# Install remaining dependencies
+pip install -r requirements.txt
+pip install pytest


### PR DESCRIPTION
## Summary
- create `scripts/setup_tests.sh` for installing PyTorch and test dependencies
- reference the setup script in the README

## Testing
- `pytest -q` *(fails: 5 skipped)*
- `bash scripts/setup_tests.sh` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_684791c0a76883219d7f31c762702b86