### PR TITLE
Add gradient clipping option to training

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   `--cutmix_alpha_distill` and `--label_smoothing`
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
+- **Gradient Clipping**: enable by setting `grad_clip_norm` (>0) in configs
 - **Custom MBM Query Dim**: `mbm_query_dim` controls the dimension of the
   student features used as the attention query in `LightweightAttnMBM`.
   When omitted or set to `0`, the script automatically falls back to the

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -82,6 +82,7 @@ mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: false
 mbm_query_dim: 0      # <=0 -> use sum(feat_dims); set to student feat dim to override
+grad_clip_norm: 0.0   # max norm for gradient clipping (0 to disable)
 
 cutmix_alpha: 1.0
 cutmix_alpha_distill: 0.0

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -181,10 +181,19 @@ def student_distillation_update(
             optimizer.zero_grad()
             if scaler is not None:
                 scaler.scale(loss).backward()
+                if cfg.get("grad_clip_norm", 0) > 0:
+                    scaler.unscale_(optimizer)
+                    torch.nn.utils.clip_grad_norm_(
+                        student_model.parameters(), cfg["grad_clip_norm"]
+                    )
                 scaler.step(optimizer)
                 scaler.update()
             else:
                 loss.backward()
+                if cfg.get("grad_clip_norm", 0) > 0:
+                    torch.nn.utils.clip_grad_norm_(
+                        student_model.parameters(), cfg["grad_clip_norm"]
+                    )
                 optimizer.step()
 
             bs = x.size(0)


### PR DESCRIPTION
## Summary
- add gradient clipping support in trainer modules
- expose new `grad_clip_norm` option in default config
- mention gradient clipping in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a1a2a1748321bc431cf022551c6a