### PR TITLE
Allow overriding base config in batch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ environment name, set the `CONDA_ENV` variable accordingly. You can also
 skip activation entirely by exporting `USE_CONDA=0` before running the
 scripts.
 
+The base config merged by `generate_config.py` defaults to
+`configs/default.yaml`. Override it by setting the `BASE_CONFIG`
+environment variable:
+
+```bash
+BASE_CONFIG=configs/partial_freeze.yaml bash scripts/run_many.sh
+```
+
 ## Testing
 
 Install **PyTorch** and the remaining dependencies using the helper script and

--- a/scripts/run_many.sh
+++ b/scripts/run_many.sh
@@ -3,6 +3,9 @@
 set -e
 export PYTHONPATH="$(pwd):${PYTHONPATH}"
 
+# Base configuration for generate_config.py
+BASE_CONFIG=${BASE_CONFIG:-configs/default.yaml}
+
 # Conda setup (optional)
 USE_CONDA=${USE_CONDA:-1}
 CONDA_ENV=${CONDA_ENV:-facil_env}
@@ -61,7 +64,7 @@ for T2 in efficientnet_b2 swin_tiny; do
 
         CFG_TMP=$(mktemp)
         python scripts/generate_config.py \
-          --base configs/default.yaml \
+          --base "$BASE_CONFIG" \
           --out "$CFG_TMP" \
           teacher_lr=${T_LR} \
           student_lr=${S_LR} \

--- a/scripts/run_sweep.sh
+++ b/scripts/run_sweep.sh
@@ -4,6 +4,9 @@
 set -e
 export PYTHONPATH="$(pwd):${PYTHONPATH}"
 
+# Base configuration for generate_config.py
+BASE_CONFIG=${BASE_CONFIG:-configs/default.yaml}
+
 # Conda setup (optional)
 USE_CONDA=${USE_CONDA:-1}
 CONDA_ENV=${CONDA_ENV:-facil_env}
@@ -31,7 +34,7 @@ for teacher_lr in 0.0001 0.0002 0.0005; do
 
     CFG_TMP=$(mktemp)
     python scripts/generate_config.py \
-      --base configs/default.yaml \
+      --base "$BASE_CONFIG" \
       --out "$CFG_TMP" \
       teacher_lr=${teacher_lr} \
       student_lr=${S_LR} \


### PR DESCRIPTION
## Summary
- allow selecting a base config via the `BASE_CONFIG` environment variable
- use this variable when calling `generate_config.py`
- document the new option in the README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install torch)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68525fa7f10883219ed0c8acb83b7327