### PR TITLE
Use consistent teacher_type key

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Alternatively edit the YAML file used by `scripts/fine_tuning.py`:
 
 ```yaml
 # configs/fine_tune.yaml
+teacher_type: resnet101
 finetune_epochs: 100
 finetune_lr: 0.0005
 use_cutmix: false
@@ -205,7 +206,8 @@ Set `efficientnet_dropout` to control the dropout rate used in EfficientNet
 teachers. The default value is **0.3**. You can override it on the command line:
 
 ```bash
-python scripts/fine_tuning.py --config configs/fine_tune.yaml --dropout_p 0.5
+python scripts/fine_tuning.py --config configs/fine_tune.yaml \
+  --teacher_type resnet101 --dropout_p 0.5
 ```
 
 For partial freezing with EfficientNet, a new freeze scope

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -11,7 +11,7 @@ use_amp: false
 amp_dtype: float16
 grad_scaler_init_scale: 1024
 
-
+# teacher_type -> architecture name for each teacher
 teacher1_type: "resnet101"
 teacher2_type: "efficientnet_b2"
 

--- a/configs/fine_tune.yaml
+++ b/configs/fine_tune.yaml
@@ -6,7 +6,7 @@ small_input: true        # 32x32 이미지에 맞게 stem stride를 1로 수정
 deterministic: true
 
 # Teacher
-teacher_name: "resnet101"
+teacher_type: "resnet101"
 fine_tune_partial_freeze: false    # true 로 두면 backbone freeze, head만 학습
 efficientnet_dropout: 0.3
 

--- a/scripts/run_many.sh
+++ b/scripts/run_many.sh
@@ -41,7 +41,7 @@ for T2 in efficientnet_b2 swin_tiny; do
     echo ">>> [run_many.sh] fine-tuning teacher=${T}  (epochs=${FT_EPOCHS}, lr=${FT_LR})"
     if [ ! -f "${CKPT}" ]; then
       python scripts/fine_tuning.py \
-        --teacher_name "${T}" \
+        --teacher_type "${T}" \
         --device cuda \
         --batch_size ${BATCH_SIZE} \
         --finetune_epochs ${FT_EPOCHS} \


### PR DESCRIPTION
## Summary
- standardize on `teacher_type` for selecting the teacher architecture
- adjust fine-tuning config and script to use the new key
- update batch script and add clarifying comment in default config
- document the change in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685260bae5f48321a7a7485aa5db9806