### PR TITLE
Document N_STAGE_LIST list syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ BASE_CONFIG=configs/partial_freeze.yaml bash scripts/run_experiments.sh --mode l
 
 Edit `configs/hparams.yaml` before running `bash scripts/run_experiments.sh --mode loop` or
 `bash scripts/run_experiments.sh --mode sweep` to customize the default hyperparameters.
+`N_STAGE_LIST` can contain a space-separated list such as `"2 3 4 5"` to run
+multiple stage counts in one batch.
 
 ### Batch scripts & hyperparameter overrides
 
@@ -246,6 +248,7 @@ After saving the changes, re-run the batch script to generate new teacher
 checkpoints and continue with distillation:
 
 Edit `configs/hparams.yaml` if you want to tweak the default hyperparameters.
+You can specify several stage counts by setting `N_STAGE_LIST="2 3 4 5"`.
 
 ```bash
 bash scripts/run_experiments.sh --mode loop

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -43,6 +43,8 @@ MIXUP_ALPHA: 0.2
 LABEL_SMOOTHING: 0.1
 
 # Sweep/loop variables
+# N_STAGE_LIST accepts a space-separated list of stage counts,
+# e.g. "2 3 4 5" to run multiple values in a batch script.
 N_STAGE_LIST: 5
 SC_ALPHA_LIST: "0.3 0.6"
 STUDENT_LIST: "resnet_adapter efficientnet_adapter swin_adapter"

--- a/scripts/hparams.sh
+++ b/scripts/hparams.sh
@@ -42,6 +42,8 @@ MIXUP_ALPHA=0.2
 LABEL_SMOOTHING=0.1
 
 # Sweep/loop variables
+# N_STAGE_LIST accepts a space-separated list of stage counts,
+# e.g. "2 3 4 5" to run multiple values in a batch script.
 N_STAGE_LIST=5
 SC_ALPHA_LIST="0.3 0.6"
 STUDENT_LIST="resnet_adapter efficientnet_adapter swin_adapter"

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -87,7 +87,9 @@ run_loop() {
     # 2) ASMB multi-stage distillation
     for STUDENT in ${STUDENT_LIST}; do
       for SC_ALPHA in ${SC_ALPHA_LIST}; do
-        for STAGE in ${N_STAGE_LIST}; do
+        # N_STAGE_LIST may contain space-separated values like "2 3 4 5"
+        # Iterate over each item without quoting to allow word splitting.
+        for STAGE in $N_STAGE_LIST; do
           OUTDIR="${RESULT_ROOT}/${T2}_${STUDENT}_a${SC_ALPHA}_s${STAGE}"
           mkdir -p "${OUTDIR}"
 


### PR DESCRIPTION
## Summary
- clarify that `N_STAGE_LIST` takes a space-separated list in `hparams.yaml` and `hparams.sh`
- iterate over each stage correctly in `run_experiments.sh`
- mention the new syntax in the README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526d4a7fe08321a527698adb18efa4