### PR TITLE
Add cleanup trap for temp config

### DIFF
--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -23,10 +23,12 @@ activate_conda() {
   fi
 }
 
-# Generate config and echo path to temporary file
+# Generate config, echo path to a temporary file, and ensure cleanup on exit
 generate_config() {
   local cfg_tmp
   cfg_tmp=$(mktemp)
+  # Ensure temporary config is cleaned up even if the script exits early
+  trap 'rm -f "$cfg_tmp"' EXIT
   python scripts/generate_config.py \
     --base "$BASE_CONFIG" \
     --out "$cfg_tmp" \


### PR DESCRIPTION
## Summary
- ensure `scripts/run_experiments.sh` removes temporary config files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852738eb6dc8321bcbfd408aecadcf4