### PR TITLE
Refactor hyperparam config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ name):
 python scripts/generate_config.py --base configs/fragments/ --out combined.yaml
 ```
 
-Edit `configs/hparams.yaml` before running `bash scripts/run_experiments.sh --mode loop` or
+`configs/hparams.yaml` holds the numeric hyperparameters used by the batch
+scripts while `configs/*.yaml` describe the model architectures and freeze
+settings. Edit `configs/hparams.yaml` before running
+`bash scripts/run_experiments.sh --mode loop` or
 `bash scripts/run_experiments.sh --mode sweep` to customize the default hyperparameters.
 `N_STAGE_LIST` can contain a space-separated list such as `"2 3 4 5"` to run
 multiple stage counts in one batch.
@@ -134,8 +137,8 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
   --teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth \
   --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 0
   # mbm_query_dim is automatically set to the student feature dimension
-        •       Adjust partial-freeze settings in `configs/*.yaml`.
-        •       Edit `configs/hparams.yaml` to change learning rates and other hyperparameters.
+        •       Adjust partial-freeze or architecture settings in `configs/*.yaml`.
+        •       Edit `configs/hparams.yaml` to change numeric hyperparameters like learning rates or dropout.
 	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
         •       Optimizers and schedulers are instantiated once before stages and reset before each stage.
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -25,13 +25,8 @@ mbm_lr_factor: 5.0           # MBM/Head LR 배수
 synergy_ce_alpha: 0.3
 teacher_adapt_alpha_kd: 0.2  # Teacher adaptive 시 KL 비중
 
-reg_lambda: 1e-5          # Teacher L2 regularisation
-# --------------------------------------------------
-# L2 regularisation for MBM + Synergy-Head (App. C)
-#   - Setting it to 0.0 keeps current behaviour.
-#   - Tune around 1e-5 ~ 1e-4 for best results.
-mbm_reg_lambda: 0.0
-# --------------------------------------------------
+# teacher L2 regularisation, MBM weight decay and
+# dropout probabilities are now defined in hparams.yaml
 
 student_type: "efficientnet_adapter"
 student_epochs_per_stage: 15  # Student distill epochs per stage
@@ -59,8 +54,6 @@ num_stages: 2
 # use_partial_freeze defined in hparams.yaml
 
 mbm_in_dim: 3456
-mbm_dropout: 0.0
-synergy_head_dropout: 0.0
 mbm_use_4d: false
 mbm_attn_heads: 0
 mbm_type: "LA"        # "MLP" for old behaviour

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -34,6 +34,9 @@ STUDENT_ITERS: 40
 MBM_HIDDEN_DIM: 1024
 MBM_OUT_DIM: 2048
 MBM_REG: 5e-5         # default sweep value
+REG_LAMBDA: 1e-5      # teacher L2 regularisation
+MBM_DROPOUT: 0.0      # dropout prob inside MBM
+HEAD_DROPOUT: 0.0     # dropout prob for synergy head
 USE_PARTIAL_FREEZE: true
 TEACHER1_USE_ADAPTER: 0
 TEACHER1_BN_HEAD_ONLY: 0

--- a/configs/partial_freeze.yaml
+++ b/configs/partial_freeze.yaml
@@ -2,13 +2,7 @@
 
 # 1) 공통 설정
 # use_partial_freeze defined in hparams.yaml
-reg_lambda: 1e-4          # Teacher L2 regularisation
-# --------------------------------------------------
-# L2 regularisation for MBM + Synergy-Head (App. C)
-#   - Setting it to 0.0 keeps current behaviour.
-#   - Tune around 1e-5 ~ 1e-4 for best results.
-# MBM weight decay defined in hparams.yaml
-# --------------------------------------------------
+# teacher L2 regularisation and MBM weight decay are set in hparams.yaml
 mbm_type: "LA"        # "MLP" for old behaviour
 mbm_r: 4
 mbm_n_head: 1

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -13,6 +13,7 @@ parser.add_argument(
     help="One or more YAML files or a directory of YAML fragments",
 )
 parser.add_argument('--out', required=True, help='Output YAML file')
+parser.add_argument('--hparams', help='YAML file with numeric hyperparameters')
 parser.add_argument('overrides', nargs='*', help='KEY=VAL pairs to override')
 args = parser.parse_args()
 
@@ -29,6 +30,12 @@ for base in args.base:
             data = yaml.safe_load(f)
             if data:
                 cfg.update(data)
+
+if args.hparams:
+    with open(args.hparams) as f:
+        hparams = yaml.safe_load(f)
+        if hparams:
+            cfg.update(hparams)
 
 for ov in args.overrides:
     if '=' not in ov:

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -31,6 +31,7 @@ generate_config() {
   trap 'rm -f "$cfg_tmp"' EXIT
   python scripts/generate_config.py \
     --base "$BASE_CONFIG" \
+    --hparams configs/hparams.yaml \
     --out "$cfg_tmp" \
     teacher_lr=${T_LR} \
     student_lr=${S_LR} \
@@ -48,6 +49,9 @@ generate_config() {
     mbm_hidden_dim=${MBM_HIDDEN_DIM} \
     mbm_out_dim=${MBM_OUT_DIM} \
     mbm_reg_lambda=${MBM_REG} \
+    reg_lambda=${REG_LAMBDA} \
+    mbm_dropout=${MBM_DROPOUT} \
+    synergy_head_dropout=${HEAD_DROPOUT} \
     use_partial_freeze=${USE_PARTIAL_FREEZE} \
     teacher1_use_adapter=${TEACHER1_USE_ADAPTER} \
     teacher1_bn_head_only=${TEACHER1_BN_HEAD_ONLY} \


### PR DESCRIPTION
## Summary
- centralize numeric hyperparameters in `configs/hparams.yaml`
- slim down `configs/default.yaml` and `partial_freeze.yaml`
- update `generate_config.py` and `run_experiments.sh` to read from `hparams.yaml`
- clarify documentation about config roles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852818821d083218e2011bc68c4249d