### PR TITLE
Fix case statement closing in run_experiments.sh

### DIFF
--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -189,4 +189,4 @@ case "$MODE" in
     echo "Invalid mode: $MODE" >&2
     exit 1
     ;;
-fi
+esac


### PR DESCRIPTION
## Summary
- fix incorrect `fi` at end of `case` statement in `run_experiments.sh`
- run unit tests

## Testing
- `pytest -q`
- `bash -n scripts/run_experiments.sh`
- `bash scripts/run_experiments.sh --mode test`

------
https://chatgpt.com/codex/tasks/task_e_6858b21afbf88321be42c6807684d140