### PR TITLE
Add method flag and single-teacher runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ set the `CONDA_ENV` variable accordingly. You can also skip activation
 entirely by exporting `USE_CONDA=0` before running the script. Run experiments
 directly with `bash scripts/run_experiments.sh --mode {loop,sweep}`.
 
+Set the distillation method via the `METHOD` variable. The default `asmb`
+runs the multi‑teacher pipeline in `main.py`. Specify `vanilla_kd`, `fitnet`,
+`dkd`, `at` or `crd` to launch the single‑teacher runner:
+
+```bash
+METHOD=fitnet bash scripts/run_experiments.sh --mode loop
+```
+
 The base config merged by `generate_config.py` defaults to
 `configs/default.yaml`. The script can also merge optional fragments such as
 `configs/fine_tune.yaml` or `configs/partial_freeze.yaml`. Pass one or more
@@ -157,6 +165,16 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
         •       Edit `configs/hparams.yaml` to change numeric hyperparameters like learning rates or dropout.
 	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
         •       Optimizers and schedulers are instantiated once before stages and reset before each stage.
+
+2) Single-Teacher Distillation (run_single_teacher.py)
+
+```bash
+python scripts/run_single_teacher.py --config configs/default.yaml \
+  --method vanilla_kd --teacher_type resnet101 --teacher_ckpt teacher.pth \
+  --student_type resnet_adapter --epochs 40
+```
+
+The `--method` flag selects one of `vanilla_kd`, `fitnet`, `dkd`, `at` or `crd`.
 
 2) Evaluation (eval.py)
 

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -15,6 +15,7 @@ FT_WD: 0.0005
 CUTMIX_ALPHA: 1.0
 
 # Distillation
+METHOD: "asmb"
 T_LR: 2e-4
 S_LR: 1e-2
 T_WD: 0.0003

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -14,6 +14,7 @@ parser.add_argument(
 )
 parser.add_argument('--out', required=True, help='Output YAML file')
 parser.add_argument('--hparams', help='YAML file with numeric hyperparameters')
+parser.add_argument('--method', help='Distillation method name')
 parser.add_argument('overrides', nargs='*', help='KEY=VAL pairs to override')
 args = parser.parse_args()
 
@@ -36,6 +37,9 @@ if args.hparams:
         hparams = yaml.safe_load(f)
         if hparams:
             cfg.update(hparams)
+
+if args.method:
+    cfg['method'] = args.method
 
 for ov in args.overrides:
     if '=' not in ov:

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -32,6 +32,7 @@ generate_config() {
   python scripts/generate_config.py \
     --base "$BASE_CONFIG" \
     --hparams configs/hparams.yaml \
+    --method "$METHOD" \
     --out "$cfg_tmp" \
     teacher_lr=${T_LR} \
     student_lr=${S_LR} \
@@ -101,6 +102,7 @@ run_loop() {
 
           CFG_TMP=$(generate_config)
 
+          if [ "$METHOD" = "asmb" ]; then
           python main.py \
             --config "${CFG_TMP}" \
             --teacher1_type "${T1}" \
@@ -122,7 +124,25 @@ run_loop() {
             --data_aug ${DATA_AUG} \
             --mixup_alpha ${MIXUP_ALPHA} \
             --cutmix_alpha_distill ${CUTMIX_ALPHA_DISTILL} \
-            --label_smoothing ${LABEL_SMOOTHING}
+            --label_smoothing ${LABEL_SMOOTHING} \
+            --method ${METHOD}
+          else
+          python scripts/run_single_teacher.py \
+            --config "${CFG_TMP}" \
+            --teacher_type "${T2}" \
+            --teacher_ckpt checkpoints/${T2}_ft.pth \
+            --student_type "${STUDENT}" \
+            --student_lr ${S_LR} \
+            --batch_size ${BATCH_SIZE} \
+            --epochs ${STUDENT_ITERS} \
+            --results_dir "${OUTDIR}" \
+            --seed 42 \
+            --data_aug ${DATA_AUG} \
+            --mixup_alpha ${MIXUP_ALPHA} \
+            --cutmix_alpha_distill ${CUTMIX_ALPHA_DISTILL} \
+            --label_smoothing ${LABEL_SMOOTHING} \
+            --method ${METHOD}
+          fi
         done
       done
     done
@@ -152,7 +172,8 @@ run_sweep() {
         --teacher1_bn_head_only ${TEACHER1_BN_HEAD_ONLY} \
         --teacher2_use_adapter ${TEACHER2_USE_ADAPTER} \
         --teacher2_bn_head_only ${TEACHER2_BN_HEAD_ONLY} \
-        --label_smoothing ${LABEL_SMOOTHING}
+        --label_smoothing ${LABEL_SMOOTHING} \
+        --method ${METHOD}
     done
   done
 }

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Single-teacher KD runner."""
+import argparse
+import os
+import yaml
+import torch
+from utils.misc import set_random_seed
+from data.cifar100 import get_cifar100_loaders
+from data.imagenet100 import get_imagenet100_loaders
+from main import (
+    create_teacher_by_name,
+    create_student_by_name,
+    partial_freeze_teacher_auto,
+    partial_freeze_student_auto,
+)
+
+from methods.vanilla_kd import VanillaKDDistiller
+from methods.fitnet import FitNetDistiller
+from methods.dkd import DKDDistiller
+from methods.at import ATDistiller
+from methods.crd import CRDDistiller
+
+
+METHOD_MAP = {
+    "vanilla_kd": VanillaKDDistiller,
+    "fitnet": FitNetDistiller,
+    "dkd": DKDDistiller,
+    "at": ATDistiller,
+    "crd": CRDDistiller,
+}
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Single teacher KD")
+    p.add_argument("--config", type=str, default="configs/default.yaml")
+    p.add_argument("--method", type=str, default="vanilla_kd")
+    p.add_argument("--teacher_type", type=str)
+    p.add_argument("--teacher_ckpt", type=str)
+    p.add_argument("--student_type", type=str)
+    p.add_argument("--student_ckpt", type=str)
+    p.add_argument("--batch_size", type=int)
+    p.add_argument("--student_lr", type=float)
+    p.add_argument("--weight_decay", type=float)
+    p.add_argument("--epochs", type=int)
+    p.add_argument("--results_dir", type=str, default="results")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--device", type=str)
+    p.add_argument("--data_aug", type=int)
+    p.add_argument("--mixup_alpha", type=float)
+    p.add_argument("--cutmix_alpha_distill", type=float)
+    p.add_argument("--label_smoothing", type=float)
+    p.add_argument("--small_input", type=int)
+    return p.parse_args()
+
+
+def load_config(path):
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+def build_distiller(method, teacher, student, cfg):
+    cls = METHOD_MAP.get(method)
+    if cls is None:
+        raise ValueError(f"Unknown method {method}")
+    if method == "vanilla_kd":
+        return cls(teacher, student, alpha=cfg.get("kd_alpha", 0.5), temperature=cfg.get("tau_start", 4.0), config=cfg)
+    if method == "fitnet":
+        return cls(teacher, student)
+    if method == "dkd":
+        return cls(teacher, student)
+    if method == "at":
+        return cls(teacher, student)
+    if method == "crd":
+        return cls(teacher, student)
+    raise ValueError(method)
+
+
+def main():
+    args = parse_args()
+    base_cfg = load_config(args.config)
+    cli_cfg = {k: v for k, v in vars(args).items() if v is not None}
+    cfg = {**base_cfg, **cli_cfg}
+
+    method = cfg.get("method", args.method)
+    device = cfg.get("device", "cuda")
+    if device == "cuda" and not torch.cuda.is_available():
+        device = "cpu"
+
+    set_random_seed(cfg.get("seed", 42))
+
+    dataset = cfg.get("dataset_name", "cifar100")
+    batch_size = cfg.get("batch_size", 128)
+    data_root = cfg.get("data_root", "./data")
+    if dataset == "cifar100":
+        train_loader, test_loader = get_cifar100_loaders(
+            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+        )
+    else:
+        train_loader, test_loader = get_imagenet100_loaders(
+            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+        )
+
+    small_input = cfg.get("small_input")
+    if small_input is None:
+        small_input = dataset == "cifar100"
+
+    teacher = create_teacher_by_name(
+        cfg.get("teacher_type", "resnet101"),
+        pretrained=cfg.get("teacher_pretrained", True),
+        small_input=small_input,
+    ).to(device)
+    if cfg.get("teacher_ckpt"):
+        teacher.load_state_dict(torch.load(cfg["teacher_ckpt"], map_location=device, weights_only=True))
+    if cfg.get("use_partial_freeze", True):
+        partial_freeze_teacher_auto(teacher, cfg.get("teacher_type", "resnet101"))
+
+    student = create_student_by_name(
+        cfg.get("student_type", "resnet_adapter"),
+        pretrained=cfg.get("student_pretrained", True),
+        small_input=small_input,
+    ).to(device)
+    if cfg.get("student_ckpt"):
+        student.load_state_dict(torch.load(cfg["student_ckpt"], map_location=device, weights_only=True))
+    if cfg.get("use_partial_freeze", True):
+        partial_freeze_student_auto(student, student_name=cfg.get("student_type", "resnet_adapter"))
+
+    distiller = build_distiller(method, teacher, student, cfg)
+    acc = distiller.train_distillation(
+        train_loader,
+        test_loader,
+        lr=cfg.get("student_lr", 1e-3),
+        weight_decay=cfg.get("weight_decay", cfg.get("student_weight_decay", 1e-4)),
+        epochs=cfg.get("epochs", 10),
+        device=device,
+    )
+
+    os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
+    ckpt = os.path.join(cfg["results_dir"], f"final_student_{method}.pth")
+    torch.save(student.state_dict(), ckpt)
+    print(f"[run_single_teacher] final_acc={acc:.2f}% -> {ckpt}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add METHOD to `configs/hparams.yaml`
- allow `--method` in `generate_config.py`
- update `run_experiments.sh` to forward METHOD and call a new single-teacher script
- implement `scripts/run_single_teacher.py` for VanillaKD, FitNet, DKD, AT and CRD
- document `--method` usage and single-teacher runner in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bd9e4dcc8321bf45cf3b428cc53b