### PR TITLE
Support looping over multiple KD methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,14 @@ set the `CONDA_ENV` variable accordingly. You can also skip activation
 entirely by exporting `USE_CONDA=0` before running the script. Run experiments
 directly with `bash scripts/run_experiments.sh --mode {loop,sweep}`.
 
-Set the distillation method via the `METHOD` variable. The default `asmb`
-runs the multi‑teacher pipeline in `main.py`. Specify `vanilla_kd`, `fitnet`,
-`dkd`, `at` or `crd` to launch the single‑teacher runner:
+Set the distillation method via the `METHOD` variable or provide a
+space‑separated list using `METHOD_LIST`. The default `asmb` runs the
+multi‑teacher pipeline in `main.py`. Specify `vanilla_kd`, `fitnet`, `dkd`,
+`at` or `crd` to launch the single‑teacher runner. With `METHOD_LIST` you can
+execute several methods sequentially:
 
 ```bash
-METHOD=fitnet bash scripts/run_experiments.sh --mode loop
+METHOD_LIST="asmb fitnet vanilla_kd" bash scripts/run_experiments.sh --mode loop
 ```
 
 The base config merged by `generate_config.py` defaults to

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -52,3 +52,4 @@ LABEL_SMOOTHING: 0.1
 N_STAGE_LIST: 5
 SC_ALPHA_LIST: "0.3 0.6"
 STUDENT_LIST: "resnet_adapter efficientnet_adapter swin_adapter"
+METHOD_LIST: "asmb at crd dkd fitnet vanilla_kd"

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -67,11 +67,13 @@ generate_config() {
 
 run_loop() {
   source <(python scripts/load_hparams.py configs/hparams.yaml)
+  METHOD_LIST="${METHOD_LIST:-$METHOD}"
   mkdir -p checkpoints results
   RESULT_ROOT="results/$(date +%Y%m%d_%H%M%S)"
   mkdir -p "${RESULT_ROOT}"
 
   local T1=resnet101
+  for METHOD in $METHOD_LIST; do
   for T2 in efficientnet_b2 swin_tiny; do
     # 1) Teacher fine-tuning
     for T in "$T1" "$T2"; do
@@ -146,6 +148,7 @@ run_loop() {
         done
       done
     done
+  done
   done
 }
 


### PR DESCRIPTION
## Summary
- add `METHOD_LIST` option in `configs/hparams.yaml`
- iterate over `$METHOD_LIST` in `run_experiments.sh`
- document the new list variable in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d252449c83218c3803d03022c17e