### PR TITLE
Fix Optional typing in vanilla_kd

### DIFF
--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+from typing import Optional
 
 from modules.losses import kd_loss_fn, ce_loss_fn
 from utils.schedule import get_tau
@@ -21,7 +22,7 @@ class VanillaKDDistiller(nn.Module):
         student_model: nn.Module,
         alpha: float = 0.5,
         temperature: float = 4.0,
-        config: dict | None = None
+        config: Optional[dict] = None
     ):
         super().__init__()
         self.teacher = teacher_model


### PR DESCRIPTION
## Summary
- import `Optional` for `vanilla_kd`
- update `config` typing to use `Optional[dict]`

## Testing
- `pytest -q` *(fails: 5 skipped in 0.02s)*

------
https://chatgpt.com/codex/tasks/task_e_6858d41d79b88321ba59044b49af9513