### PR TITLE
Add automatic class count detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **Partial Freeze**: Freeze backbone parameters, adapt BN/Heads/MBM for efficiency  
 - **Multiple KD Methods**: FitNet, CRD, AT, DKD, VanillaKD, plus custom `asmb.py`
 - **CIFAR-100 / ImageNet100** dataset support
+- **Automatic class count detection**: number of classes is inferred from the
+  training loader when using `ImageFolder` or CIFAR datasets
 - **Configurable Data Augmentation**: toggle with `--data_aug` (1/0)
 - **MixUp, CutMix & Label Smoothing**: enable with `--mixup_alpha`,
   `--cutmix_alpha_distill` and `--label_smoothing`

--- a/models/students/student_efficientnet_adapter.py
+++ b/models/students/student_efficientnet_adapter.py
@@ -62,7 +62,7 @@ class ExtendedAdapterEffNetB2(nn.Module):
         return feature_dict, logit, ce_loss
 
 
-def create_efficientnet_b2_with_adapter(pretrained=True):
+def create_efficientnet_b2_with_adapter(pretrained=True, num_classes: int = 100):
     """
     1) efficientnet_b2 로드
     2) classifier => (1408->100)
@@ -74,7 +74,7 @@ def create_efficientnet_b2_with_adapter(pretrained=True):
         model = efficientnet_b2(weights=None)
 
     in_feats = model.classifier[1].in_features  # 1408
-    model.classifier[1] = nn.Linear(in_feats, 100)
+    model.classifier[1] = nn.Linear(in_feats, num_classes)
 
-    student_model = ExtendedAdapterEffNetB2(model, num_classes=100)
+    student_model = ExtendedAdapterEffNetB2(model, num_classes=num_classes)
     return student_model

--- a/models/students/student_resnet_adapter.py
+++ b/models/students/student_resnet_adapter.py
@@ -94,7 +94,7 @@ class ExtendedAdapterResNet101(nn.Module):
         return feature_dict, logit, ce_loss
 
 
-def create_resnet101_with_extended_adapter(pretrained=True):
+def create_resnet101_with_extended_adapter(pretrained=True, num_classes: int = 100):
     """
     ResNet101 load => last FC => 100
     => ExtendedAdapterResNet101 => (dict, logit, ce_loss)
@@ -105,7 +105,7 @@ def create_resnet101_with_extended_adapter(pretrained=True):
         base = resnet101(weights=None)
 
     num_ftrs = base.fc.in_features
-    base.fc  = nn.Linear(num_ftrs, 100)
+    base.fc = nn.Linear(num_ftrs, num_classes)
 
     model = ExtendedAdapterResNet101(base)
     return model

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -13,7 +13,7 @@ import copy
 import torch
 import yaml
 
-from utils.misc import set_random_seed
+from utils.misc import set_random_seed, check_label_range
 
 # data loaders
 from data.cifar100 import get_cifar100_loaders
@@ -207,6 +207,10 @@ def main():
         augment=cfg.get("data_aug", True)
     )
 
+    num_classes = len(train_loader.dataset.classes)
+    check_label_range(train_loader.dataset, num_classes)
+    check_label_range(test_loader.dataset, num_classes)
+
     small_input = cfg.get("small_input")
     if small_input is None:
         small_input = dataset_name == "cifar100"
@@ -216,7 +220,7 @@ def main():
     print(f"[FineTune] ===== Now fine-tuning teacher: {teacher_type} =====")
     teacher_model = create_teacher_by_name(
         teacher_type,
-        num_classes=cfg.get("num_classes", 100),
+        num_classes=num_classes,
         pretrained=cfg.get("teacher_pretrained", True),
         small_input=small_input,
         dropout_p=cfg.get("efficientnet_dropout", 0.3),


### PR DESCRIPTION
## Summary
- infer `num_classes` from the training loader in `main.py`, `run_single_teacher.py` and `fine_tuning.py`
- update student factories to accept a `num_classes` argument
- validate dataset label ranges via new `check_label_range` utility
- document automatic class count detection in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685913d4eb1483219c35707ead34c557