### PR TITLE
Add dataset option to single-teacher KD runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,13 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
 ```bash
 python scripts/run_single_teacher.py --config configs/default.yaml \
   --method vanilla_kd --teacher_type resnet101 --teacher_ckpt teacher.pth \
-  --student_type resnet_adapter --epochs 40
+  --student_type resnet_adapter --epochs 40 \
+  --dataset imagenet100
 ```
 
 The `--method` flag selects one of `vanilla_kd`, `fitnet`, `dkd`, `at` or `crd`.
+Pass `--dataset` to override the dataset specified in the YAML config (either
+`cifar100` or `imagenet100`).
 
 2) Evaluation (eval.py)
 

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -44,6 +44,8 @@ def parse_args():
     p.add_argument("--results_dir", type=str, default="results")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--device", type=str)
+    p.add_argument("--dataset", "--dataset_name", dest="dataset_name", type=str,
+                   help="Dataset to use (cifar100 or imagenet100). Defaults to the config value")
     p.add_argument("--data_aug", type=int)
     p.add_argument("--mixup_alpha", type=float)
     p.add_argument("--cutmix_alpha_distill", type=float)


### PR DESCRIPTION
## Summary
- allow choosing dataset via `--dataset` flag in `run_single_teacher.py`
- document the new flag in the README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685915130e4c8321bd7a1a1f7adac612