### PR TITLE
Disable partial freeze for non-asmb single-teacher runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ python scripts/run_single_teacher.py --config configs/default.yaml \
 The `--method` flag selects one of `vanilla_kd`, `fitnet`, `dkd`, `at` or `crd`.
 Pass `--dataset` to override the dataset specified in the YAML config (either
 `cifar100` or `imagenet100`).
+Partial freezing is automatically turned off for these methods—`run_single_teacher.py`
+sets `use_partial_freeze: false` when the selected `method` is not `asmb`.
 
 2) Evaluation (eval.py)
 

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -85,6 +85,8 @@ def main():
     cfg = {**base_cfg, **cli_cfg}
 
     method = cfg.get("method", args.method)
+    if method != "asmb":
+        cfg["use_partial_freeze"] = False
     teacher_type = cfg.get("teacher_type", args.teacher_type)
     student_type = cfg.get("student_type", args.student_type)
     print(


### PR DESCRIPTION
## Summary
- disable partial freezing in `run_single_teacher.py` when the selected method isn't `asmb`
- document this behavior in the Single-Teacher Distillation section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685931351bdc83218bd8c7157311179c