### PR TITLE
Ensure teacher stays in eval mode during VanillaKD

### DIFF
--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -77,7 +77,9 @@ class VanillaKDDistiller(nn.Module):
         best_state = None
 
         for epoch in range(1, epochs+1):
-            self.train()
+            # ensure only the student is in training mode
+            self.student.train()
+            self.teacher.eval()
             cur_tau = get_tau(self.cfg, epoch-1)
             total_loss, total_num = 0.0, 0
             for x, y in train_loader:


### PR DESCRIPTION
## Summary
- keep teacher in evaluation mode during training
- set only the student to train each epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595dcd7ee8832186e17ce996ea92eb