### PR TITLE
Add label smoothing to VanillaKDDistiller

### DIFF
--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -43,7 +43,12 @@ class VanillaKDDistiller(nn.Module):
         s_dict, s_logit, _ = self.student(x)     # we don't use s_dict either
 
         # CE
-        ce_loss = ce_loss_fn(s_logit, y)
+        label_smoothing = self.cfg.get("label_smoothing", 0.0)
+        ce_loss = ce_loss_fn(
+            s_logit,
+            y,
+            label_smoothing=label_smoothing,
+        )
         # KD
         T_use = self.temperature if tau is None else tau
         kd_loss = kd_loss_fn(s_logit, t_logit, T=T_use)

--- a/tests/test_vanilla_kd.py
+++ b/tests/test_vanilla_kd.py
@@ -1,0 +1,42 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from methods.vanilla_kd import VanillaKDDistiller
+from modules.losses import ce_loss_fn, kd_loss_fn
+
+
+class ConstTeacher(torch.nn.Module):
+    def __init__(self, logits):
+        super().__init__()
+        self.logits = torch.tensor(logits, dtype=torch.float32)
+
+    def forward(self, x):
+        return {"logit": self.logits.expand(x.size(0), -1)}
+
+
+class ConstStudent(torch.nn.Module):
+    def __init__(self, logits):
+        super().__init__()
+        self.logits = torch.tensor(logits, dtype=torch.float32)
+
+    def forward(self, x):
+        return {}, self.logits.expand(x.size(0), -1), None
+
+
+def test_forward_uses_label_smoothing():
+    teacher = ConstTeacher([[1.0, -1.0]])
+    student = ConstStudent([[-1.0, 1.0]])
+
+    cfg = {"label_smoothing": 0.2}
+    distiller = VanillaKDDistiller(teacher, student, alpha=0.5, temperature=1.0, config=cfg)
+
+    x = torch.zeros(1, 3)
+    y = torch.tensor([0])
+
+    loss, _ = distiller.forward(x, y)
+
+    ce = ce_loss_fn(student.logits, y, label_smoothing=0.2)
+    kd = kd_loss_fn(student.logits, teacher.logits, T=1.0)
+    expected = 0.5 * ce + 0.5 * kd
+    assert torch.allclose(loss, expected)


### PR DESCRIPTION
## Summary
- support `label_smoothing` in `VanillaKDDistiller.forward`
- test that label smoothing is used when computing CE loss

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595e726b948321a6ad57e7e9faefbb