### PR TITLE
Ensure teacher eval mode during distillation

### DIFF
--- a/methods/at.py
+++ b/methods/at.py
@@ -89,7 +89,8 @@ class ATDistiller(nn.Module):
         best_state = None
 
         for epoch in range(1, epochs+1):
-            self.train()
+            self.student.train()
+            self.teacher.eval()
             total_loss, total_num = 0.0, 0
             for x, y in train_loader:
                 x, y = x.to(device), y.to(device)

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -91,7 +91,8 @@ class CRDDistiller(nn.Module):
         best_state = None
 
         for epoch in range(1, epochs+1):
-            self.train()
+            self.student.train()
+            self.teacher.eval()
             total_loss, total_num = 0.0, 0
             for x, y in train_loader:
                 x, y = x.to(device), y.to(device)

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -100,7 +100,8 @@ class DKDDistiller(nn.Module):
         best_state = None
 
         for epoch in range(1, epochs + 1):
-            self.train()
+            self.student.train()
+            self.teacher.eval()
             total_loss, total_num = 0.0, 0
 
             for x, y in train_loader:

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -88,7 +88,8 @@ class FitNetDistiller(nn.Module):
         best_state = None
 
         for epoch in range(1, epochs+1):
-            self.train()
+            self.student.train()
+            self.teacher.eval()
             total_loss, total_num = 0.0, 0
             for x, y in train_loader:
                 x, y = x.to(device), y.to(device)

--- a/tests/test_teacher_eval_mode.py
+++ b/tests/test_teacher_eval_mode.py
@@ -1,0 +1,58 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from methods.at import ATDistiller
+from methods.fitnet import FitNetDistiller
+from methods.dkd import DKDDistiller
+from methods.crd import CRDDistiller
+
+
+class DummyTeacher(torch.nn.Module):
+    def forward(self, x):
+        b = x.size(0)
+        return {
+            "feat_4d_layer3": torch.zeros(b, 1, 1, 1),
+            "feat_4d_layer2": torch.zeros(b, 1, 1, 1),
+            "feat_2d": torch.zeros(b, 1),
+            "logit": torch.zeros(b, 2),
+        }
+
+
+class DummyStudent(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.feat = torch.nn.Linear(3, 1)
+        self.cls = torch.nn.Linear(3, 2)
+
+    def forward(self, x):
+        f = self.feat(x)
+        f4d = f.view(x.size(0), 1, 1, 1)
+        f2d = f
+        logit = self.cls(x)
+        return {"feat_4d_layer3": f4d, "feat_4d_layer2": f4d, "feat_2d": f2d}, logit, None
+
+
+def get_loader():
+    x = torch.randn(2, 3)
+    y = torch.tensor([0, 1])
+    return [(x, y)]
+
+
+@pytest.mark.parametrize(
+    "distiller_cls, kwargs",
+    [
+        (ATDistiller, {}),
+        (FitNetDistiller, {"hint_key": "feat_4d_layer3", "guided_key": "feat_4d_layer3"}),
+        (DKDDistiller, {}),
+        (CRDDistiller, {}),
+    ],
+)
+def test_train_distillation_teacher_eval(distiller_cls, kwargs):
+    teacher = DummyTeacher()
+    student = DummyStudent()
+    teacher.train()
+    distiller = distiller_cls(teacher, student, **kwargs)
+    loader = get_loader()
+    distiller.train_distillation(loader, test_loader=None, epochs=1, device="cpu")
+    assert not teacher.training


### PR DESCRIPTION
## Summary
- set teacher to `eval()` and student to `train()` inside distillation loops for AT, FitNet, DKD, and CRD
- test that `train_distillation` switches teacher to evaluation mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859602ccefc8321873f95394577b280