### PR TITLE
Fix MBM query dim fallback

### DIFF
--- a/models/mbm.py
+++ b/models/mbm.py
@@ -110,7 +110,9 @@ def build_from_teachers(
 
     mbm_type = cfg.get("mbm_type", "MLP")
     if mbm_type == "LA":
-        qdim = cfg.get("mbm_query_dim", query_dim)
+        qdim = cfg.get("mbm_query_dim")
+        if qdim is None or qdim <= 0:
+            qdim = query_dim
         if qdim is not None and qdim <= 0:
             qdim = None
         mbm = LightweightAttnMBM(


### PR DESCRIPTION
## Summary
- fix fallback logic for `mbm_query_dim`
- all tests skipped due to missing torch

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859649fb45083219689696116f89aec