### PR TITLE
Add --method arg to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ multi‑teacher pipeline in `main.py`. Specify `vanilla_kd`, `fitnet`, `dkd`,
 `at` or `crd` to launch the single‑teacher runner. With `METHOD_LIST` you can
 execute several methods sequentially:
 
+The main training script accepts the same flag via `--method` (default `asmb`)
+so `run_experiments.sh` can pass it uniformly.
+
 ```bash
 METHOD_LIST="asmb fitnet vanilla_kd" bash scripts/run_experiments.sh --mode loop
 ```

--- a/main.py
+++ b/main.py
@@ -148,6 +148,12 @@ def parse_args():
     parser.add_argument("--mbm_n_head", type=int)
     parser.add_argument("--mbm_learnable_q", type=int)
     parser.add_argument("--lr_schedule", type=str)
+    parser.add_argument(
+        "--method",
+        type=str,
+        default="asmb",
+        help="Distillation method name (for run_experiments.sh compatibility)",
+    )
     return parser.parse_args()
 
 def load_config(cfg_path):


### PR DESCRIPTION
## Summary
- add `--method` argument to `parse_args()` with default `asmb`
- note the new flag in README for script compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685966960f5083218bfbfef4fa011c70