### PR TITLE
Update README for TeacherSwinWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ Swin) to expect 32×32 inputs.
 ### Teacher Fine-Tuning
 
 Fine-tune the individual teachers before running the distillation stages.
+The bundled `TeacherSwinWrapper` accepts a Swin backbone that implements
+either a `forward_features` or `features` method to produce the intermediate
+feature map.
 Adjust the parameters in `configs/hparams.yaml`:
 
 ```bash


### PR DESCRIPTION
## Summary
- document TeacherSwinWrapper fallback to `features` in README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a04487ba483218a1135dadae336c3