### PR TITLE
Refactor config layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ METHOD_LIST="asmb fitnet vanilla_kd" bash scripts/run_experiments.sh --mode loop
 ```
 
 The base config merged by `generate_config.py` defaults to
-`configs/default.yaml`. The script can also merge optional fragments such as
+`configs/default.yaml`. This file only defines universal settings such as
+device and paths. The script can also merge optional fragments such as
 `configs/fine_tune.yaml` or `configs/partial_freeze.yaml`. Pass one or more
 fragment files (or a directory containing them) to assemble a config from
 multiple pieces. Override the selection by setting the `BASE_CONFIG`
@@ -356,21 +357,17 @@ bash scripts/run_experiments.sh --mode loop
 
 With partial freezing you can further restrict the teachers to small
 adapters or only update their batch-norm layers and classifier heads.
-Set the following keys in your config:
+Set the following flags in `configs/hparams.yaml`:
 
 ```yaml
-# configs/partial_freeze.yaml
-teacher1_use_adapter: true
-teacher1_bn_head_only: true
-teacher2_use_adapter: true
-teacher2_bn_head_only: false
+TEACHER1_USE_ADAPTER: 1
+TEACHER1_BN_HEAD_ONLY: 1
+TEACHER2_USE_ADAPTER: 1
+TEACHER2_BN_HEAD_ONLY: 0
 ```
 
-These map to `TEACHER1_USE_ADAPTER`, `TEACHER1_BN_HEAD_ONLY`,
-`TEACHER2_USE_ADAPTER` and `TEACHER2_BN_HEAD_ONLY` in
-`configs/hparams.yaml`. `run_experiments.sh` reads the values from this
-file so you can toggle them for sweeps or batch runs without editing
-every config file.
+`run_experiments.sh` exports these values so you can toggle them for
+sweeps or batch runs without editing every config file.
 
 
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,6 +1,6 @@
 # configs/default.yaml
 
-device: "cuda"          # "cuda" or "cpu"
+device: "cuda"
 seed: 42
 deterministic: true
 dataset_name: "cifar100"
@@ -11,68 +11,9 @@ use_amp: false
 amp_dtype: float16
 grad_scaler_init_scale: 1024
 
-# teacher_type -> architecture name for each teacher
-teacher1_type: "resnet101"
-teacher2_type: "efficientnet_b2"
-
-teacher1_pretrained: true
-teacher2_pretrained: true
-
-# learning rates & weight decay now defined in hparams.yaml
-teacher_adapt_epochs: 5      # Teacher Adaptive Update epochs
-mbm_lr_factor: 1.0           # MBM/Head LR 배수
-
-synergy_ce_alpha: 0.3
-teacher_adapt_alpha_kd: 1.0  # Teacher adaptive 시 KL 비중
-
-# teacher L2 regularisation, MBM weight decay and
-# dropout probabilities are now defined in hparams.yaml
-
-student_type: "efficientnet_adapter"
-student_epochs_per_stage: 15  # Student distill epochs per stage
-
-# CE/KL weights now defined in hparams.yaml
-# ----- KD temperature (τ) schedule -----
-# temperature schedule parameters defined in hparams.yaml
-
-# --- Feature-KD 옵션 (추가) -------------------------
-# feat_kd_alpha가 0이면 Feature-KD 비활성화
-feat_kd_alpha: 1.0        # λ_feat   (논문 α_feat)
-feat_kd_key: "feat_2d"    # 어느 딕셔너리 key를 쓸지 (feat_4d 도 가능)
-feat_kd_norm: "none"      # "none" | "l2"  (예: 벡터 정규화 후 MSE)
-
-# disagreement-based sample weighting
-use_disagree_weight: false
-disagree_mode: "pred"       # "pred" | "both_wrong"
-disagree_lambda_high: 1.0
-disagree_lambda_low: 1.0
-
-num_stages: 2
-
-# iteration counts defined in hparams.yaml
-
-# use_partial_freeze defined in hparams.yaml
-
-mbm_in_dim: 3456
-mbm_use_4d: false
-mbm_attn_heads: 0
-mbm_type: "LA"        # "MLP" for old behaviour
-mbm_r: 4
-mbm_n_head: 1
-mbm_learnable_q: true
-mbm_query_dim: 0  # <=0 -> use sum(feat_dims); set to student feat dim to override
-grad_clip_norm: 2.0   # max norm for gradient clipping (0 to disable)
-
-# CutMix/MixUp and label smoothing defined in hparams.yaml
-
 log_filename: "train.log"
 save_checkpoint: true
 ckpt_dir: "./checkpoints"
 
-# Optional teacher fine-tuning before ASMB stages
-# fine-tuning epochs defined in hparams.yaml
-# Fine-tuning lr & weight decay defined in hparams.yaml
-finetune_use_cutmix: true
-finetune_alpha: 1.0
 finetune_ckpt1: "./checkpoints/teacher1_finetuned.pth"
 finetune_ckpt2: "./checkpoints/teacher2_finetuned.pth"

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -60,3 +60,34 @@ N_STAGE_LIST: 5
 SC_ALPHA_LIST: "0.6" # 0.3 0.6
 STUDENT_LIST: "resnet_adapter efficientnet_adapter swin_adapter"
 METHOD_LIST: "asmb vanilla_kd" ## asmb at crd dkd fitnet 
+# Teacher adaptation
+TEACHER_ADAPT_EPOCHS: 5
+TEACHER_ADAPT_ALPHA_KD: 1.0
+MBM_LR_FACTOR: 1.0
+SYNERGY_CE_ALPHA: 0.3
+
+# Feature KD
+FEAT_KD_ALPHA: 1.0
+FEAT_KD_KEY: "feat_2d"
+FEAT_KD_NORM: "none"
+
+# Disagreement weighting
+USE_DISAGREE_WEIGHT: false
+DISAGREE_MODE: "pred"
+DISAGREE_LAMBDA_HIGH: 1.0
+DISAGREE_LAMBDA_LOW: 1.0
+
+# MBM options
+MBM_TYPE: "LA"
+MBM_R: 4
+MBM_N_HEAD: 1
+MBM_LEARNABLE_Q: true
+MBM_IN_DIM: 3456
+MBM_USE_4D: false
+MBM_ATTN_HEADS: 0
+MBM_QUERY_DIM: 0
+
+# Misc
+GRAD_CLIP_NORM: 2.0
+FINETUNE_USE_CUTMIX: true
+FINETUNE_ALPHA: 1.0

--- a/configs/partial_freeze.yaml
+++ b/configs/partial_freeze.yaml
@@ -1,30 +1,13 @@
 # configs/partial_freeze.yaml
 
-# 1) 공통 설정
 # use_partial_freeze defined in hparams.yaml
-# teacher L2 regularisation and MBM weight decay are set in hparams.yaml
-mbm_type: "LA"        # "MLP" for old behaviour
-mbm_r: 4
-mbm_n_head: 1
-mbm_learnable_q: true
 
-# 2) Teacher1 관련
-teacher1_type: "resnet101"          # 혹은 "swin_tiny", "efficientnet_b2"
-teacher1_pretrained: true
-teacher1_freeze_bn: false           # BN을 unfreeze (즉 BN도 학습)
-teacher1_freeze_scope: "layer4_fc"  # partial_freeze_teacher_resnet에서 layer4. + fc. 만 unfreeze
-# adapter & BN-head-only options now set via hparams.yaml
+teacher1_freeze_bn: false
+teacher1_freeze_scope: "layer4_fc"
 
-# 3) Teacher2 관련
-teacher2_type: "efficientnet_b2"
-teacher2_pretrained: true
-teacher2_freeze_bn: true            # BN까지 동결
-teacher2_freeze_scope: "classifier_only"  # or "features_classifier" to unfreeze features + classifier (+ mbm)
-# adapter & BN-head-only options now set via hparams.yaml
+teacher2_freeze_bn: true
+teacher2_freeze_scope: "classifier_only"
 
-# 4) Student 관련
-student_type: "resnet_adapter"
-student_freeze_bn: false            # BN unfreeze
-student_freeze_scope: "layer4_fc" #fc_only # EfficientNet 사용 시 "features_classifier" 도 가능
-student_use_adapter: false          # adapter_ 파라미터 해제 여부
-
+student_freeze_bn: false
+student_freeze_scope: "layer4_fc"
+student_use_adapter: false

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # scripts/run_experiments.sh
+# Hyperparameters are loaded from configs/hparams.yaml
 
 set -e
 export PYTHONPATH="$(pwd):${PYTHONPATH}"


### PR DESCRIPTION
## Summary
- keep `configs/default.yaml` lean with only universal defaults
- centralize tunable hyperparameters in `configs/hparams.yaml`
- trim `configs/partial_freeze.yaml` to freeze scopes only
- document new config layout in README
- note hparam file in `run_experiments.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a49607120832192788b6780e211fd