### PR TITLE
Fix teacher disagreement metric

### DIFF
--- a/modules/disagreement.py
+++ b/modules/disagreement.py
@@ -6,7 +6,7 @@ import torch
 def compute_disagreement_rate(teacher1, teacher2, loader, device="cuda"):
     """
     Compute the percentage of samples on which teacher1 and teacher2
-    BOTH make an incorrect prediction.
+    predict *different* labels.
 
     teacher1, teacher2: nn.Module (teacher wrappers)
         Their forward(x) should return (feat, logit, loss) or similar.
@@ -14,12 +14,12 @@ def compute_disagreement_rate(teacher1, teacher2, loader, device="cuda"):
     device: "cuda" or "cpu"
 
     Returns:
-        float (0~100) indicating the cross-error percentage.
+        float (0~100) indicating the disagreement percentage.
     """
     teacher1.eval()
     teacher2.eval()
     total_samples = 0
-    both_wrong = 0
+    disagree_count = 0
 
     for x, y in loader:
         x, y = x.to(device), y.to(device)
@@ -33,10 +33,13 @@ def compute_disagreement_rate(teacher1, teacher2, loader, device="cuda"):
         pred1 = logit1.argmax(dim=1)
         pred2 = logit2.argmax(dim=1)
 
-        # mask of "both teacher preds are wrong"
-        wrong_mask = (pred1 != y) & (pred2 != y)
-        both_wrong += wrong_mask.sum().item()
-        total_samples += y.size(0)
+        # mask of samples where the two teachers disagree
+        disagree_mask = pred1 != pred2
+        disagree_count += disagree_mask.float().sum().item()
+        total_samples += disagree_mask.numel()
 
-    cross_err_rate = 100.0 * both_wrong / total_samples if total_samples > 0 else 0.0
-    return cross_err_rate
+    # percentage of samples with different predictions
+    disagree_rate = (
+        100.0 * disagree_count / total_samples if total_samples > 0 else 0.0
+    )
+    return disagree_rate


### PR DESCRIPTION
## Summary
- update `compute_disagreement_rate` to count prediction differences
- document new disagreement definition

## Testing
- `python eval.py --help` *(fails: No module named 'yaml')*
- `python - <<'PY'
import torch
PY` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685a6125a3fc83218ab52872b2aa7cfe