### PR TITLE
Add mode option for disagreement rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs
   (and remove max-pool for ResNet)
+- **Disagreement Metrics**: `compute_disagreement_rate` now accepts
+  `mode="pred"` to measure prediction mismatch or `mode="both_wrong"` for
+  cross-error
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -537,6 +537,7 @@ def main():
             test_loader,
             device=device,
             cfg=cfg,
+            mode=cfg.get("disagree_mode", "both_wrong"),
         )
         print(f"[Stage {stage_id}] Teacher disagreement= {dis_rate:.2f}%")
         logger.update_metric(f"stage{stage_id}_disagreement_rate", dis_rate)


### PR DESCRIPTION
## Summary
- extend `compute_disagreement_rate` with a `mode` argument
- support prediction mismatch or cross-error measurement
- pass `disagree_mode` setting when computing the teacher disagreement rate
- document new option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6509e4d88321b26cfee3abc5a789