### PR TITLE
Handle feature KD warning once per epoch

### DIFF
--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -63,6 +63,7 @@ def student_distillation_update(
         distill_loss_sum = 0.0
         cnt = 0
         student_model.train()
+        feat_kd_warned = False
 
         mix_mode = (
             "cutmix"
@@ -167,10 +168,12 @@ def student_distillation_update(
                 if s_flat.size(1) == f_flat.size(1):
                     feat_kd_val = torch.nn.functional.mse_loss(s_flat, f_flat)
                 else:
-                    logger.info(
-                        f"[StudentDistill] skip feat KD: s_feat={s_flat.size(1)}"
-                        f" vs fsyn={f_flat.size(1)}"
-                    )
+                    if not feat_kd_warned:
+                        logger.info(
+                            f"[StudentDistill] skip feat KD: s_feat={s_flat.size(1)}"
+                            f" vs fsyn={f_flat.size(1)}"
+                        )
+                        feat_kd_warned = True
 
             loss = (
                 cfg["ce_alpha"] * ce_loss_val

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -109,6 +109,7 @@ def teacher_adaptive_update(
         teacher_loss_sum = 0.0
         count = 0
         attn_sum = 0.0
+        feat_kd_warned = False
 
         for batch in smart_tqdm(trainloader, desc=f"[TeacherAdaptive ep={ep+1}]"):
             x, y = batch
@@ -158,10 +159,12 @@ def teacher_adaptive_update(
                     if s_flat.size(1) == f_flat.size(1):
                         feat_kd_loss = torch.nn.functional.mse_loss(s_flat, f_flat)
                     else:
-                        logger.info(
-                            f"[TeacherAdaptive] skip feat KD: s_feat={s_flat.size(1)}"
-                            f" vs fsyn={f_flat.size(1)}"
-                        )
+                        if not feat_kd_warned:
+                            logger.info(
+                                f"[TeacherAdaptive] skip feat KD: s_feat={s_flat.size(1)}"
+                                f" vs fsyn={f_flat.size(1)}"
+                            )
+                            feat_kd_warned = True
 
             # 기본 KD+CE
             total_loss = (


### PR DESCRIPTION
## Summary
- add a `feat_kd_warned` flag in teacher/student trainers
- print feature KD dimension mismatch warning once per epoch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab7885fd0832190a104e5fa362cb8