### PR TITLE
Fix student Swin partial freeze scope

### DIFF
--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -242,12 +242,12 @@ def partial_freeze_student_swin(
 
     if freeze_scope == "head_only":
         for name, param in model.named_parameters():
-            if "head." in name:
+            if "head." in name or "fc." in name:
                 param.requires_grad = True
     else:
         # default => "layers.3." + "head."
         for name, param in model.named_parameters():
-            if "layers.3." in name or "head." in name:
+            if "layers.3." in name or "head." in name or "fc." in name:
                 param.requires_grad = True
 
     if use_adapter:

--- a/tests/test_partial_freeze_students.py
+++ b/tests/test_partial_freeze_students.py
@@ -1,0 +1,29 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.partial_freeze import partial_freeze_student_swin
+
+
+class DummyStudentSwin(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.swin = torch.nn.Module()
+        self.swin.layers = torch.nn.Module()
+        self.swin.layers.add_module("3", torch.nn.Linear(1, 1))
+        self.fc = torch.nn.Linear(1, 1)
+        self.adapter_block = torch.nn.Linear(1, 1)
+        self.add_module("adapter_conv", self.adapter_block)
+
+
+def _req_dict(model):
+    return {n: p.requires_grad for n, p in model.named_parameters()}
+
+
+def test_swin_student_unfreeze_default():
+    m = DummyStudentSwin()
+    partial_freeze_student_swin(m)
+    req = _req_dict(m)
+    assert req["swin.layers.3.weight"]
+    assert req["fc.weight"]
+


### PR DESCRIPTION
## Summary
- ensure `partial_freeze_student_swin` also unfreezes the final `fc` layer
- add regression test covering the student Swin freeze logic

## Testing
- `pytest -q tests/test_partial_freeze_students.py -vv` *(fails: collected 0 items / 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685b32f9ca8c8321ad4b0900816396d6