### PR TITLE
Ensure training mode in teacher adaptive update

### DIFF
--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -105,6 +105,12 @@ def teacher_adaptive_update(
     autocast_ctx, scaler = get_amp_components(cfg)
     la_mode = isinstance(mbm, LightweightAttnMBM) or cfg.get("mbm_type") == "LA"
     for ep in range(teacher_epochs):
+        for tw in teacher_wrappers:
+            tw.train()
+        mbm.train()
+        synergy_head.train()
+        if student_model is not None:
+            student_model.eval()
         cur_tau = get_tau(cfg, global_ep + ep)
         teacher_loss_sum = 0.0
         count = 0

--- a/tests/test_teacher_adaptive_update.py
+++ b/tests/test_teacher_adaptive_update.py
@@ -10,10 +10,12 @@ class DummyTeacher(torch.nn.Module):
         super().__init__()
         self.frozen = torch.nn.Linear(3, 3)
         self.trainable = torch.nn.Linear(3, 3)
+        self.record_training = None
         for p in self.frozen.parameters():
             p.requires_grad = False
 
     def forward(self, x):
+        self.record_training = self.training
         x = self.trainable(x)
         x = self.frozen(x)
         return {"feat_2d": x, "logit": x, "feat_4d": None}
@@ -30,8 +32,10 @@ class DummyStudent(torch.nn.Module):
         super().__init__()
         self.feat = torch.nn.Linear(3, 3)
         self.cls = torch.nn.Linear(3, 3)
+        self.record_training = None
 
     def forward(self, x):
+        self.record_training = self.training
         f = self.feat(x)
         logit = self.cls(x)
         return {"feat_2d": f}, logit, None
@@ -41,7 +45,12 @@ class DummyStudent(torch.nn.Module):
 
 
 class AvgMBM(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.record_training = None
+
     def forward(self, feats_2d, feats_4d=None):
+        self.record_training = self.training
         return sum(feats_2d) / len(feats_2d)
 
 
@@ -49,8 +58,10 @@ class DummyHead(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.fc = torch.nn.Linear(3, 3)
+        self.record_training = None
 
     def forward(self, x):
+        self.record_training = self.training
         return self.fc(x)
 
 
@@ -102,3 +113,51 @@ def test_teacher_adaptive_update_preserves_freeze():
 
     frozen_after = [p.requires_grad for p in t1.frozen.parameters()]
     assert frozen_before == frozen_after == [False, False]
+
+
+def test_teacher_adaptive_update_trains_modules():
+    t1 = DummyTeacher()
+    t2 = DummyTeacher()
+    student = DummyStudent()
+    mbm = AvgMBM()
+    head = DummyHead()
+
+    loader = [(torch.randn(2, 3), torch.tensor([0, 1]))]
+
+    cfg = {"device": "cpu", "synergy_ce_alpha": 0.1, "teacher_iters": 1}
+
+    params = []
+    for m in [t1, t2, mbm, head]:
+        for p in m.parameters():
+            if p.requires_grad:
+                params.append(p)
+    opt = torch.optim.SGD(params, lr=0.1)
+    logger = DummyLogger()
+
+    # start all modules in eval mode
+    for m in [t1, t2, mbm, head, student]:
+        m.eval()
+
+    teacher_adaptive_update(
+        teacher_wrappers=[t1, t2],
+        mbm=mbm,
+        synergy_head=head,
+        student_model=student,
+        trainloader=loader,
+        testloader=None,
+        cfg=cfg,
+        logger=logger,
+        optimizer=opt,
+        scheduler=None,
+        global_ep=0,
+    )
+
+    assert t1.record_training is True
+    assert t2.record_training is True
+    assert mbm.record_training is True
+    assert head.record_training is True
+    assert student.record_training is False
+    assert t1.training
+    assert t2.training
+    assert mbm.training
+    assert head.training


### PR DESCRIPTION
## Summary
- set teacher, MBM, and synergy head modules to training mode at the start of each epoch in `teacher_adaptive_update`
- call `eval()` on the student for clarity
- extend tests to verify that modules run in training mode

## Testing
- `pytest -q` *(fails: 16 skipped due to missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_685b52bcfbf88321b45f7d529e8ea4af