### PR TITLE
Enable AMP by default and extend ASMB epochs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ METHOD_LIST="asmb fitnet vanilla_kd" bash scripts/run_experiments.sh --mode loop
 ```
 
 The base config merged by `generate_config.py` defaults to
-`configs/default.yaml`. This file only defines universal settings such as
-device and paths. The script can also merge optional fragments such as
+`configs/default.yaml`. This file defines universal settings such as
+device and paths and enables Automatic Mixed Precision (AMP) by default.
+The script can also merge optional fragments such as
 `configs/partial_freeze.yaml`. Pass one or more
 fragment files (or a directory containing them) to assemble a config from
 multiple pieces. Override the selection by setting the `BASE_CONFIG`

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,7 +7,7 @@ dataset_name: "cifar100"
 small_input: true
 data_root: "./data"
 batch_size: 128
-use_amp: false
+use_amp: true
 amp_dtype: float16
 grad_scaler_init_scale: 1024
 

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -116,7 +116,7 @@ class ASMBDistiller(nn.Module):
         teacher_lr=1e-4,
         student_lr=5e-4,
         weight_decay=1e-4,
-        epochs_per_stage=5,
+        epochs_per_stage=10,
         logger=None
     ):
         """


### PR DESCRIPTION
## Summary
- enable AMP in the default config
- run ASMB epochs_per_stage for 10 epochs by default
- document AMP default in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b624a9da08321b4ba18382483f1d6