### PR TITLE
Automatically set mbm_out_dim from student

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   student features used as the attention query in `LightweightAttnMBM`.
   When omitted or set to `0`, the script automatically falls back to the
   feature dimension reported by the student model (if available).
+  The MBM output dimension (`mbm_out_dim`) now defaults to this student
+  feature size as well.
   Common student feature dimensions are:
 
   | Student model                | Feature dim |
@@ -203,7 +205,7 @@ Baseline runs (e.g., `vanilla_kd`) produce their own logs such as `VanillaKD => 
 python main.py --config configs/partial_freeze.yaml --device cuda \
   --teacher1_ckpt teacher1.pth --teacher2_ckpt teacher2.pth \
   --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 1
-  # mbm_query_dim is automatically set to the student feature dimension
+  # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
         •       Adjust partial-freeze or architecture settings in `configs/*.yaml`.
         •       Edit `configs/hparams.yaml` to change numeric hyperparameters like learning rates or dropout.
         •       Set `LR_SCHEDULE` to "step" or "cosine" to choose the learning rate scheduler.
@@ -254,7 +256,7 @@ python eval.py --eval_mode synergy \
   --mbm_ckpt mbm.pth \
   --head_ckpt synergy_head.pth \
   --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 1
-  # mbm_query_dim is automatically set to the student feature dimension
+  # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
 
 	•	Prints Train/Test accuracy, optionally logs to CSV if configured.
 

--- a/main.py
+++ b/main.py
@@ -419,6 +419,13 @@ def main():
             use_adapter=cfg.get("student_use_adapter", False)
         )
 
+    # Obtain and store student feature dimension
+    if hasattr(student_model, "get_feat_dim"):
+        feat_dim = student_model.get_feat_dim()
+        cfg["mbm_out_dim"] = feat_dim
+        logger.update_metric("mbm_out_dim", feat_dim)
+        print(f"[Info] mbm_out_dim set to student feature dimension {feat_dim}")
+
     # Validate or infer MBM query dimension
     mbm_query_dim = cfg.get("mbm_query_dim", 0)
     if cfg.get("mbm_type", "MLP") == "LA" and mbm_query_dim <= 0:


### PR DESCRIPTION
## Summary
- automatically detect the student's feature dimension and use it for `mbm_out_dim`
- log the detected dimension
- document that `mbm_out_dim` now defaults to the student's feature dimension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6b015cf48321b4c5308d9d2daf8d