### PR TITLE
Auto MBM out dim from student model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   | `student_efficientnet_adapter` | 1408        |
   | `student_resnet_adapter`       | 2048        |
   | `student_swin_adapter`         | 768         |
+- **Auto MBM Output Dim**: `mbm_out_dim` defaults to the student feature
+  dimension when not provided. This ensures Feature‑level KD works without
+  manual tuning.
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs

--- a/main.py
+++ b/main.py
@@ -419,6 +419,26 @@ def main():
             use_adapter=cfg.get("student_use_adapter", False)
         )
 
+    # Validate or infer MBM output dimension
+    mbm_out_dim = cfg.get("mbm_out_dim", 0)
+    if mbm_out_dim <= 0:
+        if hasattr(student_model, "get_feat_dim"):
+            mbm_out_dim = student_model.get_feat_dim()
+            cfg["mbm_out_dim"] = mbm_out_dim
+            print(
+                f"[Info] mbm_out_dim not specified; using student feature dimension {mbm_out_dim}"
+            )
+        else:
+            print(
+                "[Warning] Student model does not expose get_feat_dim(); please set mbm_out_dim manually"
+            )
+    elif hasattr(student_model, "get_feat_dim"):
+        s_dim = student_model.get_feat_dim()
+        if mbm_out_dim != s_dim:
+            raise ValueError(
+                f"mbm_out_dim ({mbm_out_dim}) does not match the student feature dimension ({s_dim})."
+            )
+
     # Validate or infer MBM query dimension
     mbm_query_dim = cfg.get("mbm_query_dim", 0)
     if cfg.get("mbm_type", "MLP") == "LA" and mbm_query_dim <= 0:


### PR DESCRIPTION
## Summary
- infer MBM output dimension from the student model if not provided
- document automatic MBM out dim in the feature list

## Testing
- `pytest -q` *(fails: 17 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685b6a5439f0832180f06f69d51a5936