### PR TITLE
Simplify trainer optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
         •       Edit `configs/hparams.yaml` to change numeric hyperparameters like learning rates or dropout.
         •       Set `LR_SCHEDULE` to "step" or "cosine" to choose the learning rate scheduler.
 	•	Optionally load pre-finetuned teacher checkpoints via `--teacher1_ckpt` and `--teacher2_ckpt`.
-        •       Optimizers and schedulers are instantiated once before stages and reset before each stage.
+        •       Each trainer creates its own optimizer and scheduler at the start of every stage.
 
 2) Single-Teacher Distillation (run_single_teacher.py)
 

--- a/tests/test_feature_kd_in_distill.py
+++ b/tests/test_feature_kd_in_distill.py
@@ -83,9 +83,8 @@ def test_feature_kd_term_in_student_distill():
     }
 
     logger = DummyLogger()
-    opt = torch.optim.SGD(student.parameters(), lr=0.1)
 
-    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger, opt)
+    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger)
 
     ep_loss = logger.metrics["student_ep1_loss"]
 

--- a/tests/test_student_distill_eval_mode.py
+++ b/tests/test_student_distill_eval_mode.py
@@ -64,12 +64,11 @@ def test_teachers_are_eval_during_distill():
     cfg = {"device": "cpu", "ce_alpha": 1.0, "kd_alpha": 1.0, "student_iters": 1}
 
     logger = DummyLogger()
-    opt = torch.optim.SGD(student.parameters(), lr=0.1)
 
     t1.train()
     t2.train()
 
-    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger, opt)
+    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger)
 
     assert t1.record_training is False
     assert t2.record_training is False

--- a/tests/test_teacher_adaptive_update.py
+++ b/tests/test_teacher_adaptive_update.py
@@ -87,12 +87,6 @@ def test_teacher_adaptive_update_preserves_freeze():
 
     cfg = {"device": "cpu", "synergy_ce_alpha": 0.1, "teacher_iters": 1}
 
-    params = []
-    for m in [t1, t2, mbm, head]:
-        for p in m.parameters():
-            if p.requires_grad:
-                params.append(p)
-    opt = torch.optim.SGD(params, lr=0.1)
     logger = DummyLogger()
 
     frozen_before = [p.requires_grad for p in t1.frozen.parameters()]
@@ -106,8 +100,6 @@ def test_teacher_adaptive_update_preserves_freeze():
         testloader=None,
         cfg=cfg,
         logger=logger,
-        optimizer=opt,
-        scheduler=None,
         global_ep=0,
     )
 
@@ -126,12 +118,6 @@ def test_teacher_adaptive_update_trains_modules():
 
     cfg = {"device": "cpu", "synergy_ce_alpha": 0.1, "teacher_iters": 1}
 
-    params = []
-    for m in [t1, t2, mbm, head]:
-        for p in m.parameters():
-            if p.requires_grad:
-                params.append(p)
-    opt = torch.optim.SGD(params, lr=0.1)
     logger = DummyLogger()
 
     # start all modules in eval mode
@@ -147,8 +133,6 @@ def test_teacher_adaptive_update_trains_modules():
         testloader=None,
         cfg=cfg,
         logger=logger,
-        optimizer=opt,
-        scheduler=None,
         global_ep=0,
     )
 


### PR DESCRIPTION
## Summary
- move optimizer/scheduler creation inside trainer functions
- update main to let trainers handle their own optimizers
- adjust tests for new trainer signatures
- clarify README about per-stage optimizer creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6d1424008321b1d0f855602e51af