### PR TITLE
Unify optimizer handling for training loops

### DIFF
--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -1,12 +1,9 @@
 # modules/trainer_student.py
 
 import torch
-import torch.nn as nn
 import copy
 from utils.progress import smart_tqdm
 from models.la_mbm import LightweightAttnMBM
-import torch.optim as optim
-from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR
 
 from modules.losses import kd_loss_fn, ce_loss_fn
 from modules.disagreement import sample_weights_from_disagreement
@@ -21,6 +18,8 @@ def student_distillation_update(
     testloader,
     cfg,
     logger,
+    optimizer,
+    scheduler,
     global_ep: int = 0
 ):
     """
@@ -49,23 +48,7 @@ def student_distillation_update(
         syn_reqgrad_states.append(p.requires_grad)
         p.requires_grad = False
 
-    optimizer = optim.AdamW(
-        student_model.parameters(),
-        lr=cfg["student_lr"],
-        weight_decay=cfg["student_weight_decay"],
-        betas=(0.9, 0.999),
-        eps=1e-8,
-    )
-
     student_epochs = cfg.get("student_iters", cfg.get("student_epochs_per_stage", 15))
-    if cfg.get("lr_schedule", "step") == "cosine":
-        scheduler = CosineAnnealingLR(optimizer, T_max=student_epochs)
-    else:
-        scheduler = StepLR(
-            optimizer,
-            step_size=cfg.get("student_step_size", 10),
-            gamma=cfg.get("student_gamma", 0.1),
-        )
 
     best_acc = 0.0
     best_state = copy.deepcopy(student_model.state_dict())

--- a/tests/test_feature_kd_in_distill.py
+++ b/tests/test_feature_kd_in_distill.py
@@ -84,7 +84,21 @@ def test_feature_kd_term_in_student_distill():
 
     logger = DummyLogger()
 
-    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger)
+    opt = torch.optim.SGD(student.parameters(), lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+
+    student_distillation_update(
+        [t1, t2],
+        mbm,
+        head,
+        student,
+        loader,
+        loader,
+        cfg,
+        logger,
+        optimizer=opt,
+        scheduler=sched,
+    )
 
     ep_loss = logger.metrics["student_ep1_loss"]
 

--- a/tests/test_student_distill_eval_mode.py
+++ b/tests/test_student_distill_eval_mode.py
@@ -68,7 +68,21 @@ def test_teachers_are_eval_during_distill():
     t1.train()
     t2.train()
 
-    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger)
+    opt = torch.optim.SGD(student.parameters(), lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+
+    student_distillation_update(
+        [t1, t2],
+        mbm,
+        head,
+        student,
+        loader,
+        loader,
+        cfg,
+        logger,
+        optimizer=opt,
+        scheduler=sched,
+    )
 
     assert t1.record_training is False
     assert t2.record_training is False

--- a/tests/test_teacher_adaptive_update.py
+++ b/tests/test_teacher_adaptive_update.py
@@ -91,6 +91,13 @@ def test_teacher_adaptive_update_preserves_freeze():
 
     frozen_before = [p.requires_grad for p in t1.frozen.parameters()]
 
+    params = [p for p in t1.parameters() if p.requires_grad]
+    params += [p for p in t2.parameters() if p.requires_grad]
+    params += [p for p in mbm.parameters() if p.requires_grad]
+    params += [p for p in head.parameters() if p.requires_grad]
+    opt = torch.optim.SGD(params, lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+
     teacher_adaptive_update(
         teacher_wrappers=[t1, t2],
         mbm=mbm,
@@ -100,6 +107,8 @@ def test_teacher_adaptive_update_preserves_freeze():
         testloader=None,
         cfg=cfg,
         logger=logger,
+        optimizer=opt,
+        scheduler=sched,
         global_ep=0,
     )
 
@@ -124,6 +133,13 @@ def test_teacher_adaptive_update_trains_modules():
     for m in [t1, t2, mbm, head, student]:
         m.eval()
 
+    params = [p for p in t1.parameters() if p.requires_grad]
+    params += [p for p in t2.parameters() if p.requires_grad]
+    params += [p for p in mbm.parameters() if p.requires_grad]
+    params += [p for p in head.parameters() if p.requires_grad]
+    opt = torch.optim.SGD(params, lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+
     teacher_adaptive_update(
         teacher_wrappers=[t1, t2],
         mbm=mbm,
@@ -133,6 +149,8 @@ def test_teacher_adaptive_update_trains_modules():
         testloader=None,
         cfg=cfg,
         logger=logger,
+        optimizer=opt,
+        scheduler=sched,
         global_ep=0,
     )
 


### PR DESCRIPTION
## Summary
- remove optimizer creation from `trainer_teacher` and `trainer_student`
- build global optimizers and schedulers in `main.py`
- pass optimizers and schedulers into training routines
- update tests to supply these new arguments

## Testing
- `pytest -q` *(fails: 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685b7ee89b1483219876ce1adc2c76cc