### PR TITLE
Fix MBM latent alignment shape mismatch

### DIFF
--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -106,4 +106,4 @@ class LightweightAttnMBM(nn.Module):
         out = self.out_proj(attn_out.squeeze(1))
         if isinstance(query_or_feats, list):
             return out
-        return out, attn, q, attn_out.squeeze(1)
+        return out, attn, q.squeeze(1), attn_out.squeeze(1)


### PR DESCRIPTION
## Summary
- squeeze attention query before returning in `LightweightAttnMBM`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba2a1bc208321b48a8aaa95c43592