### PR TITLE
Add numeric freeze_level for teachers

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -54,6 +54,10 @@ reg_lambda: 1e-5      # teacher L2 regularisation
 mbm_dropout: 0.0      # dropout prob inside MBM
 head_dropout: 0.0     # dropout prob for synergy head
 use_partial_freeze: true
+# freeze_level guide: 0=head only, 1=last block+head, 2=two blocks+head
+student_freeze_level: 2  # 0: head only, 1: last block + head, 2: last 2 blocks + head
+student_use_adapter: true
+student_freeze_bn: false
 teacher1_use_adapter: 0
 teacher1_bn_head_only: 0
 teacher2_use_adapter: 0

--- a/configs/partial_freeze.yaml
+++ b/configs/partial_freeze.yaml
@@ -1,13 +1,14 @@
 # configs/partial_freeze.yaml
 
 # use_partial_freeze defined in hparams.yaml
+# freeze_level guide: 0=head only, 1=last block+head, 2=two blocks+head
 
 teacher1_freeze_bn: false
-teacher1_freeze_scope: "layer4_fc"
+teacher1_freeze_level: 2  # 0: head only, 1: last block + head, 2: last 2 blocks + head
 
 teacher2_freeze_bn: true
-teacher2_freeze_scope: "features_classifier" # classifier_only
+teacher2_freeze_level: 2  # 0: head only, 1: last block + head, 2: last 2 blocks + head
 
 student_freeze_bn: false
-student_freeze_scope: "layer4_fc" # layer3_layer4_fc
+student_freeze_level: 2  # 0: head only, 1: last block + head, 2: last 2 blocks + head
 student_use_adapter: true

--- a/main.py
+++ b/main.py
@@ -184,7 +184,7 @@ def partial_freeze_teacher_auto(
     freeze_ln=True,
     use_adapter=False,
     bn_head_only=False,
-    freeze_scope=None,
+    freeze_level=1,
 ):
     if teacher_name == "resnet101":
         partial_freeze_teacher_resnet(
@@ -192,7 +192,7 @@ def partial_freeze_teacher_auto(
             freeze_bn=freeze_bn,
             use_adapter=use_adapter,
             bn_head_only=bn_head_only,
-            freeze_scope=freeze_scope,
+            freeze_level=freeze_level,
         )
     elif teacher_name == "efficientnet_b2":
         partial_freeze_teacher_efficientnet(
@@ -200,34 +200,53 @@ def partial_freeze_teacher_auto(
             freeze_bn=freeze_bn,
             use_adapter=use_adapter,
             bn_head_only=bn_head_only,
-            freeze_scope=freeze_scope,
+            freeze_level=freeze_level,
         )
     elif teacher_name == "swin_tiny":
         partial_freeze_teacher_swin(
             model,
             freeze_ln=freeze_ln,
             use_adapter=use_adapter,
-            freeze_scope=freeze_scope,
+            freeze_level=freeze_level,
         )
     else:
         raise ValueError(f"[partial_freeze_teacher_auto] Unknown teacher_name={teacher_name}")
 
 def partial_freeze_student_auto(
     model,
-    student_name="resnet_adapter", 
-    freeze_bn=True, 
+    student_name="resnet_adapter",
+    freeze_bn=True,
     freeze_ln=True,
     use_adapter=False,
-    freeze_scope=None
+    freeze_level=1,
 ):
     if student_name == "resnet_adapter":
-        partial_freeze_student_resnet(model, freeze_bn=freeze_bn, use_adapter=use_adapter, freeze_scope=freeze_scope)
+        partial_freeze_student_resnet(
+            model,
+            freeze_bn=freeze_bn,
+            use_adapter=use_adapter,
+            freeze_level=freeze_level,
+        )
     elif student_name == "efficientnet_adapter":
-        partial_freeze_student_efficientnet(model, freeze_bn=freeze_bn, use_adapter=use_adapter, freeze_scope=freeze_scope)
+        partial_freeze_student_efficientnet(
+            model,
+            freeze_bn=freeze_bn,
+            use_adapter=use_adapter,
+            freeze_level=freeze_level,
+        )
     elif student_name == "swin_adapter":
-        partial_freeze_student_swin(model, freeze_ln=freeze_ln, use_adapter=use_adapter, freeze_scope=freeze_scope)
+        partial_freeze_student_swin(
+            model,
+            freeze_ln=freeze_ln,
+            use_adapter=use_adapter,
+            freeze_level=freeze_level,
+        )
     else:
-        partial_freeze_student_resnet(model, freeze_bn=freeze_bn, freeze_scope=freeze_scope)
+        partial_freeze_student_resnet(
+            model,
+            freeze_bn=freeze_bn,
+            freeze_level=freeze_level,
+        )
 
 def main():
     # 1) parse args
@@ -307,7 +326,7 @@ def main():
             freeze_ln=cfg.get("teacher1_freeze_ln", True),
             use_adapter=cfg.get("teacher1_use_adapter", False),
             bn_head_only=cfg.get("teacher1_bn_head_only", False),
-            freeze_scope=cfg.get("teacher1_freeze_scope", None)
+            freeze_level=cfg.get("teacher1_freeze_level", 1)
         )
 
     teacher2 = create_teacher_by_name(
@@ -330,7 +349,7 @@ def main():
             freeze_ln=cfg.get("teacher2_freeze_ln", True),
             use_adapter=cfg.get("teacher2_use_adapter", False),
             bn_head_only=cfg.get("teacher2_bn_head_only", False),
-            freeze_scope=cfg.get("teacher2_freeze_scope", None)
+            freeze_level=cfg.get("teacher2_freeze_level", 1)
         )
 
     # optional fine-tuning of teachers before ASMB stages
@@ -415,8 +434,8 @@ def main():
             student_name=student_name,
             freeze_bn=cfg.get("student_freeze_bn", True),
             freeze_ln=cfg.get("student_freeze_ln", True),
-            freeze_scope=cfg.get("student_freeze_scope", None),
-            use_adapter=cfg.get("student_use_adapter", False)
+            use_adapter=cfg.get("student_use_adapter", False),
+            freeze_level=cfg.get("student_freeze_level", 1),
         )
 
     # Obtain and store student feature dimension

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -117,6 +117,7 @@ def partial_freeze_teacher_auto(
     freeze_ln=True,
     use_adapter=False,
     bn_head_only=False,
+    freeze_level=1,
 ):
     """
     If needed, partial freeze for fine-tune. Or you can freeze nothing if you want full fine-tune.
@@ -127,7 +128,7 @@ def partial_freeze_teacher_auto(
             freeze_bn=freeze_bn,
             use_adapter=use_adapter,
             bn_head_only=bn_head_only,
-            freeze_scope=None,
+            freeze_level=freeze_level,
         )
     elif teacher_type == "efficientnet_b2":
         partial_freeze_teacher_efficientnet(
@@ -135,14 +136,14 @@ def partial_freeze_teacher_auto(
             freeze_bn=freeze_bn,
             use_adapter=use_adapter,
             bn_head_only=bn_head_only,
-            freeze_scope=None,
+            freeze_level=freeze_level,
         )
     elif teacher_type == "swin_tiny":
         partial_freeze_teacher_swin(
             model,
             freeze_ln=freeze_ln,
             use_adapter=use_adapter,
-            freeze_scope=None,
+            freeze_level=freeze_level,
         )
     else:
         raise ValueError(f"Unknown teacher_type={teacher_type}")
@@ -257,6 +258,7 @@ def main():
             freeze_ln=freeze_ln,
             use_adapter=cfg.get("teacher_use_adapter", False),
             bn_head_only=cfg.get("teacher_bn_head_only", False),
+            freeze_level=cfg.get("teacher_freeze_level", 1),
         )
         print("[FineTune] partial freeze mode => only head is trainable (example).")
     else:

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -127,7 +127,15 @@ def main():
     if cfg.get("teacher_ckpt"):
         teacher.load_state_dict(torch.load(cfg["teacher_ckpt"], map_location=device, weights_only=True))
     if cfg.get("use_partial_freeze", True):
-        partial_freeze_teacher_auto(teacher, cfg.get("teacher_type", "resnet101"))
+        partial_freeze_teacher_auto(
+            teacher,
+            cfg.get("teacher_type", "resnet101"),
+            freeze_bn=cfg.get("teacher_freeze_bn", True),
+            freeze_ln=cfg.get("teacher_freeze_ln", True),
+            use_adapter=cfg.get("teacher_use_adapter", False),
+            bn_head_only=cfg.get("teacher_bn_head_only", False),
+            freeze_level=cfg.get("teacher_freeze_level", 1),
+        )
 
     student = create_student_by_name(
         cfg.get("student_type", "resnet_adapter"),
@@ -138,7 +146,14 @@ def main():
     if cfg.get("student_ckpt"):
         student.load_state_dict(torch.load(cfg["student_ckpt"], map_location=device, weights_only=True))
     if cfg.get("use_partial_freeze", True):
-        partial_freeze_student_auto(student, student_name=cfg.get("student_type", "resnet_adapter"))
+        partial_freeze_student_auto(
+            student,
+            student_name=cfg.get("student_type", "resnet_adapter"),
+            freeze_bn=cfg.get("student_freeze_bn", True),
+            freeze_ln=cfg.get("student_freeze_ln", True),
+            use_adapter=cfg.get("student_use_adapter", False),
+            freeze_level=cfg.get("student_freeze_level", 1),
+        )
 
     distiller = build_distiller(method, teacher, student, cfg)
     acc = distiller.train_distillation(

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -144,7 +144,14 @@ def main():
             torch.load(cfg["student_ckpt"], map_location=device, weights_only=True)
         )
 
-    partial_freeze_student_auto(student, student_name=cfg.get("student_type", "resnet_adapter"))
+    partial_freeze_student_auto(
+        student,
+        student_name=cfg.get("student_type", "resnet_adapter"),
+        freeze_bn=cfg.get("student_freeze_bn", True),
+        freeze_ln=cfg.get("student_freeze_ln", True),
+        use_adapter=cfg.get("student_use_adapter", False),
+        freeze_level=cfg.get("student_freeze_level", 1),
+    )
 
     os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
     ckpt = os.path.join(cfg["results_dir"], "student_baseline.pth")

--- a/tests/test_partial_freeze_students.py
+++ b/tests/test_partial_freeze_students.py
@@ -22,7 +22,7 @@ def _req_dict(model):
 
 def test_swin_student_unfreeze_default():
     m = DummyStudentSwin()
-    partial_freeze_student_swin(m)
+    partial_freeze_student_swin(m, freeze_level=1)
     req = _req_dict(m)
     assert req["swin.layers.3.weight"]
     assert req["fc.weight"]

--- a/tests/test_partial_freeze_teachers.py
+++ b/tests/test_partial_freeze_teachers.py
@@ -42,7 +42,7 @@ def _req_dict(model):
 
 def test_resnet_layer4_fc():
     m = DummyResNetTeacher()
-    partial_freeze_teacher_resnet(m, freeze_scope="layer4_fc")
+    partial_freeze_teacher_resnet(m, freeze_level=2)
     req = _req_dict(m)
     assert req["backbone.layer4.weight"]
     assert req["backbone.fc.weight"]
@@ -52,7 +52,7 @@ def test_resnet_layer4_fc():
 
 def test_efficientnet_features_classifier():
     m = DummyEfficientNetTeacher()
-    partial_freeze_teacher_efficientnet(m, freeze_scope="features_classifier")
+    partial_freeze_teacher_efficientnet(m, freeze_level=2)
     req = _req_dict(m)
     assert req["backbone.features.weight"]
     assert req["backbone.classifier.weight"]
@@ -61,7 +61,7 @@ def test_efficientnet_features_classifier():
 
 def test_swin_head_only():
     m = DummySwinTeacher()
-    partial_freeze_teacher_swin(m, freeze_scope="head_only")
+    partial_freeze_teacher_swin(m, freeze_level=0)
     req = _req_dict(m)
     assert req["backbone.head.weight"]
     assert not req["backbone.features.weight"]
@@ -69,7 +69,7 @@ def test_swin_head_only():
 
 def test_adapter_pattern():
     m = DummyResNetTeacher()
-    partial_freeze_teacher_resnet(m, freeze_scope="fc_only", use_adapter=True)
+    partial_freeze_teacher_resnet(m, freeze_level=0, use_adapter=True)
     req = _req_dict(m)
     assert req["backbone.fc.weight"]
     assert req["backbone.layer4.adapter_conv.weight"]


### PR DESCRIPTION
## Summary
- support freeze_level parameter for teacher partial-freezing
- map numeric levels to appropriate layer scopes per model
- update main training and helper scripts with new option
- adjust partial_freeze config and unit tests
- document freeze level meanings in configuration files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba829b8b0832184b4588ce463d7cf