### PR TITLE
Add CLI option for freezing student layers

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,6 +141,7 @@ def parse_args():
     parser.add_argument("--use_amp", type=int)
     parser.add_argument("--amp_dtype", type=str)
     parser.add_argument("--grad_scaler_init_scale", type=int)
+    parser.add_argument("--student_freeze_level", type=int)
 
     # MBM options
     parser.add_argument("--mbm_type", type=str)

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -134,6 +134,7 @@ run_loop() {
             --teacher1_bn_head_only ${teacher1_bn_head_only} \
             --teacher2_use_adapter ${teacher2_use_adapter} \
             --teacher2_bn_head_only ${teacher2_bn_head_only} \
+            --student_freeze_level 2 \
             --results_dir "${OUTDIR}" \
             --seed 42 \
             --data_aug ${data_aug} \
@@ -191,6 +192,7 @@ run_sweep() {
         --teacher1_bn_head_only ${teacher1_bn_head_only} \
         --teacher2_use_adapter ${teacher2_use_adapter} \
         --teacher2_bn_head_only ${teacher2_bn_head_only} \
+        --student_freeze_level 2 \
         --label_smoothing ${label_smoothing} \
         --method ${METHOD}
     done

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -52,6 +52,7 @@ def parse_args():
     p.add_argument("--cutmix_alpha_distill", type=float)
     p.add_argument("--label_smoothing", type=float)
     p.add_argument("--small_input", type=int)
+    p.add_argument("--student_freeze_level", type=int)
     return p.parse_args()
 
 

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -33,6 +33,7 @@ def parse_args():
     p.add_argument("--data_aug", type=int)
     p.add_argument("--label_smoothing", type=float)
     p.add_argument("--small_input", type=int)
+    p.add_argument("--student_freeze_level", type=int)
     return p.parse_args()
 
 


### PR DESCRIPTION
## Summary
- expose `--student_freeze_level` CLI argument in all training scripts
- pass freeze level when launching experiments

## Testing
- `pytest -q`
- `python scripts/generate_config.py --base configs/partial_freeze.yaml --out cfg_tmp.yaml student_freeze_level=1` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685bcdda706483219b8db03be4c25f16