### PR TITLE
Expose configurable student freeze level

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -58,6 +58,7 @@ teacher1_use_adapter: 0
 teacher1_bn_head_only: 0
 teacher2_use_adapter: 0
 teacher2_bn_head_only: 0
+student_freeze_level: 2
 mixup_alpha: 0.0
 label_smoothing: 0.0
 

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -134,7 +134,7 @@ run_loop() {
             --teacher1_bn_head_only ${teacher1_bn_head_only} \
             --teacher2_use_adapter ${teacher2_use_adapter} \
             --teacher2_bn_head_only ${teacher2_bn_head_only} \
-            --student_freeze_level 2 \
+            --student_freeze_level ${student_freeze_level} \
             --results_dir "${OUTDIR}" \
             --seed 42 \
             --data_aug ${data_aug} \
@@ -192,7 +192,7 @@ run_sweep() {
         --teacher1_bn_head_only ${teacher1_bn_head_only} \
         --teacher2_use_adapter ${teacher2_use_adapter} \
         --teacher2_bn_head_only ${teacher2_bn_head_only} \
-        --student_freeze_level 2 \
+        --student_freeze_level ${student_freeze_level} \
         --label_smoothing ${label_smoothing} \
         --method ${METHOD}
     done


### PR DESCRIPTION
## Summary
- add `student_freeze_level` to `configs/hparams.yaml`
- parameterize `--student_freeze_level` option in `run_experiments.sh`

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685be8be0b088321bbf7a3942d4fc419