### PR TITLE
Fix baseline KD optimizers and scheduler

### DIFF
--- a/methods/at.py
+++ b/methods/at.py
@@ -80,16 +80,34 @@ class ATDistiller(nn.Module):
         lr=1e-3,
         weight_decay=1e-4,
         epochs=10,
-        device="cuda"
+        device="cuda",
+        cfg=None,
     ):
         self.to(device)
-        # student만 업데이트
-        optimizer = optim.SGD(
+
+        if cfg is not None:
+            lr = cfg.get("student_lr", lr)
+            weight_decay = cfg.get("student_weight_decay", weight_decay)
+            lr_schedule = cfg.get("lr_schedule", "cosine")
+            step_size = cfg.get("student_step_size", 10)
+            gamma = cfg.get("student_gamma", 0.1)
+        else:
+            lr_schedule = "cosine"
+            step_size = 10
+            gamma = 0.1
+
+        optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
-            momentum=0.9,
-            weight_decay=weight_decay
+            weight_decay=weight_decay,
+            betas=(0.9, 0.999),
+            eps=1e-8,
         )
+
+        if lr_schedule == "cosine":
+            scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+        else:
+            scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
 
         best_acc = 0.0
         best_state = None
@@ -106,10 +124,13 @@ class ATDistiller(nn.Module):
                 loss.backward()
                 optimizer.step()
 
+            
                 total_loss += loss.item()*x.size(0)
                 total_num  += x.size(0)
 
             avg_loss = total_loss / total_num
+
+            scheduler.step()
 
             # evaluate
             if test_loader is not None:
@@ -132,7 +153,7 @@ class ATDistiller(nn.Module):
         correct, total = 0, 0
         for x, y in loader:
             x, y = x.to(device), y.to(device)
-            _, s_logit = self.student(x)
+            _, s_logit, _ = self.student(x)
             pred = s_logit.argmax(dim=1)
             correct += (pred==y).sum().item()
             total   += y.size(0)

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -82,15 +82,34 @@ class CRDDistiller(nn.Module):
         lr=1e-3,
         weight_decay=1e-4,
         epochs=10,
-        device="cuda"
+        device="cuda",
+        cfg=None,
     ):
         self.to(device)
-        optimizer = optim.SGD(
+
+        if cfg is not None:
+            lr = cfg.get("student_lr", lr)
+            weight_decay = cfg.get("student_weight_decay", weight_decay)
+            lr_schedule = cfg.get("lr_schedule", "cosine")
+            step_size = cfg.get("student_step_size", 10)
+            gamma = cfg.get("student_gamma", 0.1)
+        else:
+            lr_schedule = "cosine"
+            step_size = 10
+            gamma = 0.1
+
+        optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
-            momentum=0.9,
-            weight_decay=weight_decay
+            weight_decay=weight_decay,
+            betas=(0.9, 0.999),
+            eps=1e-8,
         )
+
+        if lr_schedule == "cosine":
+            scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+        else:
+            scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
 
         best_acc = 0.0
         best_state = None
@@ -107,10 +126,13 @@ class CRDDistiller(nn.Module):
                 loss.backward()
                 optimizer.step()
 
+            
                 total_loss += loss.item() * x.size(0)
                 total_num  += x.size(0)
 
             avg_loss = total_loss / total_num
+
+            scheduler.step()
 
             # optional: evaluate
             if test_loader is not None:

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -63,7 +63,8 @@ class VanillaKDDistiller(nn.Module):
         lr=1e-3,
         weight_decay=1e-4,
         epochs=10,
-        device="cuda"
+        device="cuda",
+        cfg=None,
     ):
         """
         Basic KD training loop:
@@ -71,12 +72,30 @@ class VanillaKDDistiller(nn.Module):
           - Evaluate optionally each epoch
         """
         self.to(device)
-        optimizer = optim.SGD(
+
+        if cfg is not None:
+            lr = cfg.get("student_lr", lr)
+            weight_decay = cfg.get("student_weight_decay", weight_decay)
+            lr_schedule = cfg.get("lr_schedule", "cosine")
+            step_size = cfg.get("student_step_size", 10)
+            gamma = cfg.get("student_gamma", 0.1)
+        else:
+            lr_schedule = "cosine"
+            step_size = 10
+            gamma = 0.1
+
+        optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
-            momentum=0.9,
-            weight_decay=weight_decay
+            weight_decay=weight_decay,
+            betas=(0.9, 0.999),
+            eps=1e-8,
         )
+
+        if lr_schedule == "cosine":
+            scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+        else:
+            scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
 
         best_acc = 0.0
         best_state = None
@@ -95,10 +114,13 @@ class VanillaKDDistiller(nn.Module):
                 loss.backward()
                 optimizer.step()
 
+
                 total_loss += loss.item() * x.size(0)
                 total_num  += x.size(0)
 
             avg_loss = total_loss / total_num
+
+            scheduler.step()
 
             if test_loader is not None:
                 acc = self.evaluate(test_loader, device)

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -165,6 +165,7 @@ def main():
         weight_decay=cfg.get("weight_decay", cfg.get("student_weight_decay", 1e-4)),
         epochs=cfg.get("epochs", 10),
         device=device,
+        cfg=cfg,
     )
 
     os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)


### PR DESCRIPTION
## Summary
- update baseline distillers to use AdamW with configurable LR schedulers
- pass hparams to train_distillation in run_single_teacher
- fix AT evaluator to unpack student outputs correctly

## Testing
- `pytest -q`
- `python -m py_compile methods/at.py methods/crd.py methods/dkd.py methods/fitnet.py methods/vanilla_kd.py scripts/run_single_teacher.py`


------
https://chatgpt.com/codex/tasks/task_e_685c283c398c8321ae0a495e3345d5b4