### PR TITLE
Introduce timestamp-based experiment IDs

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,6 +108,7 @@ def parse_args():
     parser.add_argument("--student_epochs_per_stage", type=int)
     parser.add_argument("--epochs",     type=int)            # 예: teacher_iters
     parser.add_argument("--results_dir", type=str)
+    parser.add_argument("--exp_id", type=str, default=None, help="Unique experiment ID")
     parser.add_argument("--seed", type=int, default=42)
 
     # optional fine-tune params

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -110,7 +110,10 @@ run_loop() {
         # N_STAGE_LIST may contain space-separated values like "2 3 4 5"
         # Iterate over each item without quoting to allow word splitting.
         for STAGE in $n_stage_list; do
-          OUTDIR="${RESULT_ROOT}/${T2}_${STUDENT}_a${SC_ALPHA}_s${STAGE}"
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          EXP_ID="${METHOD}_${T2}_vs_${T1}_${STUDENT}_s${STAGE}_a${SC_ALPHA}_${TIMESTAMP}"
+
+          OUTDIR="${RESULT_ROOT}/${EXP_ID}"
           mkdir -p "${OUTDIR}"
 
           CFG_TMP=$(generate_config)
@@ -137,6 +140,7 @@ run_loop() {
             --teacher2_bn_head_only ${teacher2_bn_head_only} \
             --student_freeze_level ${student_freeze_level} \
             --results_dir "${OUTDIR}" \
+            --exp_id "${EXP_ID}" \
             --seed 42 \
             --data_aug ${data_aug} \
             --mixup_alpha ${mixup_alpha} \

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -61,8 +61,8 @@ class ExperimentLogger:
 
         self.exp_name = exp_name
 
-        # Generate exp_id (e.g. "eval_experiment_single_20240805_153210")
-        self.exp_id = self._generate_exp_id()
+        # Generate exp_id using provided value or timestamp
+        self.exp_id = self.config.get("exp_id") or self._generate_exp_id(exp_name)
         self.config["exp_id"] = self.exp_id
 
         # Where to save results
@@ -72,14 +72,14 @@ class ExperimentLogger:
         # For timing
         self.start_time = time.time()
 
-    def _generate_exp_id(self):
+    def _generate_exp_id(self, exp_name="exp"):
         """
         Creates an experiment ID like 'eval_experiment_synergy_20240805_153210'
         using exp_name, eval_mode, and timestamp
         """
         eval_mode = self.config.get("eval_mode", "noeval")
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        return f"{self.exp_name}_{eval_mode}_{ts}"
+        return f"{exp_name}_{eval_mode}_{ts}"
 
     def update_metric(self, key, value):
         """


### PR DESCRIPTION
## Summary
- generate unique experiment IDs in `run_experiments.sh`
- pass the new `--exp_id` argument to `main.py`
- expose `--exp_id` CLI option in `main.py`
- allow `ExperimentLogger` to honor external IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c327d602883219f1f08c0dc5fd21c