### PR TITLE
Add LA MBM student distill test

### DIFF
--- a/tests/test_feature_kd_in_distill.py
+++ b/tests/test_feature_kd_in_distill.py
@@ -2,6 +2,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+from models.la_mbm import LightweightAttnMBM
 from modules.trainer_student import student_distillation_update
 from modules.losses import ce_loss_fn, kd_loss_fn
 
@@ -108,4 +109,71 @@ def test_feature_kd_term_in_student_distill():
     mse = torch.nn.functional.mse_loss(student.feat, fsyn)
     expected = cfg["ce_alpha"] * ce + cfg["kd_alpha"] * kd + cfg["feat_kd_alpha"] * mse
 
+    assert ep_loss == pytest.approx(expected.item())
+
+
+@pytest.mark.parametrize("use_la", [False, True])
+def test_student_distill_loss_components(use_la):
+    t1 = ConstTeacher([[1.0, 2.0]], [[0.5, 0.5]])
+    t2 = ConstTeacher([[3.0, 0.0]], [[0.1, 0.9]])
+    student = ConstStudent([[0.0, 0.0]], [[0.0, 1.0]])
+
+    if use_la:
+        mbm = LightweightAttnMBM(
+            [2, 2], out_dim=2, r=1, n_head=1, learnable_q=False, query_dim=2
+        )
+    else:
+        mbm = AvgMBM()
+
+    head = ConstHead([[0.5, -0.5]])
+
+    loader = [(torch.zeros(1, 3), torch.tensor([1]))]
+
+    cfg = {
+        "device": "cpu",
+        "ce_alpha": 1.0,
+        "kd_alpha": 1.0,
+        "feat_kd_alpha": 0.5,
+        "student_iters": 1,
+    }
+
+    logger = DummyLogger()
+
+    opt = torch.optim.SGD(student.parameters(), lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+
+    student_distillation_update(
+        [t1, t2],
+        mbm,
+        head,
+        student,
+        loader,
+        loader,
+        cfg,
+        logger,
+        optimizer=opt,
+        scheduler=sched,
+    )
+
+    ep_loss = logger.metrics["student_ep1_loss"]
+    feat_kd_logged = logger.metrics["ep1_feat_kd"]
+
+    ce = ce_loss_fn(student.logit, torch.tensor([1]))
+    kd = kd_loss_fn(student.logit, head.logit, T=cfg.get("tau_start", 4.0))
+
+    with torch.no_grad():
+        if use_la:
+            _, _, s_q, t_attn = mbm(student.feat, [t1.feat, t2.feat])
+            feat_kd = torch.nn.functional.mse_loss(s_q, t_attn)
+        else:
+            fsyn = mbm([t1.feat, t2.feat])
+            feat_kd = torch.nn.functional.mse_loss(student.feat, fsyn)
+
+    expected = (
+        cfg["ce_alpha"] * ce
+        + cfg["kd_alpha"] * kd
+        + cfg["feat_kd_alpha"] * feat_kd
+    )
+
+    assert feat_kd_logged == pytest.approx(feat_kd.item())
     assert ep_loss == pytest.approx(expected.item())


### PR DESCRIPTION
## Summary
- extend feature KD distillation tests with new parameterized case
- verify loss components for LA-MBM and standard MBM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c783e948c8321bbc6373bc7e5359f