### PR TITLE
Propagate dataset class count into configs

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -163,7 +163,9 @@ def main():
     small_input = cfg.get("small_input")
     if small_input is None:
         small_input = dataset_name == "cifar100"
-    n_classes = 100
+    n_classes = len(train_loader.dataset.classes)
+    cfg["num_classes"] = n_classes
+    logger.update_metric("num_classes", n_classes)
 
     if cfg["eval_mode"] == "single":
         # single model eval

--- a/main.py
+++ b/main.py
@@ -297,6 +297,8 @@ def main():
         raise ValueError(f"Unknown dataset_name={dataset}")
 
     num_classes = len(train_loader.dataset.classes)
+    cfg["num_classes"] = num_classes
+    logger.update_metric("num_classes", num_classes)
     check_label_range(train_loader.dataset, num_classes)
     check_label_range(test_loader.dataset, num_classes)
 

--- a/tests/test_synergy_head_num_classes.py
+++ b/tests/test_synergy_head_num_classes.py
@@ -1,0 +1,38 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from models.mbm import build_from_teachers, SynergyHead
+
+class DummyTeacher(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+    def get_feat_dim(self):
+        return self.dim
+    def get_feat_channels(self):
+        return self.dim
+
+class DummyDataset(torch.utils.data.Dataset):
+    def __init__(self, num_classes):
+        self.classes = list(range(num_classes))
+    def __len__(self):
+        return 1
+    def __getitem__(self, idx):
+        return torch.zeros(3), 0
+
+def get_loader(num_classes):
+    dataset = DummyDataset(num_classes)
+    return torch.utils.data.DataLoader(dataset, batch_size=1)
+
+@pytest.mark.parametrize("n_cls", [3, 7])
+def test_synergy_head_output_matches_dataset_class_count(n_cls):
+    loader = get_loader(n_cls)
+    cfg = {"mbm_out_dim": 8}
+    # mimic logic in main.py/eval.py
+    num_classes = len(loader.dataset.classes)
+    cfg["num_classes"] = num_classes
+    teachers = [DummyTeacher(4), DummyTeacher(4)]
+    _, head = build_from_teachers(teachers, cfg, query_dim=None)
+    assert isinstance(head, SynergyHead)
+    assert head[-1].out_features == num_classes


### PR DESCRIPTION
## Summary
- propagate num_classes info from dataloader into `cfg`
- record dataset class count in logger metrics
- adjust eval script to infer class count from loaders
- test that synergy head size matches dataset class count

## Testing
- `pytest -q` *(fails: 20 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685c7e526ee88321a610f97dae1951e7