### PR TITLE
Improve AMP device handling

### DIFF
--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import pytest
-pytest.importorskip("torch")
+torch = pytest.importorskip("torch")
 from utils.misc import get_amp_components
 
 def test_amp_disabled():
@@ -11,6 +11,16 @@ def test_amp_disabled():
     assert scaler is None
 
 def test_amp_enabled():
-    cfg = {"use_amp": True, "amp_dtype": "float16"}
+    cfg = {"use_amp": True, "amp_dtype": "float16", "device": "cuda"}
     ctx, scaler = get_amp_components(cfg)
-    assert scaler is not None
+    if torch.cuda.is_available():
+        assert scaler is not None
+    else:
+        assert scaler is None
+
+
+def test_amp_cpu_device():
+    cfg = {"use_amp": True, "device": "cpu"}
+    ctx, scaler = get_amp_components(cfg)
+    assert isinstance(ctx, contextlib.AbstractContextManager)
+    assert scaler is None

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -137,7 +137,11 @@ def mixup_criterion(criterion, pred, y_a, y_b, lam):
 def get_amp_components(cfg):
     """Return autocast context and GradScaler based on config."""
     use_amp = bool(cfg.get("use_amp", False))
+    device = cfg.get("device", "cuda")
     if not use_amp:
+        from contextlib import nullcontext
+        return nullcontext(), None
+    if device != "cuda" or not torch.cuda.is_available():
         from contextlib import nullcontext
         return nullcontext(), None
     amp_dtype = cfg.get("amp_dtype", "float16")


### PR DESCRIPTION
## Summary
- detect the desired device inside `get_amp_components`
- disable AMP when not running on CUDA
- update AMP tests for CPU logic and add coverage for CPU device

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7f96649c8321881d524926683697