### PR TITLE
Handle high-dim kd logits

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -37,6 +37,12 @@ def kd_loss_fn(student_logits, teacher_logits, T=4.0, reduction="batchmean"):
 
     Returns scalar tensor (KD loss).
     """
+    # average spatial dimensions if present
+    if student_logits.dim() > 2:
+        student_logits = student_logits.mean(dim=tuple(range(2, student_logits.dim())))
+    if teacher_logits.dim() > 2:
+        teacher_logits = teacher_logits.mean(dim=tuple(range(2, teacher_logits.dim())))
+
     # student prob (with log) under temperature
     s_log_probs = F.log_softmax(student_logits / T, dim=1)
     # teacher prob under temperature

--- a/tests/test_kd_loss_high_dim.py
+++ b/tests/test_kd_loss_high_dim.py
@@ -1,0 +1,13 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.losses import kd_loss_fn
+
+
+def test_kd_loss_fn_handles_high_dim_logits():
+    student = torch.randn(2, 5, 4, 4)
+    teacher = torch.randn(2, 5, 4, 4)
+    out = kd_loss_fn(student, teacher, T=2.0, reduction="none")
+    assert out.shape == (2, 5)
+


### PR DESCRIPTION
## Summary
- support multi-dimensional tensors inside `kd_loss_fn`
- test KD loss on 4D tensors

## Testing
- `pytest -q` *(fails: 21 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685cfeb02a7c8321a52a7ef10155cdfa