### PR TITLE
Add shape validation in kd_loss_fn

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -37,6 +37,11 @@ def kd_loss_fn(student_logits, teacher_logits, T=4.0, reduction="batchmean"):
 
     Returns scalar tensor (KD loss).
     """
+    if student_logits.shape != teacher_logits.shape:
+        raise ValueError(
+            f"Mismatched logit shapes: student {student_logits.shape} vs teacher {teacher_logits.shape}"
+        )
+
     # student prob (with log) under temperature
     s_log_probs = F.log_softmax(student_logits / T, dim=1)
     # teacher prob under temperature

--- a/tests/test_kd_loss_shape.py
+++ b/tests/test_kd_loss_shape.py
@@ -1,0 +1,12 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.losses import kd_loss_fn
+
+
+def test_kd_loss_mismatched_shapes_raise():
+    student = torch.zeros(1, 3)
+    teacher = torch.zeros(1, 4)
+    with pytest.raises(ValueError, match="Mismatched logit shapes"):
+        kd_loss_fn(student, teacher)


### PR DESCRIPTION
## Summary
- check logits shapes in `kd_loss_fn`
- raise `ValueError` on mismatch
- test that mismatched shapes raise the error

## Testing
- `pytest -q -rs` *(fails: could not import torch)*

------
https://chatgpt.com/codex/tasks/task_e_685d0a5f560083219cba1ae0fde0945a