### PR TITLE
Add strict=False when loading pretrained models

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -179,10 +179,10 @@ def main():
             ckpt = torch.load(
                 cfg["ckpt_path"], map_location=device, weights_only=True
             )
-            if "model_state" in ckpt:
-                model.load_state_dict(ckpt["model_state"])
-            else:
-                model.load_state_dict(ckpt)
+                if "model_state" in ckpt:
+                    model.load_state_dict(ckpt["model_state"], strict=False)
+                else:
+                    model.load_state_dict(ckpt, strict=False)
             print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
@@ -220,12 +220,12 @@ def main():
             t1_ck = torch.load(
                 cfg["teacher1_ckpt"], map_location=device, weights_only=True
             )
-            teacher1.load_state_dict(t1_ck)
+            teacher1.load_state_dict(t1_ck, strict=False)
         if cfg["teacher2_ckpt"]:
             t2_ck = torch.load(
                 cfg["teacher2_ckpt"], map_location=device, weights_only=True
             )
-            teacher2.load_state_dict(t2_ck)
+            teacher2.load_state_dict(t2_ck, strict=False)
 
         # 4) MBM and synergy head
         mbm_query_dim = cfg.get("mbm_query_dim")
@@ -240,12 +240,12 @@ def main():
             mbm_ck = torch.load(
                 cfg["mbm_ckpt"], map_location=device, weights_only=True
             )
-            mbm.load_state_dict(mbm_ck)
+            mbm.load_state_dict(mbm_ck, strict=False)
         if cfg["head_ckpt"]:
             head_ck = torch.load(
                 cfg["head_ckpt"], map_location=device, weights_only=True
             )
-            synergy_head.load_state_dict(head_ck)
+            synergy_head.load_state_dict(head_ck, strict=False)
 
         # 5) student for LA MBM or optional synergy
         student_name = cfg.get("student_type", "resnet_adapter")
@@ -261,9 +261,9 @@ def main():
                 cfg["student_ckpt"], map_location=device, weights_only=True
             )
             if "model_state" in s_ck:
-                student.load_state_dict(s_ck["model_state"])
+                student.load_state_dict(s_ck["model_state"], strict=False)
             else:
-                student.load_state_dict(s_ck)
+                student.load_state_dict(s_ck, strict=False)
 
         # synergy ensemble
         synergy_model = SynergyEnsemble(

--- a/main.py
+++ b/main.py
@@ -336,7 +336,10 @@ def main():
 
     if cfg.get("teacher1_ckpt"):
         teacher1.load_state_dict(
-            torch.load(cfg["teacher1_ckpt"], map_location=device, weights_only=True)
+            torch.load(
+                cfg["teacher1_ckpt"], map_location=device, weights_only=True
+            ),
+            strict=False,
         )
         print(f"[Main] Loaded teacher1 from {cfg['teacher1_ckpt']}")
 
@@ -360,7 +363,10 @@ def main():
 
     if cfg.get("teacher2_ckpt"):
         teacher2.load_state_dict(
-            torch.load(cfg["teacher2_ckpt"], map_location=device, weights_only=True)
+            torch.load(
+                cfg["teacher2_ckpt"], map_location=device, weights_only=True
+            ),
+            strict=False,
         )
         print(f"[Main] Loaded teacher2 from {cfg['teacher2_ckpt']}")
 
@@ -447,7 +453,10 @@ def main():
 
     if cfg.get("student_ckpt"):
         student_model.load_state_dict(
-            torch.load(cfg["student_ckpt"], map_location=device, weights_only=True)
+            torch.load(
+                cfg["student_ckpt"], map_location=device, weights_only=True
+            ),
+            strict=False,
         )
         print(f"[Main] Loaded student from {cfg['student_ckpt']}")
 

--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -114,7 +114,10 @@ def finetune_teacher_cutmix(
 
     if os.path.exists(ckpt_path):
         print(f"[CutMix] Found checkpoint => load {ckpt_path}")
-        teacher_model.load_state_dict(torch.load(ckpt_path, weights_only=True))
+        teacher_model.load_state_dict(
+            torch.load(ckpt_path, map_location=device, weights_only=True),
+            strict=False,
+        )
         test_acc = eval_teacher(teacher_model, test_loader, device=device, cfg=None)
         print(f"[CutMix] loaded => testAcc={test_acc:.2f}")
         return teacher_model, test_acc
@@ -178,7 +181,10 @@ def standard_ce_finetune(
 
     if os.path.exists(ckpt_path):
         print(f"[CEFineTune] Found checkpoint => load {ckpt_path}")
-        teacher_model.load_state_dict(torch.load(ckpt_path, weights_only=True))
+        teacher_model.load_state_dict(
+            torch.load(ckpt_path, map_location=device, weights_only=True),
+            strict=False,
+        )
         test_acc = eval_teacher(teacher_model, test_loader, device=device, cfg=cfg)
         print(f"[CEFineTune] loaded => testAcc={test_acc:.2f}")
         return teacher_model, test_acc

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -240,7 +240,8 @@ def main():
         teacher_model.load_state_dict(
             torch.load(
                 cfg["finetune_ckpt_path"], map_location=device, weights_only=True
-            )
+            ),
+            strict=False,
         )
         print(f"[FineTune] ckpt exists → fine-tune 스킵 ({cfg['finetune_ckpt_path']})")
         # 평가만 한 번 찍고 바로 반환

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -127,7 +127,10 @@ def main():
         num_classes=num_classes,
     ).to(device)
     if cfg.get("teacher_ckpt"):
-        teacher.load_state_dict(torch.load(cfg["teacher_ckpt"], map_location=device, weights_only=True))
+        teacher.load_state_dict(
+            torch.load(cfg["teacher_ckpt"], map_location=device, weights_only=True),
+            strict=False,
+        )
     if cfg.get("use_partial_freeze", True):
         partial_freeze_teacher_auto(
             teacher,
@@ -146,7 +149,10 @@ def main():
         num_classes=num_classes,
     ).to(device)
     if cfg.get("student_ckpt"):
-        student.load_state_dict(torch.load(cfg["student_ckpt"], map_location=device, weights_only=True))
+        student.load_state_dict(
+            torch.load(cfg["student_ckpt"], map_location=device, weights_only=True),
+            strict=False,
+        )
     if cfg.get("use_partial_freeze", True):
         partial_freeze_student_auto(
             student,

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -62,7 +62,10 @@ def train_student_ce(
 
     if os.path.exists(ckpt_path):
         print(f"[StudentCE] Found checkpoint => load {ckpt_path}")
-        student_model.load_state_dict(torch.load(ckpt_path, weights_only=True))
+        student_model.load_state_dict(
+            torch.load(ckpt_path, map_location=device, weights_only=True),
+            strict=False,
+        )
         test_acc = eval_teacher(student_model, test_loader, device=device, cfg=cfg)
         print(f"[StudentCE] loaded => testAcc={test_acc:.2f}")
         return test_acc
@@ -143,7 +146,8 @@ def main():
     ).to(device)
     if cfg.get("student_ckpt"):
         student.load_state_dict(
-            torch.load(cfg["student_ckpt"], map_location=device, weights_only=True)
+            torch.load(cfg["student_ckpt"], map_location=device, weights_only=True),
+            strict=False,
         )
 
     partial_freeze_student_auto(

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -52,7 +52,7 @@ def load_checkpoint(model, optimizer, load_path):
         return 0  # or -1, indicating failure
 
     ckpt = torch.load(load_path)
-    model.load_state_dict(ckpt["model_state"])
+    model.load_state_dict(ckpt["model_state"], strict=False)
     optimizer.load_state_dict(ckpt["optim_state"])
     start_epoch = ckpt["epoch"]
     return start_epoch


### PR DESCRIPTION
## Summary
- load pretrained checkpoints with `strict=False`
- add map_location usage for checkpoint loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7d55f9208321aa9dfdf86192d4d8