### PR TITLE
Fix MBM feature dims with distillation adapters

### DIFF
--- a/models/mbm.py
+++ b/models/mbm.py
@@ -97,7 +97,13 @@ def build_from_teachers(
     cfg: dict,
     query_dim: Optional[int] = None,
 ) -> Tuple[ManifoldBridgingModule, SynergyHead]:
-    feat_dims = [t.get_feat_dim() for t in teachers]
+    use_da = bool(cfg.get("use_distillation_adapter", False))
+    feat_dims = []
+    for t in teachers:
+        if use_da and hasattr(t, "distill_dim"):
+            feat_dims.append(getattr(t, "distill_dim"))
+        else:
+            feat_dims.append(t.get_feat_dim())
     in_dim = sum(feat_dims)
 
     use_4d = bool(cfg.get("mbm_use_4d", False))

--- a/tests/test_build_from_teachers.py
+++ b/tests/test_build_from_teachers.py
@@ -38,3 +38,29 @@ def test_build_from_teachers_la_auto_query_dim():
     assert out.shape == (2, 8)
     assert logits.shape == (2, 10)
     assert mbm.q_proj.in_features == q.size(1)
+
+
+def test_build_from_teachers_with_distillation_adapter():
+    class ADummyTeacher(torch.nn.Module):
+        def __init__(self, feat_dim, distill_dim):
+            super().__init__()
+            self.dim = feat_dim
+            self.distill_dim = distill_dim
+
+        def get_feat_dim(self):
+            return self.dim
+
+        def get_feat_channels(self):
+            return self.dim
+
+    teachers = [ADummyTeacher(8, 2), ADummyTeacher(8, 2)]
+    cfg = {
+        "mbm_type": "LA",
+        "mbm_query_dim": 4,
+        "mbm_out_dim": 8,
+        "num_classes": 10,
+        "mbm_learnable_q": False,
+        "use_distillation_adapter": True,
+    }
+    mbm, _ = build_from_teachers(teachers, cfg, query_dim=4)
+    assert mbm.k_proj[0].in_features == teachers[0].distill_dim


### PR DESCRIPTION
## Summary
- handle `use_distillation_adapter` in `build_from_teachers`
- test MBM creation when distillation adapters are used

## Testing
- `pytest -q` *(fails: 21 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a0100cc8321847096cce717c191