### PR TITLE
Implement hybrid guidance for ASMB

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 
   The same values can be overridden via CLI using
   `--feat_kd_alpha 1.0 --feat_kd_key feat_2d --feat_kd_norm none`.
+- **Hybrid Guidance**: set `hybrid_beta` (>0) to blend vanilla KD from the
+  average teacher logits with the default ASMB loss.
 - **Custom MBM Query Dim**: `mbm_query_dim` controls the dimension of the
   student features used as the attention query in `LightweightAttnMBM`.
   When omitted or set to `0`, the script automatically falls back to the

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -13,6 +13,8 @@ deterministic: true
 
 # Teacher defaults
 teacher_type: "resnet152"
+teacher1_ckpt: "./checkpoints/teacher1_finetuned.pth"
+teacher2_ckpt: "./checkpoints/teacher2_finetuned.pth"
 finetune_partial_freeze: false
 efficientnet_dropout: 0.3
 
@@ -30,6 +32,7 @@ teacher_weight_decay: 0.0003
 student_weight_decay: 0.0005
 ce_alpha: 0.5
 kd_alpha: 0.5
+hybrid_beta: 0.2
 cutmix_alpha_distill: 0.0  # CutMix alpha used during distillation
 
 # Learning rate schedule
@@ -73,7 +76,7 @@ teacher_adapt_epochs: 5
 teacher_adapt_alpha_kd: 1.0
 mbm_lr_factor: 1.0
 synergy_ce_alpha: 0.3
-use_distillation_adapter: false
+use_distillation_adapter: true
 
 # Feature KD
 feat_kd_alpha: 1.0


### PR DESCRIPTION
## Summary
- add optional hybrid KD loss in `ASMBDistiller`
- document `hybrid_beta` in README
- set up defaults for hybrid beta and distillation adapter
- reference fine-tuned teacher checkpoints in hyperparameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecbd53d708321b6048a70bfc0a4bb