### PR TITLE
Organize experiment outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,7 @@ def parse_args():
     parser.add_argument("--student_epochs_per_stage", type=int)
     parser.add_argument("--epochs",     type=int)            # 예: teacher_iters
     parser.add_argument("--results_dir", type=str)
+    parser.add_argument("--ckpt_dir", type=str, default=None)
     parser.add_argument("--exp_id", type=str, default=None, help="Unique experiment ID")
     parser.add_argument("--seed", type=int, default=42)
 
@@ -634,8 +635,9 @@ def main():
         logger.update_metric(f"stage{stage_id}_student_acc", final_acc)
 
     # 8) save final
-    student_ckpt_path = f"{cfg['results_dir']}/final_student_asmb.pth"
-    os.makedirs(os.path.dirname(student_ckpt_path), exist_ok=True)
+    ckpt_dir = cfg.get("ckpt_dir", cfg["results_dir"])
+    os.makedirs(ckpt_dir, exist_ok=True)
+    student_ckpt_path = os.path.join(ckpt_dir, "student_final.pth")
     torch.save(student_model.state_dict(), student_ckpt_path)
     print(f"[main] Distillation done => {student_ckpt_path}")
     logger.update_metric("final_student_ckpt", student_ckpt_path)

--- a/run.sh
+++ b/run.sh
@@ -4,21 +4,23 @@
 #SBATCH --partition=base_suma_rtx3090
 #SBATCH --gres=gpu:1
 #SBATCH --time=10:00:00
-#SBATCH --output=logs/asmb_%j.log
-#SBATCH --error=logs/asmb_%j.err
+#SBATCH --output=outputs/asmb_%j/run.log
+#SBATCH --error=outputs/asmb_%j/run.log
 
+# Unique output directory per SLURM job
 JOB_ID=${SLURM_JOB_ID:-manual}
-mkdir -p logs
-cp configs/hparams.yaml "logs/asmb_${JOB_ID}_hparams.yaml"
+OUTPUT_DIR="outputs/asmb_${JOB_ID}"
+mkdir -p "$OUTPUT_DIR"
+cp configs/hparams.yaml "${OUTPUT_DIR}/hparams.yaml"
 BASE_CFG_PATH=${BASE_CONFIG:-configs/default.yaml}
-cp "$BASE_CFG_PATH" "logs/asmb_${JOB_ID}_base.yaml"
+cp "$BASE_CFG_PATH" "${OUTPUT_DIR}/base.yaml"
 # Save a fully merged YAML with all hyperparameters
 python scripts/generate_config.py \
   --base "$BASE_CFG_PATH" \
   --hparams configs/hparams.yaml \
-  --out "logs/asmb_${JOB_ID}_full.yaml"
+  --out "${OUTPUT_DIR}/full.yaml"
 
 source ~/.bashrc
 conda activate facil_env
 
-bash scripts/run_experiments.sh --mode loop
+bash scripts/run_experiments.sh --mode loop --output_dir "$OUTPUT_DIR"

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -43,6 +43,7 @@ def parse_args():
     p.add_argument("--weight_decay", type=float)
     p.add_argument("--epochs", type=int)
     p.add_argument("--results_dir", type=str, default="results")
+    p.add_argument("--ckpt_dir", type=str, default=None)
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--device", type=str)
     p.add_argument("--dataset", "--dataset_name", dest="dataset_name", type=str,
@@ -174,8 +175,9 @@ def main():
         cfg=cfg,
     )
 
-    os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
-    ckpt = os.path.join(cfg["results_dir"], f"final_student_{method}.pth")
+    ckpt_dir = cfg.get("ckpt_dir", cfg.get("results_dir", "results"))
+    os.makedirs(ckpt_dir, exist_ok=True)
+    ckpt = os.path.join(ckpt_dir, f"final_student_{method}.pth")
     torch.save(student.state_dict(), ckpt)
     print(f"[run_single_teacher] final_acc={acc:.2f}% -> {ckpt}")
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -67,7 +67,6 @@ class ExperimentLogger:
 
         # Where to save results
         self.results_dir = self.config.get("results_dir", "results")
-        os.makedirs(self.results_dir, exist_ok=True)
 
         # For timing
         self.start_time = time.time()
@@ -107,12 +106,12 @@ class ExperimentLogger:
         total_time = time.time() - self.start_time
         self.config["total_time_sec"] = total_time
 
-        # 2) JSON file path
-        json_path = os.path.join(self.results_dir, f"{self.exp_id}.json")
+        # 2) JSON file path (fixed name within results_dir)
+        json_path = os.path.join(self.results_dir, "summary.json")
 
-        # 3) CSV file path (unique for each experiment)
-        csv_filename = f"{self.exp_id}.csv"
-        self.config["csv_filename"] = csv_filename  # store in JSON as well
+        # 3) CSV file path (fixed name)
+        csv_filename = "summary.csv"
+        self.config["csv_filename"] = csv_filename
         csv_path = os.path.join(self.results_dir, csv_filename)
 
         # Save the JSON (all info)


### PR DESCRIPTION
## Summary
- create per-job output directory in `run.sh`
- pass output directory to `run_experiments.sh`
- create subfolders for each experiment and pass checkpoint folder paths
- store checkpoints via `--ckpt_dir` argument
- write fixed summary files in `ExperimentLogger`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616dd30f7483219ded43659f540898