### PR TITLE
Simplify config output in run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,10 @@ learning rate:
 teacher_lr=0.0002 BASE_CONFIG=configs/partial_freeze.yaml bash scripts/run_experiments.sh --mode loop
 ```
 
-When launching jobs via `run.sh`, the script saves a copy of
-`configs/hparams.yaml` to `logs/asmb_${SLURM_JOB_ID}_hparams.yaml` (or to a
-timestamped file when run outside Slurm). During the batch loop, each generated
-configuration is copied to both `${OUTDIR}/config.yaml` and
-`logs/asmb_${SLURM_JOB_ID}_<experiment>.yaml` so you can recover the exact
-settings used for every run.
+When launching jobs via `run.sh`, the script writes the merged configuration to
+`outputs/asmb_${SLURM_JOB_ID}/config.yaml`. During the batch loop, this file is
+copied into each experiment directory so you can recover the exact settings used
+for every run.
 
 ## Testing
 

--- a/run.sh
+++ b/run.sh
@@ -11,14 +11,13 @@
 JOB_ID=${SLURM_JOB_ID:-manual}
 OUTPUT_DIR="outputs/asmb_${JOB_ID}"
 mkdir -p "$OUTPUT_DIR"
-cp configs/hparams.yaml "${OUTPUT_DIR}/hparams.yaml"
+# Path to the base configuration
 BASE_CFG_PATH=${BASE_CONFIG:-configs/default.yaml}
-cp "$BASE_CFG_PATH" "${OUTPUT_DIR}/base.yaml"
 # Save a fully merged YAML with all hyperparameters
 python scripts/generate_config.py \
   --base "$BASE_CFG_PATH" \
   --hparams configs/hparams.yaml \
-  --out "${OUTPUT_DIR}/full.yaml"
+  --out "${OUTPUT_DIR}/config.yaml"
 
 source ~/.bashrc
 conda activate facil_env


### PR DESCRIPTION
## Summary
- generate a single `config.yaml` when launching jobs
- document the new behavior in README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686172a19dd48321a7ea8708c0b748db