### PR TITLE
Fix teacher config names

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Alternatively edit the YAML file used by `scripts/fine_tuning.py`:
 
 ```yaml
 # configs/hparams.yaml
-teacher_type: resnet152
+default_teacher_type: resnet152
 finetune_epochs: 100
 finetune_lr: 0.0005
 finetune_use_cutmix: false

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -12,7 +12,13 @@ small_input: true
 deterministic: true
 
 # Teacher defaults
-teacher_type: "resnet152"
+# For ASMB (main experiment)
+teacher1_type: "resnet152"
+teacher2_type: "efficientnet_b2"
+
+# For single-teacher scripts (fine_tuning.py, etc.)
+default_teacher_type: "resnet152"
+
 teacher1_ckpt: "./checkpoints/teacher1_finetuned.pth"
 teacher2_ckpt: "./checkpoints/teacher2_finetuned.pth"
 finetune_partial_freeze: false

--- a/eval.py
+++ b/eval.py
@@ -198,8 +198,8 @@ def main():
     else:
         # synergy mode
         # 1) YAML: teacher1_type, teacher2_type
-        teacher1_type = cfg.get("teacher1_type", "resnet152")
-        teacher2_type = cfg.get("teacher2_type", "efficientnet_b2")
+        teacher1_type = cfg["teacher1_type"]
+        teacher2_type = cfg["teacher2_type"]
 
         # 2) create teachers
         teacher1 = create_teacher_by_name(

--- a/main.py
+++ b/main.py
@@ -325,8 +325,8 @@ def main():
         small_input = dataset == "cifar100"
 
     # 4) Create teacher1, teacher2
-    teacher1_type = cfg.get("teacher1_type", "resnet152")
-    teacher2_type = cfg.get("teacher2_type", "efficientnet_b2")
+    teacher1_type = cfg["teacher1_type"]
+    teacher2_type = cfg["teacher2_type"]
 
     teacher1 = create_teacher_by_name(
         teacher_name=teacher1_type,

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -225,7 +225,7 @@ def main():
         small_input = dataset_name == "cifar100"
 
     # 2) teacher
-    teacher_type = cfg.get("teacher_type", "resnet152")  # e.g. "resnet152", "efficientnet_b2", "swin_tiny"
+    teacher_type = cfg.get("teacher_type", cfg.get("default_teacher_type"))  # e.g. "resnet152", "efficientnet_b2", "swin_tiny"
     print(f"[FineTune] ===== Now fine-tuning teacher: {teacher_type} =====")
     teacher_model = create_teacher_by_name(
         teacher_type,

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -90,7 +90,7 @@ def main():
     method = cfg.get("method", args.method)
     if method != "asmb":
         cfg["use_partial_freeze"] = False
-    teacher_type = cfg.get("teacher_type", args.teacher_type)
+    teacher_type = cfg.get("teacher_type", cfg.get("default_teacher_type"))
     student_type = cfg.get("student_type", args.student_type)
     print(
         f">>> [run_single_teacher.py] method={method} teacher={teacher_type} student={student_type}"
@@ -122,7 +122,7 @@ def main():
         small_input = dataset == "cifar100"
 
     teacher = create_teacher_by_name(
-        cfg.get("teacher_type", "resnet152"),
+        cfg.get("teacher_type", cfg.get("default_teacher_type")),
         pretrained=cfg.get("teacher_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
@@ -135,7 +135,7 @@ def main():
     if cfg.get("use_partial_freeze", True):
         partial_freeze_teacher_auto(
             teacher,
-            cfg.get("teacher_type", "resnet152"),
+            cfg.get("teacher_type", cfg.get("default_teacher_type")),
             freeze_bn=cfg.get("teacher_freeze_bn", True),
             freeze_ln=cfg.get("teacher_freeze_ln", True),
             use_adapter=cfg.get("teacher_use_adapter", False),


### PR DESCRIPTION
## Summary
- make teacher types explicit in hparams
- require teacher1_type/teacher2_type in main and eval
- support default_teacher_type for single-teacher utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686176f67c8c8321876faac26cd39249