### PR TITLE
Simplify experiment output handling

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,17 +7,13 @@
 #SBATCH --output=outputs/asmb_%j/run.log
 #SBATCH --error=outputs/asmb_%j/run.log
 
-# Unique output directory per SLURM job
+# Create a unique output directory per SLURM job
 JOB_ID=${SLURM_JOB_ID:-manual}
 OUTPUT_DIR="outputs/asmb_${JOB_ID}"
 mkdir -p "$OUTPUT_DIR"
-# Save a fully merged YAML with all hyperparameters
-python scripts/generate_config.py \
-  --base configs/default.yaml configs/partial_freeze.yaml \
-  --hparams configs/hparams.yaml \
-  --out "${OUTPUT_DIR}/config.yaml"
 
 source ~/.bashrc
 conda activate facil_env
 
+# Pass the unique output directory to the main experiment script
 bash scripts/run_experiments.sh --mode loop --output_dir "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- update `run.sh` to only create job directory and call experiment script
- simplify `scripts/run_experiments.sh` to use passed output directory and global checkpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618025f33c8321a124425f8bffedf0