### PR TITLE
Implement FitNet regressor for mismatched channels

### DIFF
--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -71,7 +71,11 @@ def build_distiller(method, teacher, student, cfg):
     if method == "vanilla_kd":
         return cls(teacher, student, alpha=cfg.get("kd_alpha", 0.5), temperature=cfg.get("tau_start", 4.0), config=cfg)
     if method == "fitnet":
-        return cls(teacher, student)
+        # FitNet에 필요한 채널 수를 지정합니다.
+        # (Teacher: EfficientNet-B2, Student: ResNet-Adapter, layer2 기준)
+        s_channels = 512
+        t_channels = 48  # EfficientNet-B2의 layer2 출력 채널 수
+        return cls(teacher, student, s_channels=s_channels, t_channels=t_channels)
     if method == "dkd":
         return cls(teacher, student)
     if method == "at":

--- a/tests/test_distiller_label_smoothing.py
+++ b/tests/test_distiller_label_smoothing.py
@@ -39,7 +39,7 @@ class ConstStudent(torch.nn.Module):
     "distiller_cls, kwargs",
     [
         (ATDistiller, {"alpha": 0.0}),
-        (FitNetDistiller, {"alpha_hint": 0.0, "alpha_ce": 1.0}),
+        (FitNetDistiller, {"alpha_hint": 0.0, "alpha_ce": 1.0, "s_channels": 1, "t_channels": 1}),
         (DKDDistiller, {"alpha": 0.0, "beta": 0.0, "warmup": 1}),
         (CRDDistiller, {"alpha": 0.0}),
     ],

--- a/tests/test_teacher_eval_mode.py
+++ b/tests/test_teacher_eval_mode.py
@@ -43,7 +43,7 @@ def get_loader():
     "distiller_cls, kwargs",
     [
         (ATDistiller, {}),
-        (FitNetDistiller, {"hint_key": "feat_4d_layer3", "guided_key": "feat_4d_layer3"}),
+        (FitNetDistiller, {"hint_key": "feat_4d_layer3", "guided_key": "feat_4d_layer3", "s_channels": 1, "t_channels": 1}),
         (DKDDistiller, {}),
         (CRDDistiller, {}),
     ],


### PR DESCRIPTION
## Summary
- extend `FitNetDistiller` with optional channel arguments and a regressor layer
- adjust forward pass to match teacher feature shape
- supply default channels for EfficientNet/ResNet combination in runner
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618a4b04d0832180878e442a081018