### PR TITLE
Fix Swin teacher output handling

### DIFF
--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -46,9 +46,15 @@ class TeacherSwinWrapper(nn.Module):
 
         # 2) handle feature shape
         if f4d.dim() == 2:
+            # already pooled -> treat as 2D feature
             f2d = f4d
             feat_4d = f2d.unsqueeze(-1).unsqueeze(-1)
+        elif f4d.dim() == 3:
+            # Swin Tiny from timm sometimes returns [N, seq_len, C]
+            f2d = f4d.mean(dim=1)
+            feat_4d = f2d.unsqueeze(-1).unsqueeze(-1)
         else:
+            # standard 4D [N, C, H, W]
             feat_4d = f4d
             f2d = F.adaptive_avg_pool2d(f4d, (1, 1)).flatten(1)
 

--- a/tests/test_teacher_swin_wrapper.py
+++ b/tests/test_teacher_swin_wrapper.py
@@ -26,6 +26,16 @@ class Dummy2DBackbone(torch.nn.Module):
         return x.mean(dim=(2, 3))
 
 
+class Dummy3DBackbone(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.head = torch.nn.Linear(1, 2)
+
+    def forward_features(self, x):
+        b, c, h, w = x.shape
+        return x.view(b, -1, 1)
+
+
 def test_forward_outputs_feature_keys():
     backbone = DummyBackbone()
     wrapper = TeacherSwinWrapper(backbone)
@@ -46,6 +56,18 @@ def test_forward_accepts_2d_output():
 
     assert out["feat_4d"].dim() == 4
     expected_f2d = x.mean(dim=(2, 3))
+    assert torch.allclose(out["feat_2d"], expected_f2d)
+    assert out["feat_4d"].shape == (*expected_f2d.shape, 1, 1)
+
+
+def test_forward_accepts_3d_output():
+    backbone = Dummy3DBackbone()
+    wrapper = TeacherSwinWrapper(backbone)
+    x = torch.randn(2, 1, 2, 2)
+
+    out = wrapper(x)
+
+    expected_f2d = x.view(2, -1, 1).mean(dim=1)
     assert torch.allclose(out["feat_2d"], expected_f2d)
     assert out["feat_4d"].shape == (*expected_f2d.shape, 1, 1)
 


### PR DESCRIPTION
## Summary
- handle sequence output from Swin Tiny teachers
- test TeacherSwinWrapper with 3D output

## Testing
- `pytest -k teacher_swin_wrapper -q` *(fails: 22 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6861ccb08dec8321b0988c61202fa7da