### PR TITLE
Expose Swin adapter dim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   | `student_efficientnet_adapter` | 1408        |
   | `student_resnet_adapter`       | 2048        |
   | `student_swin_adapter`         | 768         |
+- **Swin Adapter Dim**: `swin_adapter_dim` sets the hidden size of the MLP
+  adapter used by `student_swin_adapter` (default `64`)
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -37,6 +37,7 @@ teacher2_bn_head_only: 0
 # Additional teacher options
 finetune_partial_freeze: false
 efficientnet_dropout: 0.3
+swin_adapter_dim: 64  # hidden size for student_swin_adapter
 
 # ===============================================================
 # 3. Fine-tuning Hyperparameters

--- a/eval.py
+++ b/eval.py
@@ -254,6 +254,7 @@ def main():
             pretrained=False,
             small_input=small_input,
             num_classes=n_classes,
+            cfg=cfg,
         ).to(device)
 
         if cfg.get("student_ckpt"):

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ def create_student_by_name(
     pretrained: bool = True,
     small_input: bool = False,
     num_classes: int = 100,
+    cfg: dict | None = None,
 ):
     """
     Returns a student model that follows the common interface
@@ -83,10 +84,15 @@ def create_student_by_name(
         from models.students.student_swin_adapter import (
             create_swin_adapter_student,
         )
+        adapter_dim = 64
+        if cfg is not None:
+            adapter_dim = cfg.get("swin_adapter_dim", adapter_dim)
         return create_swin_adapter_student(
             pretrained=pretrained,
             small_input=small_input,
             num_classes=num_classes,
+            adapter_dim=adapter_dim,
+            cfg=cfg,
         )
 
     else:
@@ -460,6 +466,7 @@ def main():
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
+        cfg=cfg,
     ).to(device)
 
     if cfg.get("student_ckpt"):

--- a/models/students/student_swin_adapter.py
+++ b/models/students/student_swin_adapter.py
@@ -14,7 +14,9 @@ class StudentSwinAdapter(nn.Module):
       => returns (feature_dict, logit, ce_loss)
     """
     def __init__(self, pretrained=True, adapter_dim=64, num_classes=100,
-                 small_input: bool = False):
+                 small_input: bool = False, cfg: dict | None = None):
+        if cfg is not None:
+            adapter_dim = cfg.get("swin_adapter_dim", adapter_dim)
         super().__init__()
         self.criterion_ce = nn.CrossEntropyLoss()
 
@@ -81,7 +83,9 @@ class StudentSwinAdapter(nn.Module):
 
 
 def create_swin_adapter_student(pretrained=True, adapter_dim=64, num_classes=100,
-                                small_input: bool = False):
+                                small_input: bool = False, cfg: dict | None = None):
+    if cfg is not None:
+        adapter_dim = cfg.get("swin_adapter_dim", adapter_dim)
     """
     Creates the Student Swin model w/ adapter => (dict, logit, ce_loss)
     """

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -152,6 +152,7 @@ def main():
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
+        cfg=cfg,
     ).to(device)
     if cfg.get("student_ckpt"):
         student.load_state_dict(

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -143,6 +143,7 @@ def main():
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
+        cfg=cfg,
     ).to(device)
     if cfg.get("student_ckpt"):
         student.load_state_dict(


### PR DESCRIPTION
## Summary
- allow overriding Swin adapter hidden dimension via `swin_adapter_dim`
- plumb the new config through `create_student_by_name` and scripts
- update `StudentSwinAdapter` factory to read the parameter
- document `swin_adapter_dim` in README
- default to 64 in `hparams.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e991ade08321b3ff5e8c7cf81dc0