### PR TITLE
Add configurable data loader workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ Use the `--data_aug` flag to control dataset transforms. When set to `1` (defaul
 python main.py --config configs/default.yaml --data_aug 0
 ```
 
+Set `num_workers` in your YAML file to control how many processes each
+`DataLoader` uses (defaults to `2`).
+
 | Flag | Purpose |
 | ---- | ------- |
 | `--mixup_alpha` | MixUp alpha for distillation |

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -7,6 +7,7 @@ dataset_name: "cifar100"
 small_input: true
 data_root: "./data"
 batch_size: 128
+num_workers: 2
 use_amp: true
 amp_dtype: float16
 grad_scaler_init_scale: 1024

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -11,6 +11,7 @@ deterministic: true
 dataset_name: "cifar100"
 data_root: "./data"
 batch_size: 128
+num_workers: 2
 data_aug: 1
 small_input: true
 

--- a/configs/partial_freeze.yaml
+++ b/configs/partial_freeze.yaml
@@ -18,3 +18,4 @@ teacher2_freeze_level: 2
 student_freeze_bn: false
 student_freeze_level: 2
 student_use_adapter: true
+num_workers: 2

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -5,7 +5,7 @@ import torch
 import torchvision
 import torchvision.transforms as T
 
-def get_imagenet100_loaders(root="./data/imagenet100", batch_size=128, num_workers=4, augment=True):
+def get_imagenet100_loaders(root="./data/imagenet100", batch_size=128, num_workers=2, augment=True):
     """    
     ImageNet100 size = (224×224)
     Returns:

--- a/eval.py
+++ b/eval.py
@@ -160,7 +160,10 @@ def main():
 
     # 4) Data
     dataset_name = cfg.get("dataset_name", "cifar100")
-    train_loader, test_loader = get_cifar100_loaders(batch_size=cfg["batch_size"])
+    train_loader, test_loader = get_cifar100_loaders(
+        batch_size=cfg["batch_size"],
+        num_workers=cfg.get("num_workers", 2),
+    )
     device = cfg["device"]
     small_input = cfg.get("small_input")
     if small_input is None:

--- a/main.py
+++ b/main.py
@@ -330,12 +330,14 @@ def main():
         train_loader, test_loader = get_cifar100_loaders(
             root=data_root,
             batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
             augment=cfg.get("data_aug", True),
         )
     elif dataset == "imagenet100":
         train_loader, test_loader = get_imagenet100_loaders(
             root=data_root,
             batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
             augment=cfg.get("data_aug", True),
         )
     else:

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -75,14 +75,22 @@ def load_config(cfg_path):
             return yaml.safe_load(f)
     return {}
 
-def get_data_loaders(dataset_name, batch_size=128, augment=True):
+def get_data_loaders(dataset_name, batch_size=128, num_workers=2, augment=True):
     """
     Returns train_loader, test_loader based on dataset_name.
     """
     if dataset_name == "cifar100":
-        return get_cifar100_loaders(batch_size=batch_size, augment=augment)
+        return get_cifar100_loaders(
+            batch_size=batch_size,
+            num_workers=num_workers,
+            augment=augment,
+        )
     elif dataset_name == "imagenet100":
-        return get_imagenet100_loaders(batch_size=batch_size, augment=augment)
+        return get_imagenet100_loaders(
+            batch_size=batch_size,
+            num_workers=num_workers,
+            augment=augment,
+        )
     else:
         raise ValueError(f"Unknown dataset_name={dataset_name}")
 
@@ -229,7 +237,8 @@ def main():
     train_loader, test_loader = get_data_loaders(
         dataset_name,
         batch_size=batch_size,
-        augment=cfg.get("data_aug", True)
+        num_workers=cfg.get("num_workers", 2),
+        augment=cfg.get("data_aug", True),
     )
 
     num_classes = len(train_loader.dataset.classes)

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -110,11 +110,17 @@ def main():
     data_root = cfg.get("data_root", "./data")
     if dataset == "cifar100":
         train_loader, test_loader = get_cifar100_loaders(
-            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+            root=data_root,
+            batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
+            augment=cfg.get("data_aug", True),
         )
     else:
         train_loader, test_loader = get_imagenet100_loaders(
-            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+            root=data_root,
+            batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
+            augment=cfg.get("data_aug", True),
         )
 
     num_classes = len(train_loader.dataset.classes)

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -123,11 +123,17 @@ def main():
     data_root = cfg.get("data_root", "./data")
     if dataset == "cifar100":
         train_loader, test_loader = get_cifar100_loaders(
-            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+            root=data_root,
+            batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
+            augment=cfg.get("data_aug", True),
         )
     else:
         train_loader, test_loader = get_imagenet100_loaders(
-            root=data_root, batch_size=batch_size, augment=cfg.get("data_aug", True)
+            root=data_root,
+            batch_size=batch_size,
+            num_workers=cfg.get("num_workers", 2),
+            augment=cfg.get("data_aug", True),
         )
 
     num_classes = len(train_loader.dataset.classes)


### PR DESCRIPTION
## Summary
- allow setting DataLoader `num_workers` via YAML configs
- pass `cfg['num_workers']` to CIFAR100/ImageNet100 loaders
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ec4ec398832192dc1e1e2ba231ef