### PR TITLE
Remove momentum docs, add Adam beta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
 - **Gradient Clipping**: enable by setting `grad_clip_norm` (>0) in configs
-- **Configurable SGD Momentum**: set `sgd_momentum` in configs or override
-  with `--sgd_momentum`
+- **Configurable Adam Betas**: set `adam_beta1` and `adam_beta2` in configs or override
+  with `--adam_beta1` and `--adam_beta2`
 - **Learnable MBM Query**: set `mbm_learnable_q: true` to use a global learnable
   token instead of the student feature as attention query
 - **Feature-Level KD**: align student features with the synergy representation.
@@ -364,7 +364,8 @@ Adjust the parameters in `configs/hparams.yaml`:
 # configs/hparams.yaml
 finetune_epochs=100   # number of fine-tuning epochs
 finetune_lr=0.0005    # learning rate
-sgd_momentum=0.9      # SGD momentum
+adam_beta1=0.9        # Adam beta1
+adam_beta2=0.999      # Adam beta2
 finetune_cutmix_alpha=0  # set to 0 to disable CutMix
 lr_schedule=step   # step or cosine
 ```
@@ -376,7 +377,8 @@ Alternatively edit the YAML file used by `scripts/fine_tuning.py`:
 default_teacher_type: resnet152
 finetune_epochs: 100
 finetune_lr: 0.0005
-sgd_momentum: 0.9
+adam_beta1: 0.9
+adam_beta2: 0.999
 finetune_use_cutmix: false
 efficientnet_dropout: 0.3  # dropout probability for EfficientNet teachers
 ```

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -57,7 +57,8 @@ teacher_lr: 1e-4
 student_lr: 3e-4
 teacher_weight_decay: 0.0003
 student_weight_decay: 0.0005
-sgd_momentum: 0.9
+adam_beta1: 0.9
+adam_beta2: 0.999
 ce_alpha: 0.5
 kd_alpha: 0.5
 synergy_ce_alpha: 0.3

--- a/main.py
+++ b/main.py
@@ -568,6 +568,8 @@ def main():
     mbm_params = [p for p in mbm.parameters() if p.requires_grad]
     syn_params = [p for p in synergy_head.parameters() if p.requires_grad]
 
+    beta1 = cfg.get("adam_beta1", 0.9)
+    beta2 = cfg.get("adam_beta2", 0.999)
     teacher_optimizer = optim.Adam(
         [
             {"params": teacher_params, "lr": cfg["teacher_lr"]},
@@ -581,6 +583,7 @@ def main():
             },
         ],
         weight_decay=cfg["teacher_weight_decay"],
+        betas=(beta1, beta2),
     )
 
     teacher_total_epochs = num_stages * cfg.get("teacher_iters", cfg.get("teacher_adapt_epochs", 5))
@@ -597,7 +600,7 @@ def main():
         student_model.parameters(),
         lr=cfg["student_lr"],
         weight_decay=cfg["student_weight_decay"],
-        betas=(0.9, 0.999),
+        betas=(beta1, beta2),
         eps=1e-8,
     )
 

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -159,13 +159,21 @@ class ASMBDistiller(nn.Module):
         for p in self.synergy_head.parameters():
             if p.requires_grad:
                 teacher_params.append(p)
+        beta1 = self.config.get("adam_beta1", 0.9)
+        beta2 = self.config.get("adam_beta2", 0.999)
         teacher_optimizer = optim.Adam(
-            teacher_params, lr=teacher_lr, weight_decay=weight_decay
+            teacher_params,
+            lr=teacher_lr,
+            weight_decay=weight_decay,
+            betas=(beta1, beta2),
         )
 
         student_params = [p for p in self.student.parameters() if p.requires_grad]
         student_optimizer = optim.AdamW(
-            student_params, lr=student_lr, weight_decay=weight_decay
+            student_params,
+            lr=student_lr,
+            weight_decay=weight_decay,
+            betas=(beta1, beta2),
         )
         total_epochs = epochs_per_stage * self.num_stages
         student_scheduler = optim.lr_scheduler.CosineAnnealingLR(

--- a/methods/at.py
+++ b/methods/at.py
@@ -96,11 +96,13 @@ class ATDistiller(nn.Module):
             step_size = 10
             gamma = 0.1
 
+        beta1 = cfg.get("adam_beta1", 0.9) if cfg else 0.9
+        beta2 = cfg.get("adam_beta2", 0.999) if cfg else 0.999
         optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(beta1, beta2),
             eps=1e-8,
         )
 

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -104,11 +104,13 @@ class CRDDistiller(nn.Module):
             step_size = 10
             gamma = 0.1
 
+        beta1 = cfg.get("adam_beta1", 0.9) if cfg else 0.9
+        beta2 = cfg.get("adam_beta2", 0.999) if cfg else 0.999
         optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(beta1, beta2),
             eps=1e-8,
         )
 

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -107,11 +107,13 @@ class DKDDistiller(nn.Module):
             step_size = 10
             gamma = 0.1
 
+        beta1 = cfg.get("adam_beta1", 0.9) if cfg else 0.9
+        beta2 = cfg.get("adam_beta2", 0.999) if cfg else 0.999
         optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(beta1, beta2),
             eps=1e-8,
         )
 

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -105,11 +105,13 @@ class FitNetDistiller(nn.Module):
             step_size = 10
             gamma = 0.1
 
+        beta1 = cfg.get("adam_beta1", 0.9) if cfg else 0.9
+        beta2 = cfg.get("adam_beta2", 0.999) if cfg else 0.999
         optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(beta1, beta2),
             eps=1e-8,
         )
 

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -84,11 +84,13 @@ class VanillaKDDistiller(nn.Module):
             step_size = 10
             gamma = 0.1
 
+        beta1 = cfg.get("adam_beta1", 0.9) if cfg else 0.9
+        beta2 = cfg.get("adam_beta2", 0.999) if cfg else 0.999
         optimizer = optim.AdamW(
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(beta1, beta2),
             eps=1e-8,
         )
 


### PR DESCRIPTION
## Summary
- strip README references to SGD momentum
- expose Adam beta hyperparameters in code and configs
- document AdamW betas in fine-tuning examples
- remove `sgd_momentum` from default config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ef472e408321b7a4210cc88d6472