### PR TITLE
Add Adam beta CLI options

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,6 +158,8 @@ def parse_args():
     parser.add_argument("--teacher2_bn_head_only", type=int)
     parser.add_argument("--use_amp", type=int)
     parser.add_argument("--amp_dtype", type=str)
+    parser.add_argument("--adam_beta1", type=float)
+    parser.add_argument("--adam_beta2", type=float)
     parser.add_argument("--grad_scaler_init_scale", type=int)
     parser.add_argument("--student_freeze_level", type=int)
 
@@ -581,6 +583,10 @@ def main():
             },
         ],
         weight_decay=cfg["teacher_weight_decay"],
+        betas=(
+            cfg.get("adam_beta1", 0.9),
+            cfg.get("adam_beta2", 0.999),
+        ),
     )
 
     teacher_total_epochs = num_stages * cfg.get("teacher_iters", cfg.get("teacher_adapt_epochs", 5))
@@ -597,7 +603,10 @@ def main():
         student_model.parameters(),
         lr=cfg["student_lr"],
         weight_decay=cfg["student_weight_decay"],
-        betas=(0.9, 0.999),
+        betas=(
+            cfg.get("adam_beta1", 0.9),
+            cfg.get("adam_beta2", 0.999),
+        ),
         eps=1e-8,
     )
 

--- a/methods/at.py
+++ b/methods/at.py
@@ -100,7 +100,10 @@ class ATDistiller(nn.Module):
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(
+                self.cfg.get("adam_beta1", 0.9),
+                self.cfg.get("adam_beta2", 0.999),
+            ),
             eps=1e-8,
         )
 

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -108,7 +108,10 @@ class CRDDistiller(nn.Module):
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(
+                self.cfg.get("adam_beta1", 0.9),
+                self.cfg.get("adam_beta2", 0.999),
+            ),
             eps=1e-8,
         )
 

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -111,7 +111,10 @@ class DKDDistiller(nn.Module):
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(
+                self.cfg.get("adam_beta1", 0.9),
+                self.cfg.get("adam_beta2", 0.999),
+            ),
             eps=1e-8,
         )
 

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -109,7 +109,10 @@ class FitNetDistiller(nn.Module):
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(
+                self.cfg.get("adam_beta1", 0.9),
+                self.cfg.get("adam_beta2", 0.999),
+            ),
             eps=1e-8,
         )
 

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -88,7 +88,10 @@ class VanillaKDDistiller(nn.Module):
             self.student.parameters(),
             lr=lr,
             weight_decay=weight_decay,
-            betas=(0.9, 0.999),
+            betas=(
+                self.cfg.get("adam_beta1", 0.9),
+                self.cfg.get("adam_beta2", 0.999),
+            ),
             eps=1e-8,
         )
 

--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -101,6 +101,7 @@ def finetune_teacher_cutmix(
     device="cuda",
     ckpt_path="teacher_finetuned_cutmix.pth",
     label_smoothing: float = 0.0,
+    cfg=None,
 ):
     """
     teacher_model: must produce a dict containing "logit". Only the
@@ -126,6 +127,10 @@ def finetune_teacher_cutmix(
         teacher_model.parameters(),
         lr=lr,
         weight_decay=weight_decay,
+        betas=(
+            cfg.get("adam_beta1", 0.9) if cfg is not None else 0.9,
+            cfg.get("adam_beta2", 0.999) if cfg is not None else 0.999,
+        ),
     )
     scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
 
@@ -197,6 +202,10 @@ def standard_ce_finetune(
         teacher_model.parameters(),
         lr=lr,
         weight_decay=weight_decay,
+        betas=(
+            cfg.get("adam_beta1", 0.9) if cfg is not None else 0.9,
+            cfg.get("adam_beta2", 0.999) if cfg is not None else 0.999,
+        ),
     )
     criterion = nn.CrossEntropyLoss(label_smoothing=label_smoothing)
 

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -65,6 +65,8 @@ def parse_args():
     parser.add_argument("--dropout_p", type=float)
     parser.add_argument("--use_amp", type=int)
     parser.add_argument("--amp_dtype", type=str)
+    parser.add_argument("--adam_beta1", type=float)
+    parser.add_argument("--adam_beta2", type=float)
     parser.add_argument("--grad_scaler_init_scale", type=int)
 
     return parser.parse_args()
@@ -184,6 +186,7 @@ def standard_ce_finetune(
     device,
     ckpt_path,
     label_smoothing: float = 0.0,
+    cfg=None,
 ):
     """Simple fine-tune loop using cross-entropy loss.
 
@@ -197,6 +200,10 @@ def standard_ce_finetune(
         model.parameters(),
         lr=lr,
         weight_decay=weight_decay,
+        betas=(
+            cfg.get("adam_beta1", 0.9) if cfg is not None else 0.9,
+            cfg.get("adam_beta2", 0.999) if cfg is not None else 0.999,
+        ),
     )
     crit  = torch.nn.CrossEntropyLoss(label_smoothing=label_smoothing)
     best_acc = 0.0
@@ -323,6 +330,7 @@ def main():
             device=device,
             ckpt_path=ckpt_path,
             label_smoothing=cfg.get("label_smoothing", 0.0),
+            cfg=cfg,
         )
     else:
         # => implement your own standard CE fine-tune loop or reuse a function
@@ -336,6 +344,7 @@ def main():
             device=device,
             ckpt_path=ckpt_path,
             label_smoothing=cfg.get("label_smoothing", 0.0),
+            cfg=cfg,
         )
 
     print(f"[FineTune] done => bestAcc={best_acc:.2f}, final ckpt={ckpt_path}")

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -34,6 +34,8 @@ def parse_args():
     p.add_argument("--label_smoothing", type=float)
     p.add_argument("--small_input", type=int)
     p.add_argument("--student_freeze_level", type=int)
+    p.add_argument("--adam_beta1", type=float)
+    p.add_argument("--adam_beta2", type=float)
     return p.parse_args()
 
 
@@ -74,6 +76,10 @@ def train_student_ce(
         student_model.parameters(),
         lr=lr,
         weight_decay=weight_decay,
+        betas=(
+            cfg.get("adam_beta1", 0.9) if cfg is not None else 0.9,
+            cfg.get("adam_beta2", 0.999) if cfg is not None else 0.999,
+        ),
     )
     criterion = nn.CrossEntropyLoss(label_smoothing=label_smoothing)
 

--- a/tests/test_argparse_adam_beta.py
+++ b/tests/test_argparse_adam_beta.py
@@ -1,0 +1,29 @@
+import ast
+import sys
+
+# Extract parse_args function without importing full dependencies
+with open('main.py', 'r') as f:
+    src = f.read()
+mod = ast.parse(src)
+parse_src = None
+for node in mod.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'parse_args':
+        parse_src = ast.get_source_segment(src, node)
+        break
+import argparse
+
+namespace = {'argparse': argparse}
+exec(parse_src, namespace)
+parse_args = namespace['parse_args']
+
+def test_adam_beta_parse(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog', '--adam_beta1', '0.8', '--adam_beta2', '0.95'])
+    args = parse_args()
+    assert args.adam_beta1 == 0.8
+    assert args.adam_beta2 == 0.95
+
+def test_adam_beta_default(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog'])
+    args = parse_args()
+    assert args.adam_beta1 is None
+    assert args.adam_beta2 is None


### PR DESCRIPTION
## Summary
- support `--adam_beta1` and `--adam_beta2` CLI arguments in main
- propagate betas into optimizer setups
- expose same CLI options in training scripts
- handle betas inside distillation and finetuning modules
- test CLI parsing for the new arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f215b2e88321be726214b0b91064