### PR TITLE
Add RKD loss integration

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -119,6 +119,7 @@ cutmix_alpha_distill: 0.0
 feat_kd_alpha: 1.0
 feat_kd_key: "feat_2d"
 feat_kd_norm: "none"
+rkd_loss_weight: 0.0
 
 # --- Disagreement weighting ---
 use_disagree_weight: false

--- a/tests/test_rkd_loss.py
+++ b/tests/test_rkd_loss.py
@@ -1,0 +1,33 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.losses import rkd_distance_loss, rkd_angle_loss
+
+
+def test_rkd_distance_zero_when_relative_same():
+    s = torch.tensor([[0.0, 0.0], [1.0, 0.0]], dtype=torch.float32)
+    t = torch.tensor([[2.0, 1.0], [3.0, 1.0]], dtype=torch.float32)
+    loss = rkd_distance_loss(s, t)
+    assert loss.item() == pytest.approx(0.0)
+
+
+def test_rkd_distance_nonzero():
+    s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [3.0, 0.0]], dtype=torch.float32)
+    t = torch.tensor([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]], dtype=torch.float32)
+    loss = rkd_distance_loss(s, t)
+    assert loss.item() > 0
+
+
+def test_rkd_angle_zero_when_same():
+    s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+    t = torch.tensor([[2.0, 2.0], [3.0, 2.0], [2.0, 3.0]], dtype=torch.float32)
+    loss = rkd_angle_loss(s, t)
+    assert loss.item() == pytest.approx(0.0)
+
+
+def test_rkd_angle_nonzero():
+    s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
+    t = torch.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+    loss = rkd_angle_loss(s, t)
+    assert loss.item() > 0


### PR DESCRIPTION
## Summary
- implement `rkd_distance_loss` and `rkd_angle_loss`
- integrate RKD into ASMB student update
- expose `rkd_loss_weight` hyperparameter
- add unit tests for RKD losses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68620c741d7c832195b52f889f8d0ec3