### PR TITLE
Fix module imports for scripts

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -9,8 +9,11 @@ Usage:
 All fine-tuning options live in `configs/hparams.yaml`.
 """
 
-import argparse
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
 import copy
 import torch
 import yaml

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 # scripts/run_single_teacher.py
 """Single-teacher KD runner."""
-import argparse
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
 import yaml
 import torch
 from utils.misc import set_random_seed, check_label_range

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 # scripts/train_student_baseline.py
 """Train a student model with cross-entropy only."""
-import argparse
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
 import copy
 import torch
 import torch.nn as nn


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in training scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862160055a48321aa87d8d1a9eb3a76