### PR TITLE
Remove obsolete teacher type defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,6 @@ Alternatively edit the YAML file used by `scripts/fine_tuning.py`:
 
 ```yaml
 # configs/hparams.yaml
-default_teacher_type: resnet152
 finetune_epochs: 100
 finetune_lr: 0.0005
 finetune_use_cutmix: false

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -20,16 +20,11 @@ small_input: true
 # ===============================================================
 # For ASMB Multi-Teacher
 # Available teacher architectures: resnet101, resnet152, efficientnet_b2, swin_tiny
-teacher1_type: "resnet152"         # default first teacher model type
-teacher2_type: "efficientnet_b2"   # default second teacher model type
 # Lists used by run_experiments.sh when looping
-teacher1_type_list: ["resnet152"]
-teacher2_type_list: ["efficientnet_b2", "swin_tiny"]
+teacher1_list: ["resnet152"]
+teacher2_list: ["efficientnet_b2", "swin_tiny"]
 student_list: ["resnet_adapter", "resnet152_adapter"]
 method_list: ["asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"]
-
-# For single-teacher scripts (fine_tuning.py, etc.)
-default_teacher_type: "resnet152"
 
 # Partial-freeze / adapter options
 use_partial_freeze: true

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -75,8 +75,8 @@ run_loop() {
   source <(python scripts/load_hparams.py configs/partial_freeze.yaml)
   
   METHOD_LIST="${method_list:-$method}"
-  T1_LIST="${teacher1_type_list:-$teacher1_type}"
-  T2_LIST="${teacher2_type_list:-$teacher2_type}"
+  T1_LIST="${teacher1_list}"
+  T2_LIST="${teacher2_list}"
   mkdir -p "${OUTPUT_DIR}"
   mkdir -p checkpoints
 
@@ -178,6 +178,10 @@ run_sweep() {
   source <(python scripts/load_hparams.py configs/partial_freeze.yaml)
   echo ">>> [run_experiments.sh] running METHOD=${METHOD}"
 
+  # Use the first entry from the teacher lists for sweeps
+  local T1="${teacher1_list%% *}"
+  local T2="${teacher2_list%% *}"
+
   for teacher_lr in 0.0001 0.0002 0.0005; do
     for sc_alpha in 0.2 0.3 0.5; do
       echo "=========================================="
@@ -189,6 +193,8 @@ run_sweep() {
 
       python main.py \
         --config "${CFG_TMP}" \
+        --teacher1_type "${T1}" \
+        --teacher2_type "${T2}" \
         --synergy_ce_alpha ${sc_alpha} \
         --device ${device} \
         --finetune_epochs 0 \


### PR DESCRIPTION
## Summary
- clean up teacher type fields in `configs/hparams.yaml`
- update `run_experiments.sh` to use new list variables
- pass teacher types during sweeps
- drop `default_teacher_type` reference from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621a8f40848321b21d1e7cee676410