### PR TITLE
Fix Swin wrapper shape handling

### DIFF
--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -53,8 +53,13 @@ class TeacherSwinWrapper(nn.Module):
             f2d = f4d
             feat_4d = f2d.unsqueeze(-1).unsqueeze(-1)
         elif f4d.dim() == 3:
-            # Swin Tiny from timm sometimes returns [N, seq_len, C]
-            f2d = f4d.mean(dim=1)
+            # Swin Tiny from timm may return [N, seq_len, C] or [N, C, seq_len]
+            if f4d.shape[1] == self.feat_dim:
+                # [N, C, seq_len] => average over sequence dimension
+                f2d = f4d.mean(dim=2)
+            else:
+                # [N, seq_len, C] => average over sequence dimension
+                f2d = f4d.mean(dim=1)
             feat_4d = f2d.unsqueeze(-1).unsqueeze(-1)
         else:
             # standard 4D [N, C, H, W]

--- a/tests/test_teacher_swin_wrapper.py
+++ b/tests/test_teacher_swin_wrapper.py
@@ -36,6 +36,16 @@ class Dummy3DBackbone(torch.nn.Module):
         return x.view(b, -1, 1)
 
 
+class Dummy3DBackboneChannelFirst(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.head = torch.nn.Linear(1, 2)
+
+    def forward_features(self, x):
+        b, c, h, w = x.shape
+        return x.view(b, 1, -1)
+
+
 def test_forward_outputs_feature_keys():
     backbone = DummyBackbone()
     wrapper = TeacherSwinWrapper(backbone)
@@ -68,6 +78,18 @@ def test_forward_accepts_3d_output():
     out = wrapper(x)
 
     expected_f2d = x.view(2, -1, 1).mean(dim=1)
+    assert torch.allclose(out["feat_2d"], expected_f2d)
+    assert out["feat_4d"].shape == (*expected_f2d.shape, 1, 1)
+
+
+def test_forward_accepts_3d_channel_first_output():
+    backbone = Dummy3DBackboneChannelFirst()
+    wrapper = TeacherSwinWrapper(backbone)
+    x = torch.randn(2, 1, 2, 2)
+
+    out = wrapper(x)
+
+    expected_f2d = x.view(2, 1, -1).mean(dim=2)
     assert torch.allclose(out["feat_2d"], expected_f2d)
     assert out["feat_4d"].shape == (*expected_f2d.shape, 1, 1)
 


### PR DESCRIPTION
## Summary
- handle `[N, C, seq_len]` feature shape in `TeacherSwinWrapper`
- add unit test covering channel-first 3D features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68621f149de483219ad0aa9b9db8236c