### PR TITLE
Fix fine-tune checks and distillation adapter defaults

### DIFF
--- a/models/teachers/adapters.py
+++ b/models/teachers/adapters.py
@@ -16,9 +16,10 @@ class DistillationAdapter(nn.Module):
         if cfg is not None:
             hidden_dim = cfg.get("distill_hidden_dim", hidden_dim)
             out_dim = cfg.get("distill_out_dim", out_dim)
-        if hidden_dim is None:
+        # allow 0 or None to trigger automatic dimension selection
+        if not hidden_dim:
             hidden_dim = max(1, in_dim // 2)
-        if out_dim is None:
+        if not out_dim:
             out_dim = max(1, in_dim // 4)
         self.mlp = nn.Sequential(
             nn.Linear(in_dim, hidden_dim),

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -27,8 +27,11 @@ class TeacherEfficientNetWrapper(nn.Module):
         self.feat_channels = 1408
 
         # distillation adapter
+        cfg = cfg or {}
+        hidden_dim = cfg.get("distill_hidden_dim")
+        out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, cfg=cfg
+            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
         )
         self.distill_dim = self.distillation_adapter.out_dim
     

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -32,8 +32,11 @@ class TeacherResNetWrapper(nn.Module):
         self.feat_channels = 2048
 
         # distillation adapter
+        cfg = cfg or {}
+        hidden_dim = cfg.get("distill_hidden_dim")
+        out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, cfg=cfg
+            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
         )
         self.distill_dim = self.distillation_adapter.out_dim
     

--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -28,8 +28,11 @@ class TeacherSwinWrapper(nn.Module):
         self.feat_channels = self.feat_dim
 
         # distillation adapter
+        cfg = cfg or {}
+        hidden_dim = cfg.get("distill_hidden_dim")
+        out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, cfg=cfg
+            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
         )
         self.distill_dim = self.distillation_adapter.out_dim
 

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -90,7 +90,8 @@ run_loop() {
           for T in "$T1" "$T2"; do
         mkdir -p checkpoints # Ensure global checkpoint dir exists
         CKPT="checkpoints/${T}_ft.pth"
-        if [ ! -f "${CKPT}" ]; then
+        # Only fine-tune when epochs>0 and checkpoint doesn't already exist
+        if [ ${finetune_epochs} -gt 0 ] && [ ! -f "${CKPT}" ]; then
         echo ">>> [run_experiments.sh] fine-tuning teacher=${T}  (epochs=${finetune_epochs}, lr=${finetune_lr})"
         python scripts/fine_tuning.py \
           --teacher_type "${T}" \
@@ -102,7 +103,7 @@ run_loop() {
           --finetune_cutmix_alpha ${finetune_cutmix_alpha} \
           --finetune_ckpt_path "${CKPT}" \
           --data_aug ${data_aug}
-          fi
+        fi
         done
 
         # 2) ASMB multi-stage distillation


### PR DESCRIPTION
## Summary
- avoid running `fine_tuning.py` when `finetune_epochs` is 0
- allow zero config values for teacher distillation adapters
- pass hidden/out dims from config in teacher wrappers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862223ffd748321b6a533508970a64b