### PR TITLE
Preserve teacher modes in compute_disagreement_rate

### DIFF
--- a/modules/disagreement.py
+++ b/modules/disagreement.py
@@ -44,6 +44,10 @@ def compute_disagreement_rate(
     float
         Disagreement rate in ``[0, 100]``.
     """
+    # record current training modes to restore them later
+    teacher1_train_state = teacher1.training
+    teacher2_train_state = teacher2.training
+
     teacher1.eval()
     teacher2.eval()
     total_samples = 0
@@ -72,6 +76,11 @@ def compute_disagreement_rate(
         total_samples += y.size(0)
 
     dis_rate = 100.0 * disagree_count / total_samples if total_samples > 0 else 0.0
+
+    # restore original training modes
+    teacher1.train(teacher1_train_state)
+    teacher2.train(teacher2_train_state)
+
     return dis_rate
 
 

--- a/tests/test_compute_disagreement_rate.py
+++ b/tests/test_compute_disagreement_rate.py
@@ -9,8 +9,10 @@ class ConstTeacher(torch.nn.Module):
     def __init__(self, logits):
         super().__init__()
         self.logits = torch.tensor(logits, dtype=torch.float32)
+        self.record_training = None
 
     def forward(self, x):
+        self.record_training = self.training
         b = x.size(0)
         return {"logit": self.logits.expand(b, -1)}
 
@@ -35,3 +37,31 @@ def test_disagreement_rate_pred_and_both_wrong():
 
     assert pred_rate == pytest.approx(100.0)
     assert both_wrong_rate == pytest.approx(50.0)
+
+
+def test_disagreement_rate_preserves_training_state():
+    t1 = ConstTeacher([[2.0, 0.0, 0.0]])
+    t2 = ConstTeacher([[0.0, 2.0, 0.0]])
+    loader = get_loader()
+
+    # teachers start in train mode
+    t1.train()
+    t2.train()
+
+    compute_disagreement_rate(t1, t2, loader, device="cpu")
+
+    assert t1.record_training is False
+    assert t2.record_training is False
+    assert t1.training
+    assert t2.training
+
+    # teachers start in eval mode
+    t1.eval()
+    t2.eval()
+
+    compute_disagreement_rate(t1, t2, loader, device="cpu")
+
+    assert t1.record_training is False
+    assert t2.record_training is False
+    assert not t1.training
+    assert not t2.training


### PR DESCRIPTION
## Summary
- keep track of teacher training states inside `compute_disagreement_rate`
- restore both teachers to their original mode after measuring disagreement
- extend the disagreement rate test suite to verify state restoration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622b77e25883219afc9a1c42cfdee4