### PR TITLE
Add CLI args to compare_ablation script

### DIFF
--- a/analysis/compare_ablation.py
+++ b/analysis/compare_ablation.py
@@ -3,16 +3,45 @@
 """
 analysis/compare_ablation.py
 
-Example script to compare ablation results from multiple CSV files,
-and produce a summary table or stats.
+Example script to compare ablation results from a CSV file and
+produce a summary table or stats. The input path defaults to
+``results/summary.csv`` and the output is written to
+``results/ablation_summary.csv``.
+
+Usage::
+
+    python analysis/compare_ablation.py \
+        --summary_csv results/summary.csv \
+        --out_path results/ablation_summary.csv
 """
 
 import os
+import argparse
 import pandas as pd
 
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Aggregate ablation results from a CSV file"
+    )
+    parser.add_argument(
+        "--summary_csv",
+        type=str,
+        default="results/summary.csv",
+        help="Path to input summary CSV",
+    )
+    parser.add_argument(
+        "--out_path",
+        type=str,
+        default="results/ablation_summary.csv",
+        help="Where to save the aggregated summary",
+    )
+    return parser.parse_args()
+
 def main():
+    args = parse_args()
     # 예: results/summary.csv 에는 여러 파라미터/성과가 정리돼 있다고 가정
-    summary_path = "results/summary.csv"
+    summary_path = args.summary_csv
     if not os.path.exists(summary_path):
         print(f"[Error] summary.csv not found at {summary_path}")
         return
@@ -29,7 +58,7 @@ def main():
     print("== Ablation Summary: By Method & LR & synergy_ce_alpha ==\n")
     print(agg_result)
 
-    out_path = "results/ablation_summary.csv"
+    out_path = args.out_path
     agg_result.to_csv(out_path, index=False)
     print(f"[Info] ablation summary saved to {out_path}")
 


### PR DESCRIPTION
## Summary
- make `analysis/compare_ablation.py` accept input/output CSV paths via argparse
- document new usage in the header comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622b7ebabc83218cdb3a2566649f16