### PR TITLE
Fix ExperimentLogger finalize dir creation

### DIFF
--- a/tests/test_experiment_logger_finalize.py
+++ b/tests/test_experiment_logger_finalize.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import json
+import csv
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from utils.logger import ExperimentLogger
+
+
+def test_finalize_creates_missing_dir(tmp_path):
+    results_dir = tmp_path / "nested" / "results"
+    cfg = {"results_dir": str(results_dir), "eval_mode": "test"}
+    logger = ExperimentLogger(cfg)
+    logger.update_metric("train_acc", 0.0)
+    logger.finalize()
+
+    json_path = results_dir / "summary.json"
+    csv_path = results_dir / "summary.csv"
+
+    assert json_path.is_file()
+    assert csv_path.is_file()
+
+    # sanity check that files are readable
+    with open(json_path) as f:
+        data = json.load(f)
+        assert data["exp_id"]
+
+    with open(csv_path) as f:
+        rows = list(csv.reader(f))
+        assert len(rows) >= 2

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -106,6 +106,10 @@ class ExperimentLogger:
         total_time = time.time() - self.start_time
         self.config["total_time_sec"] = total_time
 
+
+        # Ensure results directory exists
+        os.makedirs(self.results_dir, exist_ok=True)
+
         # 2) JSON file path (fixed name within results_dir)
         json_path = os.path.join(self.results_dir, "summary.json")
 


### PR DESCRIPTION
## Summary
- ensure ExperimentLogger creates the results directory before writing files
- add regression test for finalizing when results dir is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622b844ae0832183b1f3e676f325b9