### PR TITLE
Remove unused import

### DIFF
--- a/models/students/student_resnet_adapter.py
+++ b/models/students/student_resnet_adapter.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torchvision.models import resnet101, ResNet101_Weights
 
 class ExtendedAdapterResNet101(nn.Module):


### PR DESCRIPTION
## Summary
- clean up ResNet adapter by removing an unused `torch.nn.functional` import

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622f9bab4c8321a47ef60b3ab6eb91