### PR TITLE
Add config support to distillers

### DIFF
--- a/methods/at.py
+++ b/methods/at.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from typing import Optional
 from modules.losses import ce_loss_fn
 
 def single_layer_at_loss(f_s, f_t, p=2):
@@ -44,8 +45,16 @@ class ATDistiller(nn.Module):
     3) at_loss_dict(...) => single_layer_at_loss
     4) total_loss = CE + alpha*AT
     """
-    def __init__(self, teacher_model, student_model, alpha=1.0, p=2,
-                 layer_key="feat_4d_layer3", label_smoothing: float = 0.0):
+    def __init__(
+        self,
+        teacher_model,
+        student_model,
+        alpha=1.0,
+        p=2,
+        layer_key="feat_4d_layer3",
+        label_smoothing: float = 0.0,
+        config: Optional[dict] = None,
+    ):
         super().__init__()
         self.teacher = teacher_model
         self.student = student_model
@@ -53,6 +62,7 @@ class ATDistiller(nn.Module):
         self.p = p
         self.layer_key = layer_key
         self.label_smoothing = label_smoothing
+        self.cfg = config if config is not None else {}
 
     def forward(self, x, y):
         # 1) teacher

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+from typing import Optional
 from modules.losses import kd_loss_fn, ce_loss_fn
 
 class CRDLoss(nn.Module):
@@ -41,8 +42,16 @@ class CRDDistiller(nn.Module):
       - CE = cross entropy with s_logit
       - total_loss = alpha * CRD + (1 - alpha) * CE
     """
-    def __init__(self, teacher_model, student_model, feat_key="feat_2d",
-                 alpha=0.5, temperature=0.07, label_smoothing: float = 0.0):
+    def __init__(
+        self,
+        teacher_model,
+        student_model,
+        feat_key="feat_2d",
+        alpha=0.5,
+        temperature=0.07,
+        label_smoothing: float = 0.0,
+        config: Optional[dict] = None,
+    ):
         super().__init__()
         self.teacher = teacher_model
         self.student = student_model
@@ -50,6 +59,7 @@ class CRDDistiller(nn.Module):
         self.alpha = alpha
         self.crd_loss_fn = CRDLoss(temperature=temperature)
         self.label_smoothing = label_smoothing
+        self.cfg = config if config is not None else {}
 
         s_dim = student_model.get_feat_dim()
         t_dim = teacher_model.get_feat_dim()

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+from typing import Optional
 from modules.losses import ce_loss_fn, dkd_loss
 
 class DKDDistiller(nn.Module):
@@ -14,15 +15,18 @@ class DKDDistiller(nn.Module):
       student(x)->(s_dict, s_logit, _)
     => total_loss = CE + warmup_factor * DKD
     """
-    def __init__(self, 
-                 teacher_model, 
-                 student_model,
-                 ce_weight=1.0,
-                 alpha=1.0,
-                 beta=1.0,
-                 temperature=4.0,
-                 warmup=5,
-                 label_smoothing: float = 0.0):
+    def __init__(
+        self,
+        teacher_model,
+        student_model,
+        ce_weight=1.0,
+        alpha=1.0,
+        beta=1.0,
+        temperature=4.0,
+        warmup=5,
+        label_smoothing: float = 0.0,
+        config: Optional[dict] = None,
+    ):
         """
         Args:
           ce_weight: CE 손실 가중치
@@ -39,6 +43,7 @@ class DKDDistiller(nn.Module):
         self.temperature = temperature
         self.warmup = warmup
         self.label_smoothing = label_smoothing
+        self.cfg = config if config is not None else {}
 
     def forward(self, x, y, epoch=1):
         """

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+from typing import Optional
 from modules.losses import ce_loss_fn
 
 class FitNetDistiller(nn.Module):
@@ -25,6 +26,7 @@ class FitNetDistiller(nn.Module):
         alpha_hint=1.0,
         alpha_ce=1.0,
         label_smoothing: float = 0.0,
+        config: Optional[dict] = None,
     ):
         super().__init__()
         self.teacher = teacher_model
@@ -37,6 +39,7 @@ class FitNetDistiller(nn.Module):
         self.alpha_hint = alpha_hint
         self.alpha_ce = alpha_ce
         self.label_smoothing = label_smoothing
+        self.cfg = config if config is not None else {}
 
         # 학생 특징맵을 스승 특징맵 채널로 변환하는 1x1 convolution
         self.regressor = nn.Conv2d(s_channels, t_channels, kernel_size=1)

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -78,13 +78,19 @@ def build_distiller(method, teacher, student, cfg):
         # (Teacher: EfficientNet-B2, Student: ResNet-Adapter, layer2 기준)
         s_channels = 512
         t_channels = 88  # EfficientNet-B2의 'feat_4d_layer2' 출력 채널 수
-        return cls(teacher, student, s_channels=s_channels, t_channels=t_channels)
+        return cls(
+            teacher,
+            student,
+            s_channels=s_channels,
+            t_channels=t_channels,
+            config=cfg,
+        )
     if method == "dkd":
-        return cls(teacher, student)
+        return cls(teacher, student, config=cfg)
     if method == "at":
-        return cls(teacher, student)
+        return cls(teacher, student, config=cfg)
     if method == "crd":
-        return cls(teacher, student)
+        return cls(teacher, student, config=cfg)
     raise ValueError(method)
 
 


### PR DESCRIPTION
## Summary
- make ATDistiller, FitNetDistiller, DKDDistiller and CRDDistiller accept an optional `config` argument
- save provided config in `self.cfg` for these classes
- pass `config=cfg` when constructing the distiller in `run_single_teacher.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862584228b08321885a249e977f7b8a