### PR TITLE
Fix RKD zero distance edge case

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -112,8 +112,18 @@ def rkd_distance_loss(student_feat, teacher_feat, eps: float = 1e-12):
     dist_s = diff_s.pow(2).sum(dim=2).sqrt()
     dist_t = diff_t.pow(2).sum(dim=2).sqrt()
 
-    mean_s = dist_s[dist_s > 0].mean()
-    mean_t = dist_t[dist_t > 0].mean()
+    pos_s = dist_s > 0
+    pos_t = dist_t > 0
+
+    if pos_s.any():
+        mean_s = dist_s[pos_s].mean()
+    else:
+        mean_s = dist_s.new_tensor(1.0)
+
+    if pos_t.any():
+        mean_t = dist_t[pos_t].mean()
+    else:
+        mean_t = dist_t.new_tensor(1.0)
 
     dist_s = dist_s / (mean_s + eps)
     dist_t = dist_t / (mean_t + eps)

--- a/tests/test_rkd_loss.py
+++ b/tests/test_rkd_loss.py
@@ -12,6 +12,14 @@ def test_rkd_distance_zero_when_relative_same():
     assert loss.item() == pytest.approx(0.0)
 
 
+def test_rkd_distance_zero_when_identical():
+    s = torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float32)
+    t = torch.tensor([[2.0, 2.0], [2.0, 2.0]], dtype=torch.float32)
+    loss = rkd_distance_loss(s, t)
+    assert torch.isfinite(loss)
+    assert loss.item() == pytest.approx(0.0)
+
+
 def test_rkd_distance_nonzero():
     s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [3.0, 0.0]], dtype=torch.float32)
     t = torch.tensor([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]], dtype=torch.float32)


### PR DESCRIPTION
## Summary
- handle cases where no positive pairwise distances exist in RKD distance loss
- ensure identical features yield finite zero loss
- test that the distance loss is finite when student and teacher features match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625b0acf408321aa9899b6d081f6f9