### PR TITLE
Fix indentation in checkpoint loading

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -182,10 +182,10 @@ def main():
             ckpt = torch.load(
                 cfg["ckpt_path"], map_location=device, weights_only=True
             )
-                if "model_state" in ckpt:
-                    model.load_state_dict(ckpt["model_state"], strict=False)
-                else:
-                    model.load_state_dict(ckpt, strict=False)
+            if "model_state" in ckpt:
+                model.load_state_dict(ckpt["model_state"], strict=False)
+            else:
+                model.load_state_dict(ckpt, strict=False)
             print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")


### PR DESCRIPTION
## Summary
- ensure eval.py loads single model checkpoints without indentation errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625bd5d8ac832185d5b012f14876bf