### PR TITLE
Add ImageNet100 support for eval.py

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,7 +1,8 @@
 # eval.py
 """
-Evaluates either a single model or a synergy model (Teacher1+2 + MBM + synergy head),
+Evaluates either a single model or a synergy model (Teacher1+2 + MBM + synergy head)
 and logs the results (train_acc, test_acc, etc.) using ExperimentLogger.
+Supports evaluation on the CIFAR-100 and ImageNet-100 datasets.
 """
 
 import argparse
@@ -11,6 +12,7 @@ import torch.nn as nn
 import os
 
 from data.cifar100 import get_cifar100_loaders
+from data.imagenet100 import get_imagenet100_loaders
 from models.mbm import ManifoldBridgingModule, SynergyHead, build_from_teachers
 from models.la_mbm import LightweightAttnMBM
 from utils.logger import ExperimentLogger
@@ -158,12 +160,18 @@ def main():
     logger.update_metric("mbm_n_head", cfg.get("mbm_n_head"))
     logger.update_metric("mbm_learnable_q", cfg.get("mbm_learnable_q"))
 
-    # 4) Data
+    # 4) Data (CIFAR-100 or ImageNet-100)
     dataset_name = cfg.get("dataset_name", "cifar100")
-    train_loader, test_loader = get_cifar100_loaders(
-        batch_size=cfg["batch_size"],
-        num_workers=cfg.get("num_workers", 2),
-    )
+    if dataset_name == "imagenet100":
+        train_loader, test_loader = get_imagenet100_loaders(
+            batch_size=cfg["batch_size"],
+            num_workers=cfg.get("num_workers", 2),
+        )
+    else:
+        train_loader, test_loader = get_cifar100_loaders(
+            batch_size=cfg["batch_size"],
+            num_workers=cfg.get("num_workers", 2),
+        )
     device = cfg["device"]
     small_input = cfg.get("small_input")
     if small_input is None:


### PR DESCRIPTION
## Summary
- enable using ImageNet‑100 loaders in `eval.py`
- default `small_input` based on dataset
- document supported datasets in `eval.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625d5514e08321aead89287a04c943