### PR TITLE
Fix ckpt block indentation

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -190,11 +190,11 @@ def main():
             ckpt = torch.load(
                 cfg["ckpt_path"], map_location=device, weights_only=True
             )
-            if "model_state" in ckpt:
-                model.load_state_dict(ckpt["model_state"], strict=False)
-            else:
-                model.load_state_dict(ckpt, strict=False)
-            print(f"[Eval single] loaded from {cfg['ckpt_path']}")
+        if "model_state" in ckpt:
+            model.load_state_dict(ckpt["model_state"], strict=False)
+        else:
+            model.load_state_dict(ckpt, strict=False)
+        print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
 


### PR DESCRIPTION
## Summary
- adjust the `if "model_state" in ckpt` block so its indentation matches the surrounding `if cfg["ckpt_path"]` clause

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68625ddadec883218e7e33ccab67c067