### PR TITLE
Add label range validation in CutMix

### DIFF
--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -56,6 +56,14 @@ def train_one_epoch_cutmix(
         with autocast_ctx:
             out = teacher_model(x_cm)  # we only need `logits` for classification
             logits = out["logit"]
+            num_classes = logits.size(1)
+            min_label = int(torch.cat((y_a, y_b)).min())
+            max_label = int(torch.cat((y_a, y_b)).max())
+            if min_label < 0 or max_label >= num_classes:
+                raise ValueError(
+                    f"CutMix labels must be within [0, {num_classes - 1}], "
+                    f"got min={min_label}, max={max_label}"
+                )
             loss = cutmix_criterion(criterion, logits, y_a, y_b, lam)
 
         # 4) backward

--- a/tests/test_train_one_epoch_cutmix_label_range.py
+++ b/tests/test_train_one_epoch_cutmix_label_range.py
@@ -1,0 +1,27 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.cutmix_finetune_teacher import train_one_epoch_cutmix
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(3, 2)
+
+    def forward(self, x):
+        if x.dim() == 4:
+            x = x.mean(dim=(2, 3))
+        return {"logit": self.fc(x)}
+
+
+def test_train_one_epoch_cutmix_label_range():
+    model = DummyModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    x = torch.randn(1, 3, 4, 4)
+    y = torch.tensor([2])  # out of range for 2 classes
+    loader = [(x, y)]
+    with pytest.raises(ValueError, match="min=2, max=2"):
+        train_one_epoch_cutmix(model, loader, optimizer, alpha=0.0, device="cpu")
+


### PR DESCRIPTION
## Summary
- check that CutMix labels stay within model class range
- raise descriptive `ValueError` when labels are invalid
- test label range validation in `train_one_epoch_cutmix`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686269de44c0832192173c9fecef69e1