### PR TITLE
Improve teacher/dataset class mismatch detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ import torch.optim as optim
 from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR
 
 from utils.logger import ExperimentLogger
-from utils.misc import set_random_seed, check_label_range
+from utils.misc import set_random_seed, check_label_range, get_model_num_classes
 from modules.disagreement import compute_disagreement_rate
 from modules.trainer_teacher import teacher_adaptive_update
 from modules.trainer_student import student_distillation_update
@@ -369,6 +369,11 @@ def main():
         small_input=small_input,
         cfg=cfg,
     ).to(device)
+    model_classes = get_model_num_classes(teacher1)
+    if model_classes != num_classes:
+        raise ValueError(
+            f"Teacher1 head expects {model_classes} classes but dataset provides {num_classes}"
+        )
 
     if os.path.exists(teacher1_ckpt_path):
         teacher1.load_state_dict(
@@ -396,6 +401,11 @@ def main():
         small_input=small_input,
         cfg=cfg,
     ).to(device)
+    model_classes = get_model_num_classes(teacher2)
+    if model_classes != num_classes:
+        raise ValueError(
+            f"Teacher2 head expects {model_classes} classes but dataset provides {num_classes}"
+        )
 
     if os.path.exists(teacher2_ckpt_path):
         teacher2.load_state_dict(

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -19,7 +19,7 @@ import torch
 import yaml
 from typing import Optional
 
-from utils.misc import set_random_seed, check_label_range
+from utils.misc import set_random_seed, check_label_range, get_model_num_classes
 
 # data loaders
 from data.cifar100 import get_cifar100_loaders
@@ -274,6 +274,12 @@ def main():
         dropout_p=cfg.get("efficientnet_dropout", 0.3),
         cfg=cfg,
     ).to(device)
+
+    model_classes = get_model_num_classes(teacher_model)
+    if model_classes != num_classes:
+        raise ValueError(
+            f"Teacher head expects {model_classes} classes but dataset provides {num_classes}"
+        )
 
     # optional load ckpt
     if cfg.get("finetune_ckpt_path") and os.path.isfile(cfg["finetune_ckpt_path"]):

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import argparse
 import yaml
 import torch
-from utils.misc import set_random_seed, check_label_range
+from utils.misc import set_random_seed, check_label_range, get_model_num_classes
 from data.cifar100 import get_cifar100_loaders
 from data.imagenet100 import get_imagenet100_loaders
 from main import (
@@ -149,6 +149,11 @@ def main():
         num_classes=num_classes,
         cfg=cfg,
     ).to(device)
+    model_classes = get_model_num_classes(teacher)
+    if model_classes != num_classes:
+        raise ValueError(
+            f"Teacher head expects {model_classes} classes but dataset provides {num_classes}"
+        )
     if os.path.exists(teacher_ckpt_path):
         teacher.load_state_dict(
             torch.load(teacher_ckpt_path, map_location=device, weights_only=True),

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -185,3 +185,21 @@ def check_label_range(dataset, num_classes: int) -> None:
             f"Dataset labels must be within [0, {num_classes - 1}], "
             f"got min={min_label}, max={max_label}"
         )
+
+
+def get_model_num_classes(model):
+    """Return the classifier output dimension for a variety of models."""
+    module = getattr(model, "backbone", model)
+    if hasattr(module, "fc"):
+        return module.fc.out_features
+    if hasattr(module, "classifier"):
+        cls = module.classifier
+        if isinstance(cls, torch.nn.Linear):
+            return cls.out_features
+        if isinstance(cls, torch.nn.Sequential):
+            for layer in reversed(cls):
+                if isinstance(layer, torch.nn.Linear):
+                    return layer.out_features
+    if hasattr(module, "head"):
+        return module.head.out_features
+    raise AttributeError("Unable to infer num_classes from model")


### PR DESCRIPTION
## Summary
- add `get_model_num_classes` helper
- verify teacher output dimensions against dataset labels in training scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626ae22f3c8321a99ac0b8af676fed