### PR TITLE
Fix CutMix label range check

### DIFF
--- a/tests/test_train_one_epoch_cutmix_label_range.py
+++ b/tests/test_train_one_epoch_cutmix_label_range.py
@@ -23,5 +23,12 @@ def test_train_one_epoch_cutmix_label_range():
     y = torch.tensor([2])  # out of range for 2 classes
     loader = [(x, y)]
     with pytest.raises(ValueError, match="min=2, max=2"):
-        train_one_epoch_cutmix(model, loader, optimizer, alpha=0.0, device="cpu")
+        train_one_epoch_cutmix(
+            model,
+            loader,
+            optimizer,
+            alpha=0.0,
+            device="cpu",
+            num_classes=2,
+        )
 


### PR DESCRIPTION
## Summary
- add optional `num_classes` parameter to `train_one_epoch_cutmix`
- use dataset classes as ground truth in `finetune_teacher_cutmix`
- update tests

## Testing
- `python -m py_compile modules/cutmix_finetune_teacher.py tests/test_train_one_epoch_cutmix_label_range.py`

------
https://chatgpt.com/codex/tasks/task_e_68626c31d3a083218d40217f1846945e