### PR TITLE
Add dataset label check in CutMix training

### DIFF
--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -8,7 +8,7 @@ import torch.optim as optim
 from typing import Optional
 from utils.progress import smart_tqdm
 
-from utils.misc import cutmix_data, get_amp_components
+from utils.misc import cutmix_data, get_amp_components, check_label_range
 
 
 def cutmix_criterion(criterion, pred, y_a, y_b, lam):
@@ -50,6 +50,11 @@ def train_one_epoch_cutmix(
 
     for batch_idx, (x, y) in enumerate(smart_tqdm(loader, desc="[CutMix Train]")):
         x, y = x.to(device), y.to(device)
+
+        if num_classes is not None:
+            _batch_ds = type("BatchDataset", (), {})()
+            _batch_ds.targets = y
+            check_label_range(_batch_ds, num_classes)
 
         # 1) cutmix
         x_cm, y_a, y_b, lam = cutmix_data(x, y, alpha=alpha)

--- a/tests/test_train_one_epoch_cutmix_label_range.py
+++ b/tests/test_train_one_epoch_cutmix_label_range.py
@@ -22,7 +22,7 @@ def test_train_one_epoch_cutmix_label_range():
     x = torch.randn(1, 3, 4, 4)
     y = torch.tensor([2])  # out of range for 2 classes
     loader = [(x, y)]
-    with pytest.raises(ValueError, match="min=2, max=2"):
+    with pytest.raises(ValueError, match=r"Dataset labels must be within.*min=2, max=2"):
         train_one_epoch_cutmix(
             model,
             loader,


### PR DESCRIPTION
## Summary
- verify batch labels fall inside `[0, num_classes-1]` at the start of CutMix training
- adapt unit test to expect the dataset label check message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686271c52284832191317fa9c547edbc