### PR TITLE
Fix README Swin wrapper description

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,9 +351,10 @@ Swin) to expect 32×32 inputs.
 
 Fine-tune the individual teachers before running the distillation stages.
 All fine-tuning options live in `configs/hparams.yaml`.
-The bundled `TeacherSwinWrapper` accepts a Swin backbone that implements
-either a `forward_features` or `features` method to produce the intermediate
-feature map.
+The bundled `TeacherSwinWrapper` expects the Swin backbone to call
+`features`, `norm`, `permute`, `avgpool` and `flatten` in sequence when
+producing its feature map. This mirrors torchvision's official
+`SwinTransformer` forward path.
 Adjust the parameters in `configs/hparams.yaml`:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify how TeacherSwinWrapper uses a Swin backbone
- mention the forward sequence matches torchvision

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686278f3f2d08321831274df606c0830