### PR TITLE
Apply weights_only loading

### DIFF
--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -221,7 +221,9 @@ def finetune_teacher_cutmix(
 
     print(f"[CutMix] Fine-tune done => bestAcc={best_acc:.2f}, saved={ckpt_path}")
     # reload the best checkpoint (already saved during training)
-    teacher_model.load_state_dict(torch.load(ckpt_path, map_location=device))
+    teacher_model.load_state_dict(
+        torch.load(ckpt_path, map_location=device, weights_only=True)
+    )
     return teacher_model, best_acc
 
 def standard_ce_finetune(
@@ -295,5 +297,7 @@ def standard_ce_finetune(
         print(f"[CE FineTune|ep={ep}/{epochs}] testAcc={te_acc:.2f}, best={best_acc:.2f}")
 
     print(f"[CEFineTune] done => bestAcc={best_acc:.2f}, saved={ckpt_path}")
-    teacher_model.load_state_dict(torch.load(ckpt_path, map_location=device))
+    teacher_model.load_state_dict(
+        torch.load(ckpt_path, map_location=device, weights_only=True)
+    )
     return teacher_model, best_acc

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -51,7 +51,7 @@ def load_checkpoint(model, optimizer, load_path):
         print(f"[Warning] No checkpoint found at {load_path}")
         return 0  # or -1, indicating failure
 
-    ckpt = torch.load(load_path)
+    ckpt = torch.load(load_path, weights_only=True)
     model.load_state_dict(ckpt["model_state"], strict=False)
     optimizer.load_state_dict(ckpt["optim_state"])
     start_epoch = ckpt["epoch"]


### PR DESCRIPTION
## Summary
- load checkpoints using `weights_only=True` to avoid PyTorch FutureWarning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a1b3335c8321bfefeea2fdcd91e0