### PR TITLE
Improve RKD loss weighting

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -120,7 +120,7 @@ cutmix_alpha_distill: 0.0
 feat_kd_alpha: 1.0
 feat_kd_key: "feat_2d"
 feat_kd_norm: "none"
-rkd_loss_weight: 0.0
+rkd_loss_weight: 1.0
 rkd_gamma: 0.5
 
 # --- Disagreement weighting ---

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -285,7 +285,8 @@ class ASMBDistiller(nn.Module):
                 # synergy
                 if self.la_mode:
                     syn_feat, attn, _, _ = self.mbm(s_feat, f1)
-                    w1, w2 = attn[:, 0], attn[:, 1]
+                    attn_flat = attn.squeeze(1)
+                    w1, w2 = attn_flat[:, 0], attn_flat[:, 1]
                 else:
                     syn_feat = self.mbm(f1, f2)
                     attn = None
@@ -394,7 +395,8 @@ class ASMBDistiller(nn.Module):
 
                 if self.la_mode:
                     syn_feat, attn, _, _ = self.mbm(s_feat, f1)
-                    w1, w2 = attn[:, 0], attn[:, 1]
+                    attn_flat = attn.squeeze(1)
+                    w1, w2 = attn_flat[:, 0], attn_flat[:, 1]
                 else:
                     syn_feat = self.mbm(f1, f2)
                     attn = None
@@ -423,15 +425,15 @@ class ASMBDistiller(nn.Module):
 
                 rkd_val = torch.tensor(0.0, device=s_feat.device)
                 if self.config.get("rkd_loss_weight", 0.0) > 0:
-                    rkd_t1 = rkd_distance_loss(s_feat, t1["feat_2d"].detach())
-                    rkd_t2 = rkd_distance_loss(s_feat, t2["feat_2d"].detach())
-                    rkd_syn = rkd_distance_loss(s_feat, syn_feat.detach())
+                    rkd_t1 = rkd_distance_loss(s_feat, t1["feat_2d"].detach(), reduction="none")
+                    rkd_t2 = rkd_distance_loss(s_feat, t2["feat_2d"].detach(), reduction="none")
+                    rkd_syn = rkd_distance_loss(s_feat, syn_feat.detach(), reduction="none")
                     gamma = self.config.get("rkd_gamma", 0.5)
                     if w1 is not None:
-                        rkd_mix = (w1 * rkd_t1 + w2 * rkd_t2).mean() + gamma * rkd_syn
+                        rkd_mix = (w1 * rkd_t1 + w2 * rkd_t2) + gamma * rkd_syn
                     else:
                         rkd_mix = 0.5 * (rkd_t1 + rkd_t2) + gamma * rkd_syn
-                    rkd_val = rkd_mix
+                    rkd_val = rkd_mix.mean()
 
                 loss_asmb = (
                     self.alpha * ce_val

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -96,8 +96,14 @@ def dkd_loss(student_logits, teacher_logits, labels, alpha=1.0, beta=1.0, temper
     return loss
 
 
-def rkd_distance_loss(student_feat, teacher_feat, eps: float = 1e-12):
-    """Relational KD distance loss."""
+def rkd_distance_loss(student_feat, teacher_feat, eps: float = 1e-12, reduction: str = "mean"):
+    """Relational KD distance loss.
+
+    Parameters
+    ----------
+    reduction : str, optional
+        "mean" to return a scalar or "none" to return per-sample losses.
+    """
     if student_feat.dim() > 2:
         student_feat = student_feat.view(student_feat.size(0), -1)
     if teacher_feat.dim() > 2:
@@ -128,7 +134,9 @@ def rkd_distance_loss(student_feat, teacher_feat, eps: float = 1e-12):
     dist_s = dist_s / (mean_s + eps)
     dist_t = dist_t / (mean_t + eps)
 
-    return F.smooth_l1_loss(dist_s, dist_t)
+    if reduction == "none":
+        return F.smooth_l1_loss(dist_s, dist_t, reduction="none").mean(dim=1)
+    return F.smooth_l1_loss(dist_s, dist_t, reduction=reduction)
 
 
 def rkd_angle_loss(student_feat, teacher_feat, eps: float = 1e-12):

--- a/tests/test_rkd_loss.py
+++ b/tests/test_rkd_loss.py
@@ -27,6 +27,15 @@ def test_rkd_distance_nonzero():
     assert loss.item() > 0
 
 
+def test_rkd_distance_reduction_none_matches_mean():
+    s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]], dtype=torch.float32)
+    t = torch.tensor([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]], dtype=torch.float32)
+    vec = rkd_distance_loss(s, t, reduction="none")
+    scalar = rkd_distance_loss(s, t, reduction="mean")
+    assert vec.shape == (3,)
+    assert vec.mean().item() == pytest.approx(scalar.item())
+
+
 def test_rkd_angle_zero_when_same():
     s = torch.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
     t = torch.tensor([[2.0, 2.0], [3.0, 2.0], [2.0, 3.0]], dtype=torch.float32)


### PR DESCRIPTION
## Summary
- allow `rkd_distance_loss` to return per-sample values
- extract attention weights correctly for LA-MBM
- compute per-sample RKD mix in ASMBDistiller
- enable RKD loss via config
- test the new `reduction="none"` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863960d17148321bb0f267f61167366