### PR TITLE
Add CLI flag for teacher weight decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **MBM Dropout**: set `mbm_dropout` in configs to add dropout within the
   Manifold Bridging Module
 - **Gradient Clipping**: enable by setting `grad_clip_norm` (>0) in configs
+- **Teacher Weight Decay Override**: set `--teacher_weight_decay` to control
+  the Adam weight decay for teacher updates
 - **Learnable MBM Query**: set `mbm_learnable_q: true` to use a global learnable
   token instead of the student feature as attention query
 - **Feature-Level KD**: align student features with the synergy representation.

--- a/main.py
+++ b/main.py
@@ -122,6 +122,7 @@ def parse_args():
     # 편의용 하이퍼파라미터
     parser.add_argument("--batch_size", type=int)
     parser.add_argument("--teacher_lr", type=float)
+    parser.add_argument("--teacher_weight_decay", type=float)
     parser.add_argument("--student_lr", type=float)
     parser.add_argument("--student_epochs_per_stage", type=int)
     parser.add_argument("--epochs",     type=int)            # 예: teacher_iters

--- a/tests/test_argparse_adam_beta.py
+++ b/tests/test_argparse_adam_beta.py
@@ -27,3 +27,13 @@ def test_adam_beta_default(monkeypatch):
     args = parse_args()
     assert args.adam_beta1 is None
     assert args.adam_beta2 is None
+
+def test_teacher_weight_decay_parse(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog', '--teacher_weight_decay', '0.005'])
+    args = parse_args()
+    assert args.teacher_weight_decay == 0.005
+
+def test_teacher_weight_decay_default(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog'])
+    args = parse_args()
+    assert args.teacher_weight_decay is None


### PR DESCRIPTION
## Summary
- add `--teacher_weight_decay` option in `parse_args`
- convert argument to float during CLI merge
- document the new flag in the README feature list
- test parsing logic for the new CLI argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68639b386e4c8321ba3fc2174eecd125