### PR TITLE
Remove staged training flow

### DIFF
--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -20,7 +20,6 @@ def student_distillation_update(
     logger,
     optimizer,
     scheduler,
-    global_ep: int = 0
 ):
     """Train the student model via knowledge distillation.
 
@@ -66,7 +65,7 @@ def student_distillation_update(
     autocast_ctx, scaler = get_amp_components(cfg)
     la_mode = isinstance(mbm, LightweightAttnMBM) or cfg.get("mbm_type") == "LA"
     for ep in range(student_epochs):
-        cur_tau = get_tau(cfg, global_ep + ep)
+        cur_tau = get_tau(cfg, ep)
         distill_loss_sum = 0.0
         cnt = 0
         feat_kd_sum = 0.0
@@ -200,7 +199,7 @@ def student_distillation_update(
         if la_mode:
             logger.update_metric(f"student_ep{ep+1}_attn", attn_avg)
         logger.update_metric(f"ep{ep+1}_feat_kd", avg_feat_kd)
-        logger.update_metric(f"epoch{global_ep+ep+1}_tau", cur_tau)
+        logger.update_metric(f"epoch{ep+1}_tau", cur_tau)
 
         if scheduler is not None:
             scheduler.step()

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -72,7 +72,6 @@ def teacher_adaptive_update(
     logger,
     optimizer,
     scheduler,
-    global_ep: int = 0,
 ):
     """
     - ``teacher_wrappers``: list containing ``teacher1`` and ``teacher2``.
@@ -115,7 +114,7 @@ def teacher_adaptive_update(
         synergy_head.train()
         if student_model is not None:
             student_model.eval()
-        cur_tau = get_tau(cfg, global_ep + ep)
+        cur_tau = get_tau(cfg, ep)
         teacher_loss_sum = 0.0
         count = 0
         attn_sum = 0.0
@@ -245,7 +244,7 @@ def teacher_adaptive_update(
         # ── NEW: per-epoch logging ───────────────────────────────
         logger.update_metric(f"teacher_ep{ep+1}_loss", ep_loss)
         logger.update_metric(f"teacher_ep{ep+1}_synAcc", synergy_test_acc)
-        logger.update_metric(f"epoch{global_ep+ep+1}_tau", cur_tau)
+        logger.update_metric(f"epoch{ep+1}_tau", cur_tau)
         if la_mode:
             logger.update_metric(f"teacher_ep{ep+1}_attn", attn_avg)
 

--- a/tests/test_scheduler_optional.py
+++ b/tests/test_scheduler_optional.py
@@ -117,5 +117,4 @@ def test_teacher_update_scheduler_none():
         logger=logger,
         optimizer=opt,
         scheduler=None,
-        global_ep=0,
     )

--- a/tests/test_teacher_adaptive_update.py
+++ b/tests/test_teacher_adaptive_update.py
@@ -109,7 +109,6 @@ def test_teacher_adaptive_update_preserves_freeze():
         logger=logger,
         optimizer=opt,
         scheduler=sched,
-        global_ep=0,
     )
 
     frozen_after = [p.requires_grad for p in t1.frozen.parameters()]
@@ -151,7 +150,6 @@ def test_teacher_adaptive_update_trains_modules():
         logger=logger,
         optimizer=opt,
         scheduler=sched,
-        global_ep=0,
     )
 
     assert t1.record_training is True


### PR DESCRIPTION
## Summary
- simplify main distillation flow to run once instead of looping over stages
- remove stage counter from training utilities
- drop `num_stages` CLI option
- update affected tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e67e3c68832184d9a5c71c1ea9da