### PR TITLE
Implement ConvNeXt student models

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -22,7 +22,7 @@ small_input: true
 # Lists used by run_experiments.sh when looping
 teacher1_list: ["resnet152"]
 teacher2_list: ["efficientnet_b2", "swin_tiny"]
-student_list: ["resnet_adapter", "resnet152_adapter"]
+student_list: ["resnet_adapter", "efficientnet_adapter", "swin_adapter", "convnext_tiny"]
 method_list: ["asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"] # "asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"
 
 # Partial-freeze / adapter options

--- a/eval.py
+++ b/eval.py
@@ -257,7 +257,9 @@ def main():
             synergy_head.load_state_dict(head_ck, strict=False)
 
         # 5) student for LA MBM or optional synergy
+        student_type = cfg.get("student_type", "resnet_adapter")
         student = create_student_by_name(
+            student_type,
             pretrained=False,
             small_input=small_input,
             num_classes=n_classes,

--- a/main.py
+++ b/main.py
@@ -28,14 +28,61 @@ from models.teachers.teacher_resnet import create_resnet101, create_resnet152
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
 from models.teachers.teacher_swin import create_swin_t
 
+# Student creation (factory):
+from models.students import (
+    create_resnet_adapter,
+    create_resnet152_adapter,
+    create_efficientnet_adapter,
+    create_swin_adapter,
+    create_convnext_tiny,
+)
+
+
 def create_student_by_name(
+    student_name: str = "resnet_adapter",
     pretrained: bool = True,
     small_input: bool = False,
     num_classes: int = 100,
     cfg: Optional[dict] = None,
 ):
-    """Placeholder for removed student models."""
-    raise NotImplementedError("Student models have been removed")
+    """Instantiate a student model by name."""
+    if student_name == "resnet_adapter":
+        return create_resnet_adapter(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
+    elif student_name == "resnet152_adapter":
+        return create_resnet152_adapter(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
+    elif student_name == "efficientnet_adapter":
+        return create_efficientnet_adapter(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
+    elif student_name == "swin_adapter":
+        return create_swin_adapter(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
+    elif student_name == "convnext_tiny":
+        return create_convnext_tiny(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
+    else:
+        raise ValueError(f"[create_student_by_name] Unknown student_name={student_name}")
 
 from models.mbm import ManifoldBridgingModule, SynergyHead, build_from_teachers
 from models.ib import StudentProj
@@ -55,6 +102,7 @@ def parse_args():
     parser.add_argument("--teacher2_ckpt", type=str)
     parser.add_argument("--synergy_ce_alpha", type=float)    # α
     parser.add_argument("--hybrid_beta", type=float)
+    parser.add_argument("--student_type", type=str)
     
     # 편의용 하이퍼파라미터
     parser.add_argument("--batch_size", type=int)
@@ -425,7 +473,9 @@ def main():
     logger.update_metric("teacher2_test_acc", te2_acc)
 
     # 5) Student
+    student_type = cfg.get("student_type", "resnet_adapter")
     student_model = create_student_by_name(
+        student_type,
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,

--- a/models/students/__init__.py
+++ b/models/students/__init__.py
@@ -1,1 +1,12 @@
+from .student_resnet_adapter import create_resnet_adapter, create_resnet152_adapter
+from .student_efficientnet_adapter import create_efficientnet_adapter
+from .student_swin_adapter import create_swin_adapter
+from .student_convnext import create_convnext_tiny
 
+__all__ = [
+    "create_resnet_adapter",
+    "create_resnet152_adapter",
+    "create_efficientnet_adapter",
+    "create_swin_adapter",
+    "create_convnext_tiny",
+]

--- a/models/students/student_convnext.py
+++ b/models/students/student_convnext.py
@@ -1,0 +1,68 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional
+from torchvision.models import convnext_tiny, ConvNeXt_Tiny_Weights
+
+class StudentConvNeXtWrapper(nn.Module):
+    """Wrap a ConvNeXt-Tiny backbone for student distillation."""
+    def __init__(self, backbone: nn.Module, cfg: Optional[dict] = None):
+        super().__init__()
+        self.backbone = backbone
+        self.criterion_ce = nn.CrossEntropyLoss()
+        # convnext tiny final dim
+        self.feat_dim = backbone.classifier[2].in_features
+        self.feat_channels = self.feat_dim
+
+    def forward(self, x, y=None):
+        feat_4d = self.backbone.features(x)
+        pooled = self.backbone.avgpool(feat_4d)
+        feat_2d = torch.flatten(pooled, 1)
+        feat_2d = self.backbone.classifier[0](feat_2d)
+        logit = self.backbone.classifier[2](feat_2d)
+
+        ce_loss = None
+        if y is not None:
+            ce_loss = self.criterion_ce(logit, y)
+
+        return {
+            "feat_4d": feat_4d,
+            "feat_2d": feat_2d,
+            "logit": logit,
+            "ce_loss": ce_loss,
+            "feat_4d_layer1": feat_4d,
+            "feat_4d_layer2": feat_4d,
+            "feat_4d_layer3": feat_4d,
+        }
+
+    def get_feat_dim(self):
+        return self.feat_dim
+
+    def get_feat_channels(self):
+        return self.feat_channels
+
+
+def create_convnext_tiny(num_classes=100, pretrained=True, small_input=False, cfg: Optional[dict] = None):
+    if pretrained:
+        model = convnext_tiny(weights=ConvNeXt_Tiny_Weights.IMAGENET1K_V1)
+    else:
+        model = convnext_tiny(weights=None)
+
+    if small_input:
+        conv = model.features[0][0]
+        new_conv = nn.Conv2d(
+            conv.in_channels,
+            conv.out_channels,
+            kernel_size=conv.kernel_size,
+            stride=2,
+            padding=conv.padding,
+            bias=conv.bias is not None,
+        )
+        new_conv.weight.data.copy_(conv.weight.data)
+        if conv.bias is not None:
+            new_conv.bias.data.copy_(conv.bias.data)
+        model.features[0][0] = new_conv
+
+    in_feats = model.classifier[2].in_features
+    model.classifier[2] = nn.Linear(in_feats, num_classes)
+    return StudentConvNeXtWrapper(model, cfg=cfg)

--- a/models/students/student_efficientnet_adapter.py
+++ b/models/students/student_efficientnet_adapter.py
@@ -1,0 +1,78 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional
+from torchvision.models import efficientnet_b2, EfficientNet_B2_Weights
+
+class StudentEfficientNetWrapper(nn.Module):
+    """Wrap an EfficientNet backbone for student distillation."""
+    def __init__(self, backbone, cfg: Optional[dict] = None):
+        super().__init__()
+        self.backbone = backbone
+        self.criterion_ce = nn.CrossEntropyLoss()
+        self.feat_dim = 1408
+        self.feat_channels = 1408
+
+    def forward(self, x, y=None):
+        feat_layer1 = None
+        feat_layer2 = None
+        feat_layer3 = None
+        out = x
+        for idx, block in enumerate(self.backbone.features):
+            out = block(out)
+            if idx == 2:
+                feat_layer1 = out
+            elif idx == 4:
+                feat_layer2 = out
+            elif idx == 6:
+                feat_layer3 = out
+        feat_4d = out
+        fpool = F.adaptive_avg_pool2d(feat_4d, (1,1)).flatten(1)
+        logit = self.backbone.classifier(fpool)
+
+        ce_loss = None
+        if y is not None:
+            ce_loss = self.criterion_ce(logit, y)
+
+        return {
+            "feat_4d": feat_4d,
+            "feat_2d": fpool,
+            "logit": logit,
+            "ce_loss": ce_loss,
+            "feat_4d_layer1": feat_layer1,
+            "feat_4d_layer2": feat_layer2,
+            "feat_4d_layer3": feat_layer3,
+        }
+
+    def get_feat_dim(self):
+        return self.feat_dim
+
+    def get_feat_channels(self):
+        return self.feat_channels
+
+
+def create_efficientnet_adapter(num_classes=100, pretrained=True, small_input=False, cfg: Optional[dict] = None, dropout_p=0.3):
+    if pretrained:
+        model = efficientnet_b2(weights=EfficientNet_B2_Weights.IMAGENET1K_V1)
+    else:
+        model = efficientnet_b2(weights=None)
+
+    if small_input:
+        old_conv = model.features[0][0]
+        new_conv = nn.Conv2d(
+            old_conv.in_channels,
+            old_conv.out_channels,
+            kernel_size=old_conv.kernel_size,
+            stride=1,
+            padding=old_conv.padding,
+            bias=old_conv.bias is not None,
+        )
+        new_conv.weight.data.copy_(old_conv.weight.data)
+        if old_conv.bias is not None:
+            new_conv.bias.data.copy_(old_conv.bias.data)
+        model.features[0][0] = new_conv
+
+    in_feats = model.classifier[1].in_features
+    model.classifier[0] = nn.Dropout(p=dropout_p)
+    model.classifier[1] = nn.Linear(in_feats, num_classes)
+    return StudentEfficientNetWrapper(model, cfg=cfg)

--- a/models/students/student_resnet_adapter.py
+++ b/models/students/student_resnet_adapter.py
@@ -1,0 +1,81 @@
+import torch
+import torch.nn as nn
+from typing import Optional
+from torchvision.models import resnet50, ResNet50_Weights, resnet152, ResNet152_Weights
+
+class StudentResNetWrapper(nn.Module):
+    """Wrap a ResNet backbone for student distillation."""
+    def __init__(self, backbone: nn.Module, cfg: Optional[dict] = None):
+        super().__init__()
+        self.backbone = backbone
+        self.criterion_ce = nn.CrossEntropyLoss()
+        self.feat_dim = backbone.fc.in_features
+        self.feat_channels = backbone.fc.in_features
+
+    def forward(self, x, y=None):
+        out = self.backbone.conv1(x)
+        out = self.backbone.bn1(out)
+        out = self.backbone.relu(out)
+        out = self.backbone.maxpool(out)
+
+        out = self.backbone.layer1(out)
+        feat_layer1 = out
+        out = self.backbone.layer2(out)
+        feat_layer2 = out
+        out = self.backbone.layer3(out)
+        feat_layer3 = out
+        feat_4d = self.backbone.layer4(out)
+
+        gp = self.backbone.avgpool(feat_4d)
+        feat_2d = torch.flatten(gp, 1)
+        logit = self.backbone.fc(feat_2d)
+
+        ce_loss = None
+        if y is not None:
+            ce_loss = self.criterion_ce(logit, y)
+
+        return {
+            "feat_4d": feat_4d,
+            "feat_2d": feat_2d,
+            "logit": logit,
+            "ce_loss": ce_loss,
+            "feat_4d_layer1": feat_layer1,
+            "feat_4d_layer2": feat_layer2,
+            "feat_4d_layer3": feat_layer3,
+        }
+
+    def get_feat_dim(self):
+        return self.feat_dim
+
+    def get_feat_channels(self):
+        return self.feat_channels
+
+
+def create_resnet_adapter(num_classes=100, pretrained=True, small_input=False, cfg: Optional[dict] = None):
+    if pretrained:
+        model = resnet50(weights=ResNet50_Weights.IMAGENET1K_V2)
+    else:
+        model = resnet50(weights=None)
+
+    if small_input:
+        model.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+        model.maxpool = nn.Identity()
+
+    in_feats = model.fc.in_features
+    model.fc = nn.Linear(in_feats, num_classes)
+    return StudentResNetWrapper(model, cfg=cfg)
+
+
+def create_resnet152_adapter(num_classes=100, pretrained=True, small_input=False, cfg: Optional[dict] = None):
+    if pretrained:
+        model = resnet152(weights=ResNet152_Weights.IMAGENET1K_V2)
+    else:
+        model = resnet152(weights=None)
+
+    if small_input:
+        model.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+        model.maxpool = nn.Identity()
+
+    in_feats = model.fc.in_features
+    model.fc = nn.Linear(in_feats, num_classes)
+    return StudentResNetWrapper(model, cfg=cfg)

--- a/models/students/student_swin_adapter.py
+++ b/models/students/student_swin_adapter.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+from typing import Optional
+from torchvision.models import swin_t, Swin_T_Weights
+
+class StudentSwinWrapper(nn.Module):
+    """Wrap a Swin Tiny backbone for student distillation."""
+    def __init__(self, backbone: nn.Module, cfg: Optional[dict] = None):
+        super().__init__()
+        self.backbone = backbone
+        self.criterion_ce = nn.CrossEntropyLoss()
+        self.feat_dim = backbone.head.in_features
+        self.feat_channels = self.feat_dim
+
+    def forward(self, x, y=None):
+        out = self.backbone.features(x)
+        out = self.backbone.norm(out)
+        out = self.backbone.permute(out)
+        out = self.backbone.avgpool(out)
+        feat_2d = self.backbone.flatten(out)
+        logit = self.backbone.head(feat_2d)
+
+        ce_loss = None
+        if y is not None:
+            ce_loss = self.criterion_ce(logit, y)
+
+        feat_4d = self.backbone.features(x)
+        feat_4d = self.backbone.norm(feat_4d)
+        feat_4d = self.backbone.permute(feat_4d)
+
+        return {
+            "feat_4d": feat_4d,
+            "feat_2d": feat_2d,
+            "logit": logit,
+            "ce_loss": ce_loss,
+            "feat_4d_layer1": feat_4d,
+            "feat_4d_layer2": feat_4d,
+            "feat_4d_layer3": feat_4d,
+        }
+
+    def get_feat_dim(self):
+        return self.feat_dim
+
+    def get_feat_channels(self):
+        return self.feat_channels
+
+
+def create_swin_adapter(num_classes=100, pretrained=True, small_input=False, cfg: Optional[dict] = None):
+    if pretrained:
+        model = swin_t(weights=Swin_T_Weights.IMAGENET1K_V1)
+    else:
+        model = swin_t(weights=None)
+
+    in_feats = model.head.in_features
+    model.head = nn.Linear(in_feats, num_classes)
+    return StudentSwinWrapper(model, cfg=cfg)


### PR DESCRIPTION
## Summary
- add real student implementations: ResNet/EfficientNet/Swin adapters and ConvNeXt‑Tiny
- update `create_student_by_name` factory and scripts to use them
- allow passing `--student_type` to choose architecture
- register new students in `hparams.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ed12256883219a747a3e2a50bcc7