### PR TITLE
Fix minimal KD pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,8 +10,9 @@ from models.ib.proj_head import StudentProj
 from utils.misc import set_random_seed
 from utils.eval import evaluate_acc
 from data.cifar100 import get_cifar100_loaders
-from teachers import create_resnet152, create_efficientnet_b2
-from students import create_convnext_tiny
+from models.teachers.teacher_resnet import create_resnet152
+from models.teachers.teacher_efficientnet import create_efficientnet_b2
+from models.students.student_convnext import create_convnext_tiny
 from trainer import teacher_vib_update, student_vib_update
 
 # ---------- CLI ----------
@@ -25,7 +26,7 @@ set_random_seed(cfg.get('seed', 42))
 
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(
-    batch_size=cfg['batch_size'], num_workers=cfg['num_workers']
+    batch_size=cfg['batch_size'], num_workers=cfg.get('num_workers', 0)
 )
 
 # ---------- teachers ----------

--- a/models/students/student_convnext.py
+++ b/models/students/student_convnext.py
@@ -27,15 +27,11 @@ class StudentConvNeXtWrapper(nn.Module):
         if y is not None:
             ce_loss = self.criterion_ce(logit, y)
 
-        return {
+        feat_dict = {
             "feat_4d": feat_4d,
             "feat_2d": feat_2d,
-            "logit": logit,
-            "ce_loss": ce_loss,
-            "feat_4d_layer1": feat_4d,
-            "feat_4d_layer2": feat_4d,
-            "feat_4d_layer3": feat_4d,
         }
+        return feat_dict, logit, None
 
     def get_feat_dim(self):
         return self.feat_dim

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -53,16 +53,11 @@ class TeacherEfficientNetWrapper(nn.Module):
         if y is not None:
             ce_loss = self.criterion_ce(logit, y)
 
-        # Dict로 묶어서 반환
-        return {
-            "feat_4d": f4d,       # [N, 1408, h, w]
-            "feat_2d": fpool,     # [N, 1408]
-            "logit": logit,
-            "ce_loss": ce_loss,
-            "feat_4d_layer1": feat_layer1,
-            "feat_4d_layer2": feat_layer2,
-            "feat_4d_layer3": feat_layer3,
+        feat_dict = {
+            "feat_4d": f4d,
+            "feat_2d": fpool,
         }
+        return feat_dict, logit, None
 
     def get_feat_dim(self):
         """

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -60,16 +60,11 @@ class TeacherResNetWrapper(nn.Module):
         if y is not None:
             ce_loss = self.criterion_ce(logit, y)
 
-        # Dict
-        return {
-            "feat_4d": f4d,      # [N, 2048, H, W]
-            "feat_2d": feat_2d,  # [N, 2048]
-            "logit": logit,
-            "ce_loss": ce_loss,
-            "feat_4d_layer1": feat_layer1,
-            "feat_4d_layer2": feat_layer2,
-            "feat_4d_layer3": feat_layer3,
+        feat_dict = {
+            "feat_4d": f4d,
+            "feat_2d": feat_2d,
         }
+        return feat_dict, logit, None
 
     def get_feat_dim(self):
         """

--- a/students/__init__.py
+++ b/students/__init__.py
@@ -1,3 +1,0 @@
-from .student_convnext import create_convnext_tiny
-
-__all__ = ["create_convnext_tiny"]

--- a/teachers/__init__.py
+++ b/teachers/__init__.py
@@ -1,4 +1,0 @@
-from .teacher_resnet import create_resnet152
-from .teacher_efficientnet import create_efficientnet_b2
-
-__all__ = ["create_resnet152", "create_efficientnet_b2"]

--- a/trainer.py
+++ b/trainer.py
@@ -14,8 +14,10 @@ def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer):
         for x, y in loader:
             x, y = x.to(device), y.to(device)
             with torch.no_grad():
-                t1_dict = teacher1(x)
-                t2_dict = teacher2(x)
+                out1 = teacher1(x)
+                out2 = teacher2(x)
+                t1_dict = out1[0] if isinstance(out1, tuple) else out1
+                t2_dict = out2[0] if isinstance(out2, tuple) else out2
             f1 = t1_dict["feat_2d"]
             f2 = t2_dict["feat_2d"]
             z, logit_syn, kl_z, _ = vib_mbm(f1, f2)
@@ -35,8 +37,10 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
         for x, y in loader:
             x, y = x.to(device), y.to(device)
             with torch.no_grad():
-                t1_dict = teacher1(x)
-                t2_dict = teacher2(x)
+                out1 = teacher1(x)
+                out2 = teacher2(x)
+                t1_dict = out1[0] if isinstance(out1, tuple) else out1
+                t2_dict = out2[0] if isinstance(out2, tuple) else out2
                 f1 = t1_dict["feat_2d"]
                 f2 = t2_dict["feat_2d"]
                 _, _, _, mu = vib_mbm(f1, f2)

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -10,10 +10,10 @@ def evaluate_acc(model, loader, device="cuda"):
     for x, y in loader:
         x, y = x.to(device), y.to(device)
         out = model(x)
-        if isinstance(out, dict):
-            logits = out.get("logit", out)
-        elif isinstance(out, tuple):
+        if isinstance(out, tuple):
             logits = out[1]
+        elif isinstance(out, dict):
+            logits = out.get("logit", out)
         else:
             logits = out
         preds = logits.argmax(dim=1)


### PR DESCRIPTION
## Summary
- fix import paths for teachers and students
- drop old wrapper packages and move modules under `models`
- return `(feat_dict, logit, None)` from model wrappers
- support missing `num_workers` field
- update eval, trainer for tuple outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68640e38e1b48321ac9467e1f93bded5