### PR TITLE
Align config and docs with convnext_tiny student

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,12 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   when using this module.
   Common student feature dimensions are:
 
-  | Student model                | Feature dim |
-  |------------------------------|-------------|
-   | `student_efficientnet_adapter` | 1408        |
-   | `student_resnet_adapter`       | 2048        |
-   | `student_swin_adapter`         | 768         |
-   *The adapters above were part of the original project and are no longer
-   shipped in this repository.*
+  | Student model | Feature dim |
+  |---------------|-------------|
+  | `convnext_tiny` | 768 |
+*This minimal repository only ships `convnext_tiny` as a ready-made student.*
 - **Swin Adapter Dim**: `swin_adapter_dim` sets the hidden size of the MLP
-  adapter used by `student_swin_adapter` (default `64`)
+  adapter used by a custom `student_swin_adapter` (default `64`)
 - **Student Projection Normalization**: set `proj_normalize` (default `true`) to
   apply L2 normalization on features before the student projection head
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
@@ -87,12 +84,10 @@ pip install -r requirements.txt  # includes pandas for analysis
 ```
 
 > **Note**
-> Student model adapters (`student_resnet_adapter`, etc.) were removed from this
-> repository. To run the code you must provide your own student definitions.
-> Place custom modules under `models/students/` or copy them from the upstream
-> project. Each student should implement a `create_*` factory returning a model
-> whose `forward` yields `(feature_dict, logits, extra)` similar to the teacher
-> wrappers.
+> This minimal repository only includes the `convnext_tiny` student.
+> To use other architectures, provide custom modules under `models/students/`.
+> Each student should implement a `create_*` factory returning a model whose
+> `forward` yields `(feature_dict, logits, extra)` similar to the teacher wrappers.
 
 The unified script `run_experiments.sh` automatically tries to activate a
 Conda environment named `facil_env`. If you use a different environment name,
@@ -226,9 +221,9 @@ Usage
 ### Typical Training Flow
 
 > **Note**
-> Predefined student adapters were removed. Add your own modules under
-> `models/students/` or copy them from the upstream repository before running
-> the examples below.
+> Only a `convnext_tiny` student is provided. Add your own modules under
+> `models/students/` or copy them from the upstream repository to try other
+> architectures.
 
 1. Fine-tune each teacher (optional but recommended).
 2. For each stage, perform a teacher adaptive update followed by student knowledge distillation.
@@ -254,7 +249,7 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
 ```bash
 python scripts/run_single_teacher.py --config configs/default.yaml \
   --method vanilla_kd --teacher_type resnet152 --teacher_ckpt teacher.pth \
-  --student_type resnet_adapter --epochs 40 \
+  --student_type convnext_tiny --epochs 40 \
   --dataset imagenet100
 ```
 
@@ -272,7 +267,7 @@ Run the student alone using the same partial-freeze settings to gauge its standa
 
 ```bash
 python scripts/train_student_baseline.py --config configs/partial_freeze.yaml \
-  --student_type resnet_adapter --epochs 40 --dataset cifar100
+  --student_type convnext_tiny --epochs 40 --dataset cifar100
 # Freeze levels come from `configs/partial_freeze.yaml`
 ```
 
@@ -491,9 +486,7 @@ Folder Structure
 │   ├── mbm.py
 │   ├── students
 │   │   ├── __init__.py
-│   │   ├── student_efficientnet_adapter.py
-│   │   ├── student_resnet_adapter.py
-│   │   └── student_swin_adapter.py
+│   │   └── student_convnext.py
 │   └── teachers
 │       ├── __init__.py
 │       ├── teacher_efficientnet.py

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -12,7 +12,7 @@ deterministic: true
 # ─ 모델 ────────────────────────────────────────────
 teacher1_type: "resnet152"
 teacher2_type: "efficientnet_b2"
-student_type: "resnet_adapter"
+student_type: "convnext_tiny"
 small_input: true
 
 # ─ IB‑KD 하이퍼 ────────────────────────────────────

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -168,7 +168,7 @@ def main():
         )
 
     student = create_student_by_name(
-        cfg.get("student_type", "resnet_adapter"),
+        cfg.get("student_type", "convnext_tiny"),
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
@@ -182,7 +182,7 @@ def main():
     if cfg.get("use_partial_freeze", True):
         partial_freeze_student_auto(
             student,
-            student_name=cfg.get("student_type", "resnet_adapter"),
+            student_name=cfg.get("student_type", "convnext_tiny"),
             freeze_bn=cfg.get("student_freeze_bn", True),
             freeze_ln=cfg.get("student_freeze_ln", True),
             use_adapter=cfg.get("student_use_adapter", False),

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -155,7 +155,7 @@ def main():
         small_input = dataset == "cifar100"
 
     student = create_student_by_name(
-        cfg.get("student_type", "resnet_adapter"),
+        cfg.get("student_type", "convnext_tiny"),
         pretrained=cfg.get("student_pretrained", True),
         small_input=small_input,
         num_classes=num_classes,
@@ -169,7 +169,7 @@ def main():
 
     partial_freeze_student_auto(
         student,
-        student_name=cfg.get("student_type", "resnet_adapter"),
+        student_name=cfg.get("student_type", "convnext_tiny"),
         freeze_bn=cfg.get("student_freeze_bn", True),
         freeze_ln=cfg.get("student_freeze_ln", True),
         use_adapter=cfg.get("student_use_adapter", False),


### PR DESCRIPTION
## Summary
- use `convnext_tiny` as the default student model
- update README commands and notes
- adjust scripts to match the new default student

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68648de039b88321b2e39987945c09de