### PR TITLE
Enable AMP training and projection BatchNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   adapter used by a custom `student_swin_adapter` (default `64`)
 - **Student Projection Normalization**: set `proj_normalize` (default `true`) to
   apply L2 normalization on features before the student projection head
+  Set `proj_use_bn: true` to insert a scale-free BatchNorm layer after the
+  projection for better matching with teacher features.
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -19,6 +19,8 @@ small_input: true
 mbm_type: "VIB"
 z_dim: 256
 proj_normalize: true
+proj_use_bn: false
+use_amp: true
 beta_bottleneck: 0.003
 alpha_kd: 0.7
 ce_alpha: 1.0
@@ -29,7 +31,7 @@ student_lr: 5e-4
 teacher_weight_decay: 5e-4
 student_weight_decay: 5e-4
 lr_schedule: "cosine"
-grad_clip_norm: 0
+grad_clip_norm: 1.0
 
 # ─ 학습 스테이지 ──────────────────────────────────
 teacher_iters: 5

--- a/main.py
+++ b/main.py
@@ -38,8 +38,8 @@ t2 = create_efficientnet_b2(pretrained=True, small_input=True).to(device)
 ft_epochs = cfg.get('finetune_epochs', 0)
 ft_lr = cfg.get('finetune_lr', 1e-4)
 if ft_epochs > 0:
-    simple_finetune(t1, train_loader, ft_lr, ft_epochs, device)
-    simple_finetune(t2, train_loader, ft_lr, ft_epochs, device)
+    simple_finetune(t1, train_loader, ft_lr, ft_epochs, device, cfg)
+    simple_finetune(t2, train_loader, ft_lr, ft_epochs, device, cfg)
 freeze_all(t1)
 freeze_all(t2)
 t1.eval()
@@ -55,6 +55,7 @@ proj = StudentProj(
     student.get_feat_dim(),
     cfg['z_dim'],
     normalize=cfg.get('proj_normalize', True),
+    use_bn=cfg.get('proj_use_bn', False),
 ).to(device)
 
 opt_t = Adam(mbm.parameters(), lr=cfg['teacher_lr'], weight_decay=cfg['teacher_weight_decay'])

--- a/models/ib/proj_head.py
+++ b/models/ib/proj_head.py
@@ -4,13 +4,16 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 class StudentProj(nn.Module):
-    def __init__(self, in_dim: int, z_dim: int, normalize: bool = True):
+    def __init__(self, in_dim: int, z_dim: int, normalize: bool = True, use_bn: bool = False):
         super().__init__()
         self.proj = nn.Linear(in_dim, z_dim)
         self.normalize = normalize
+        self.bn = nn.BatchNorm1d(z_dim, affine=False) if use_bn else nn.Identity()
 
     def forward(self, x):
         x = x.flatten(1)
         if self.normalize:
             x = F.normalize(x, dim=1)
-        return self.proj(x)
+        x = self.proj(x)
+        x = self.bn(x)
+        return x

--- a/trainer.py
+++ b/trainer.py
@@ -3,9 +3,10 @@
 import torch
 import torch.nn.functional as F
 from utils.schedule import cosine_lr_scheduler
+from utils.misc import get_amp_components
 
 
-def simple_finetune(model, loader, lr, epochs, device, weight_decay=0.0):
+def simple_finetune(model, loader, lr, epochs, device, weight_decay=0.0, cfg=None):
     """Minimal cross-entropy fine-tuning loop for teachers."""
     if epochs <= 0:
         return
@@ -13,22 +14,30 @@ def simple_finetune(model, loader, lr, epochs, device, weight_decay=0.0):
     optimizer = torch.optim.Adam(
         model.parameters(), lr=lr, weight_decay=weight_decay
     )
+    autocast_ctx, scaler = get_amp_components(cfg or {})
     criterion = torch.nn.CrossEntropyLoss()
     for _ in range(epochs):
         for x, y in loader:
             x, y = x.to(device), y.to(device)
             optimizer.zero_grad()
-            out = model(x)
-            logit = out[1] if isinstance(out, tuple) else out
-            loss = criterion(logit, y)
-            loss.backward()
-            optimizer.step()
+            with autocast_ctx:
+                out = model(x)
+                logit = out[1] if isinstance(out, tuple) else out
+                loss = criterion(logit, y)
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                loss.backward()
+                optimizer.step()
 
 
 def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer):
     device = cfg.get("device", "cuda")
     beta = cfg.get("beta_bottleneck", 0.003)
     clip = cfg.get("grad_clip_norm", 0)
+    autocast_ctx, scaler = get_amp_components(cfg)
     vib_mbm.train()
     teacher1.eval()
     teacher2.eval()
@@ -43,13 +52,22 @@ def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer):
                 t2_dict = out2[0] if isinstance(out2, tuple) else out2
             f1 = t1_dict["feat_2d"]
             f2 = t2_dict["feat_2d"]
-            z, logit_syn, kl_z, _ = vib_mbm(f1, f2)
-            loss = F.cross_entropy(logit_syn, y) + beta * kl_z.mean()
+            with autocast_ctx:
+                z, logit_syn, kl_z, _ = vib_mbm(f1, f2)
+                loss = F.cross_entropy(logit_syn, y) + beta * kl_z.mean()
             optimizer.zero_grad()
-            loss.backward()
-            if clip > 0:
-                torch.nn.utils.clip_grad_norm_(vib_mbm.parameters(), clip)
-            optimizer.step()
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                if clip > 0:
+                    scaler.unscale_(optimizer)
+                    torch.nn.utils.clip_grad_norm_(vib_mbm.parameters(), clip)
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                loss.backward()
+                if clip > 0:
+                    torch.nn.utils.clip_grad_norm_(vib_mbm.parameters(), clip)
+                optimizer.step()
         scheduler.step()
 
 
@@ -58,6 +76,7 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
     alpha = cfg.get("alpha_kd", 0.7)
     ce_alpha = cfg.get("ce_alpha", 1.0)
     clip = cfg.get("grad_clip_norm", 0)
+    autocast_ctx, scaler = get_amp_components(cfg)
     vib_mbm.eval()
     student_model.train()
     scheduler = cosine_lr_scheduler(optimizer, cfg.get("student_iters", 1))
@@ -73,19 +92,31 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
                 f2 = t2_dict["feat_2d"]
                 _, _, _, mu = vib_mbm(f1, f2)
                 z_target = mu.detach()
-            feat_dict, s_logit, _ = student_model(x)
-            s_feat = feat_dict["feat_2d"]
-            z_pred = student_proj(s_feat)
-            kd = F.mse_loss(z_pred, z_target)
-            loss = ce_alpha * F.cross_entropy(s_logit, y) + alpha * kd
+            with autocast_ctx:
+                feat_dict, s_logit, _ = student_model(x)
+                s_feat = feat_dict["feat_2d"]
+                z_pred = student_proj(s_feat)
+                kd = F.mse_loss(z_pred, z_target)
+                loss = ce_alpha * F.cross_entropy(s_logit, y) + alpha * kd
             optimizer.zero_grad()
-            loss.backward()
-            if clip > 0:
-                torch.nn.utils.clip_grad_norm_(
-                    list(student_model.parameters()) + list(student_proj.parameters()),
-                    clip,
-                )
-            optimizer.step()
+            if scaler is not None:
+                scaler.scale(loss).backward()
+                if clip > 0:
+                    scaler.unscale_(optimizer)
+                    torch.nn.utils.clip_grad_norm_(
+                        list(student_model.parameters()) + list(student_proj.parameters()),
+                        clip,
+                    )
+                scaler.step(optimizer)
+                scaler.update()
+            else:
+                loss.backward()
+                if clip > 0:
+                    torch.nn.utils.clip_grad_norm_(
+                        list(student_model.parameters()) + list(student_proj.parameters()),
+                        clip,
+                    )
+                optimizer.step()
         scheduler.step()
 
 


### PR DESCRIPTION
## Summary
- default configs use AMP and clip gradients
- support optional BatchNorm in `StudentProj`
- add AMP in fine-tuning and distillation loops
- expose new config fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864945495708321a2b513d8780ab5f6