### PR TITLE
Apply training tweaks and add KL logging

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -18,12 +18,14 @@ small_input: true
 # ─ IB‑KD 하이퍼 ────────────────────────────────────
 mbm_type: "VIB"
 z_dim: 256
-proj_normalize: true
-proj_use_bn: false
+proj_normalize: false
+proj_use_bn: true
 use_amp: true
+amp_dtype: bfloat16
 beta_bottleneck: 0.003
 alpha_kd: 0.7
 ce_alpha: 1.0
+log_kl: false
 
 # ─ 옵티마이저 ──────────────────────────────────────
 teacher_lr: 3e-4
@@ -38,5 +40,5 @@ teacher_iters: 5
 student_iters: 15
 
 # ─ Teacher Fine‑tune ──────────────────────────────
-finetune_epochs: 1
+finetune_epochs: 3
 finetune_lr: 1e-4

--- a/models/ib/proj_head.py
+++ b/models/ib/proj_head.py
@@ -8,7 +8,7 @@ class StudentProj(nn.Module):
         super().__init__()
         self.proj = nn.Linear(in_dim, z_dim)
         self.normalize = normalize
-        self.bn = nn.BatchNorm1d(z_dim, affine=False) if use_bn else nn.Identity()
+        self.bn = nn.BatchNorm1d(z_dim, affine=True) if use_bn else nn.Identity()
 
     def forward(self, x):
         x = x.flatten(1)

--- a/trainer.py
+++ b/trainer.py
@@ -53,7 +53,11 @@ def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer):
             f1 = t1_dict["feat_2d"]
             f2 = t2_dict["feat_2d"]
             with autocast_ctx:
-                z, logit_syn, kl_z, _ = vib_mbm(f1, f2)
+                z, logit_syn, kl_z, _ = vib_mbm(
+                    f1,
+                    f2,
+                    log_kl=cfg.get("log_kl", False),
+                )
                 loss = F.cross_entropy(logit_syn, y) + beta * kl_z.mean()
             optimizer.zero_grad()
             if scaler is not None:
@@ -90,7 +94,11 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
                 t2_dict = out2[0] if isinstance(out2, tuple) else out2
                 f1 = t1_dict["feat_2d"]
                 f2 = t2_dict["feat_2d"]
-                _, _, _, mu = vib_mbm(f1, f2)
+                _, _, _, mu = vib_mbm(
+                    f1,
+                    f2,
+                    log_kl=cfg.get("log_kl", False),
+                )
                 z_target = mu.detach()
             with autocast_ctx:
                 feat_dict, s_logit, _ = student_model(x)


### PR DESCRIPTION
## Summary
- adjust minimal config for stable training
- use affine BatchNorm in student projection
- support optional KL debugging output in VIB module
- pass `log_kl` flag through training loops

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68649768de588321aae82b022e8f2da9