### PR TITLE
Update evaluate_acc signature

### DIFF
--- a/utils/eval.py
+++ b/utils/eval.py
@@ -3,7 +3,7 @@
 import torch
 
 @torch.no_grad()
-def evaluate_acc(model, loader, device="cuda"):
+def evaluate_acc(model, loader, device="cuda", cfg=None):
     model.eval()
     correct = 0
     total = 0


### PR DESCRIPTION
## Summary
- allow passing an optional cfg to `evaluate_acc`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68649dc308888321885bd0bb5b863955