### PR TITLE
Add bf16 support check in autocast setup

### DIFF
--- a/utils/misc.py
+++ b/utils/misc.py
@@ -81,6 +81,8 @@ def get_amp_components(cfg: dict):
     use_amp = cfg.get("use_amp", False)
     if use_amp and torch.cuda.is_available():
         dtype = cfg.get("amp_dtype", "float16")
+        if dtype == "bfloat16" and not torch.cuda.is_bf16_supported():
+            dtype = "float16"
         autocast_ctx = autocast(dtype=getattr(torch, dtype, torch.float16))
         scaler = GradScaler(init_scale=cfg.get("grad_scaler_init_scale", 1024))
     else:


### PR DESCRIPTION
## Summary
- validate bf16 support before creating autocast contexts to fall back to fp16

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68649f9698b88321beaa015a9d003658