### PR TITLE
Fix missing module imports

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,3 @@
+from .losses import *
+from .partial_freeze import *
+from .cutmix_finetune_teacher import *

--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -1,0 +1,84 @@
+"""Minimal CutMix fine-tuning utilities used by scripts.fine_tuning."""
+import os
+import numpy as np
+import torch
+import torch.nn.functional as F
+from utils.eval import evaluate_acc
+
+__all__ = ["finetune_teacher_cutmix", "eval_teacher"]
+
+
+def rand_bbox(size, lam):
+    W = size[2]
+    H = size[3]
+    cut_rat = np.sqrt(1.0 - lam)
+    cut_w = int(W * cut_rat)
+    cut_h = int(H * cut_rat)
+    cx = np.random.randint(W)
+    cy = np.random.randint(H)
+    bbx1 = np.clip(cx - cut_w // 2, 0, W)
+    bby1 = np.clip(cy - cut_h // 2, 0, H)
+    bbx2 = np.clip(cx + cut_w // 2, 0, W)
+    bby2 = np.clip(cy + cut_h // 2, 0, H)
+    return bbx1, bby1, bbx2, bby2
+
+
+def finetune_teacher_cutmix(
+    model,
+    train_loader,
+    test_loader,
+    alpha=1.0,
+    lr=1e-3,
+    weight_decay=1e-4,
+    epochs=10,
+    device="cuda",
+    ckpt_path="teacher_finetuned.pth",
+    label_smoothing: float = 0.0,
+    cfg=None,
+):
+    """Simple CutMix fine-tune loop."""
+    model = model.to(device)
+    optim = torch.optim.AdamW(
+        model.parameters(),
+        lr=lr,
+        weight_decay=weight_decay,
+        betas=(cfg.get("adam_beta1", 0.9) if cfg else 0.9,
+               cfg.get("adam_beta2", 0.999) if cfg else 0.999),
+    )
+    criterion = torch.nn.CrossEntropyLoss(label_smoothing=label_smoothing)
+
+    if os.path.exists(ckpt_path):
+        model.load_state_dict(torch.load(ckpt_path, map_location=device, weights_only=True), strict=False)
+        acc = evaluate_acc(model, test_loader, device)
+        return model, acc
+
+    best_acc = 0.0
+    for ep in range(1, epochs + 1):
+        model.train()
+        for x, y in train_loader:
+            x, y = x.to(device), y.to(device)
+            lam = np.random.beta(alpha, alpha) if alpha > 0 else 1.0
+            rand_index = torch.randperm(x.size(0)).to(device)
+            target_a = y
+            target_b = y[rand_index]
+            bbx1, bby1, bbx2, bby2 = rand_bbox(x.size(), lam)
+            x[:, :, bbx1:bbx2, bby1:bby2] = x[rand_index, :, bbx1:bbx2, bby1:bby2]
+            lam = 1 - ((bbx2 - bbx1) * (bby2 - bby1) / (x.size(-1) * x.size(-2)))
+
+            out = model(x)
+            logit = out["logit"] if isinstance(out, dict) else out
+            loss = criterion(logit, target_a) * lam + criterion(logit, target_b) * (1 - lam)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        acc = evaluate_acc(model, test_loader, device)
+        if acc > best_acc:
+            best_acc = acc
+            os.makedirs(os.path.dirname(ckpt_path), exist_ok=True)
+            torch.save(model.state_dict(), ckpt_path)
+    return model, best_acc
+
+
+def eval_teacher(model, loader, device="cuda"):
+    """Evaluate teacher accuracy (wrapper around utils.eval)."""
+    return evaluate_acc(model.to(device), loader, device)

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -1,0 +1,24 @@
+import torch
+import torch.nn.functional as F
+
+__all__ = ["kd_loss_fn", "ce_loss_fn", "dkd_loss"]
+
+
+def kd_loss_fn(student_logits: torch.Tensor, teacher_logits: torch.Tensor, T: float = 1.0) -> torch.Tensor:
+    """Basic knowledge distillation loss (KL divergence)."""
+    log_s = F.log_softmax(student_logits / T, dim=1)
+    soft_t = F.softmax(teacher_logits / T, dim=1)
+    return F.kl_div(log_s, soft_t, reduction="batchmean") * (T * T)
+
+
+def ce_loss_fn(logits: torch.Tensor, labels: torch.Tensor, label_smoothing: float = 0.0) -> torch.Tensor:
+    """Cross-entropy loss with optional label smoothing."""
+    return F.cross_entropy(logits, labels, label_smoothing=label_smoothing)
+
+
+def dkd_loss(student_logits: torch.Tensor, teacher_logits: torch.Tensor, labels: torch.Tensor,
+             alpha: float = 1.0, beta: float = 1.0, temperature: float = 4.0) -> torch.Tensor:
+    """Simplified DKD loss combining KD and CE terms."""
+    kd = kd_loss_fn(student_logits, teacher_logits, T=temperature)
+    ce = ce_loss_fn(student_logits, labels)
+    return alpha * kd + beta * ce

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -1,0 +1,65 @@
+"""Lightweight partial freeze utilities for teacher fine-tuning."""
+import torch.nn as nn
+from typing import Any
+
+__all__ = [
+    "freeze_all",
+    "partial_freeze_teacher_resnet",
+    "partial_freeze_teacher_efficientnet",
+    "partial_freeze_teacher_swin",
+]
+
+
+def freeze_all(model: nn.Module) -> None:
+    for p in model.parameters():
+        p.requires_grad = False
+
+
+def _unfreeze(module: Any) -> None:
+    if module is not None:
+        for p in getattr(module, "parameters", lambda: [])():
+            p.requires_grad = True
+
+
+def partial_freeze_teacher_resnet(
+    model: nn.Module,
+    freeze_bn: bool = True,
+    use_adapter: bool = False,
+    bn_head_only: bool = False,
+    freeze_level: int = 1,
+) -> None:
+    """Freeze the ResNet backbone except for the classifier."""
+    if freeze_level <= 0:
+        return
+    freeze_all(model)
+    backbone = getattr(model, "backbone", model)
+    _unfreeze(getattr(backbone, "fc", None))
+
+
+def partial_freeze_teacher_efficientnet(
+    model: nn.Module,
+    freeze_bn: bool = True,
+    use_adapter: bool = False,
+    bn_head_only: bool = False,
+    freeze_level: int = 1,
+) -> None:
+    """Freeze EfficientNet backbone except for the classifier."""
+    if freeze_level <= 0:
+        return
+    freeze_all(model)
+    backbone = getattr(model, "backbone", model)
+    _unfreeze(getattr(backbone, "classifier", None))
+
+
+def partial_freeze_teacher_swin(
+    model: nn.Module,
+    freeze_ln: bool = True,
+    use_adapter: bool = False,
+    freeze_level: int = 1,
+) -> None:
+    """Freeze Swin backbone except for the head."""
+    if freeze_level <= 0:
+        return
+    freeze_all(model)
+    backbone = getattr(model, "backbone", model)
+    _unfreeze(getattr(backbone, "head", None))

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -31,12 +31,7 @@ from models.teachers.teacher_efficientnet import create_efficientnet_b2
 from models.teachers.teacher_swin import create_swin_t
 
 # partial freeze
-from modules.partial_freeze import (
-    partial_freeze_teacher_resnet,
-    partial_freeze_teacher_efficientnet,
-    partial_freeze_teacher_swin,
-)
-from utils.freeze import freeze_all
+from utils.freeze import freeze_all, partial_freeze_teacher_auto
 
 # cutmix finetune
 from modules.cutmix_finetune_teacher import finetune_teacher_cutmix, eval_teacher
@@ -142,43 +137,6 @@ def create_teacher_by_name(
     else:
         raise ValueError(f"[fine_tuning.py] Unknown teacher_type={teacher_type}")
 
-def partial_freeze_teacher_auto(
-    model,
-    teacher_type,
-    freeze_bn=True,
-    freeze_ln=True,
-    use_adapter=False,
-    bn_head_only=False,
-    freeze_level=1,
-):
-    """
-    If needed, partial freeze for fine-tune. Or you can freeze nothing if you want full fine-tune.
-    """
-    if teacher_type in ("resnet101", "resnet152"):
-        partial_freeze_teacher_resnet(
-            model,
-            freeze_bn=freeze_bn,
-            use_adapter=use_adapter,
-            bn_head_only=bn_head_only,
-            freeze_level=freeze_level,
-        )
-    elif teacher_type == "efficientnet_b2":
-        partial_freeze_teacher_efficientnet(
-            model,
-            freeze_bn=freeze_bn,
-            use_adapter=use_adapter,
-            bn_head_only=bn_head_only,
-            freeze_level=freeze_level,
-        )
-    elif teacher_type == "swin_tiny":
-        partial_freeze_teacher_swin(
-            model,
-            freeze_ln=freeze_ln,
-            use_adapter=use_adapter,
-            freeze_level=freeze_level,
-        )
-    else:
-        raise ValueError(f"Unknown teacher_type={teacher_type}")
 
 def standard_ce_finetune(
     model,


### PR DESCRIPTION
## Summary
- implement lightweight `modules` package with `losses`, `partial_freeze`, and CutMix fine-tune helpers
- update `scripts/fine_tuning.py` to rely on new stubs and use `utils.freeze.partial_freeze_teacher_auto`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68649f973b348321b9d74b11e238a2ba