### PR TITLE
Add missing pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 torchvision
 PyYAML
 tqdm
+pandas


### PR DESCRIPTION
## Summary
- include pandas in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch)*

------
https://chatgpt.com/codex/tasks/task_e_6864c171321883218a88a122b1107985