### PR TITLE
Add CLI overrides and finetune helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,10 +17,18 @@ from trainer import teacher_vib_update, student_vib_update, simple_finetune
 from utils.freeze import freeze_all
 
 # ---------- CLI ----------
-parser = argparse.ArgumentParser()
-parser.add_argument('--cfg', default='configs/minimal.yaml')
+parser = argparse.ArgumentParser(description="IB-KD entry point")
+parser.add_argument('--cfg', default='configs/minimal.yaml', help='YAML config')
+parser.add_argument('--teacher1_ckpt', type=str, help='Path to teacher-1 checkpoint')
+parser.add_argument('--teacher2_ckpt', type=str, help='Path to teacher-2 checkpoint')
+parser.add_argument('--results_dir', type=str, help='Where to save logs / ckpts')
 args = parser.parse_args()
 cfg = yaml.safe_load(open(args.cfg))
+
+for k in ('teacher1_ckpt', 'teacher2_ckpt', 'results_dir'):
+    v = getattr(args, k)
+    if v is not None:
+        cfg[k] = v
 
 device = cfg.get('device', 'cuda')
 set_random_seed(cfg.get('seed', 42))

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Lightweight teacher fine-tuning script used by run_ibkd.sh."""
+import argparse
+import os
+import sys
+import yaml
+import torch
+
+sys.path.append(os.path.dirname(__file__) + "/..")
+
+from data.cifar100 import get_cifar100_loaders
+from utils.model_factory import create_teacher_by_name
+from utils.misc import set_random_seed
+from trainer import simple_finetune
+
+
+TEACHER_CHOICES = ["resnet152", "efficientnet_b2"]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Teacher fine-tuning")
+    p.add_argument("--config", default="configs/minimal.yaml")
+    p.add_argument("--teacher_type", choices=TEACHER_CHOICES, required=True)
+    p.add_argument("--finetune_ckpt_path", required=True)
+    p.add_argument("--finetune_epochs", type=int, default=3)
+    p.add_argument("--finetune_lr", type=float, default=1e-4)
+    p.add_argument("--device", default="cuda")
+    return p.parse_args()
+
+
+def load_cfg(path: str) -> dict:
+    if os.path.exists(path):
+        with open(path) as f:
+            return yaml.safe_load(f)
+    return {}
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = load_cfg(args.config)
+    set_random_seed(cfg.get("seed", 42))
+
+    loader, _ = get_cifar100_loaders(
+        batch_size=cfg.get("batch_size", 128),
+        num_workers=cfg.get("num_workers", 0),
+    )
+
+    model = create_teacher_by_name(
+        args.teacher_type,
+        num_classes=100,
+        pretrained=True,
+        small_input=True,
+    ).to(args.device)
+
+    simple_finetune(
+        model,
+        loader,
+        lr=args.finetune_lr,
+        epochs=args.finetune_epochs,
+        device=args.device,
+        cfg=cfg,
+    )
+
+    torch.save(model.state_dict(), args.finetune_ckpt_path)
+    print(f"[FINETUNE] saved => {args.finetune_ckpt_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ibkd.sh
+++ b/scripts/run_ibkd.sh
@@ -19,15 +19,37 @@ python - <<'PY'
 import torch, sys; print("[DEBUG] torch", torch.__version__, "| CUDA =", torch.cuda.is_available())
 PY
 
-# 2) 출력 폴더
+# 1) 경로 설정
+T1_CKPT="ckpts/resnet152_ft.pth"
+T2_CKPT="ckpts/efficientnet_b2_ft.pth"
 JOB_ID=${SLURM_JOB_ID:-local}
 OUT_DIR="$HOME/exp_outputs/ibkd_${JOB_ID}"
 mkdir -p "${OUT_DIR}"
 
-# 3) 실행
+# 2) ──────────────────────────────────────────────
+#    Teacher fine-tune (있으면 skip)
+ft_teacher () {
+  local MODEL=$1
+  local CKPT=$2
+  if [ -f "$CKPT" ]; then
+      echo "[INFO] $MODEL ckpt exists → skip fine-tune"
+  else
+      echo "[INFO] fine-tuning $MODEL → $CKPT"
+      python scripts/fine_tuning.py \
+          --config configs/minimal.yaml \
+          --teacher_type "$MODEL" \
+          --finetune_ckpt_path "$CKPT" \
+          --device cuda \
+          --finetune_epochs 3 \
+          --finetune_lr 1e-4
+  fi
+}
+ft_teacher resnet152       "$T1_CKPT"
+ft_teacher efficientnet_b2 "$T2_CKPT"
+
+# 3) IB-KD 학습
 python main.py \
   --cfg configs/minimal.yaml \
   --results_dir "${OUT_DIR}" \
-  --teacher1_ckpt "${TEACHER1_CKPT:-ckpts/resnet152_ft.pth}" \
-  --teacher2_ckpt "${TEACHER2_CKPT:-ckpts/efficientnet_b2_ft.pth}" \
-  "$@"
+  --teacher1_ckpt "$T1_CKPT" \
+  --teacher2_ckpt "$T2_CKPT"


### PR DESCRIPTION
## Summary
- support more CLI options in `main.py`
- skip teacher fine-tuning in `run_ibkd.sh` when checkpoints exist
- add `scripts/fine_tuning.py` helper for teacher fine-tuning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864c97c339483218b413d9a09c7dfe8