### PR TITLE
Add teacher finetune options

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -34,3 +34,8 @@ grad_clip_norm: 1.0
 teacher_iters: 5
 student_iters: 15
 
+# ─ Teacher Fine-Tune ─────
+finetune_epochs: 3
+finetune_lr: 1e-4
+finetune_weight_decay: 1e-4   # 필요하면
+

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -22,8 +22,9 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--config", default="configs/minimal.yaml")
     p.add_argument("--teacher_type", choices=TEACHER_CHOICES, required=True)
     p.add_argument("--finetune_ckpt_path", required=True)
-    p.add_argument("--finetune_epochs", type=int, default=3)
-    p.add_argument("--finetune_lr", type=float, default=1e-4)
+    p.add_argument("--finetune_epochs", type=int)
+    p.add_argument("--finetune_lr", type=float)
+    p.add_argument("--finetune_weight_decay", type=float)
     p.add_argument("--device", default="cuda")
     return p.parse_args()
 
@@ -52,12 +53,19 @@ def main() -> None:
         small_input=True,
     ).to(args.device)
 
+    epochs = args.finetune_epochs or cfg.get("finetune_epochs", 3)
+    lr = args.finetune_lr or cfg.get("finetune_lr", 1e-4)
+    wd = args.finetune_weight_decay
+    if wd is None:
+        wd = cfg.get("finetune_weight_decay", 0.0)
+
     simple_finetune(
         model,
         loader,
-        lr=args.finetune_lr,
-        epochs=args.finetune_epochs,
+        lr=lr,
+        epochs=epochs,
         device=args.device,
+        weight_decay=wd,
         cfg=cfg,
     )
 

--- a/scripts/run_ibkd.sh
+++ b/scripts/run_ibkd.sh
@@ -39,9 +39,9 @@ ft_teacher () {
           --config configs/minimal.yaml \
           --teacher_type "$MODEL" \
           --finetune_ckpt_path "$CKPT" \
-          --device cuda \
-          --finetune_epochs 3 \
-          --finetune_lr 1e-4
+          --finetune_epochs "${FINETUNE_EPOCHS:-3}" \
+          --finetune_lr     "${FINETUNE_LR:-1e-4}" \
+          --device cuda
   fi
 }
 ft_teacher resnet152       "$T1_CKPT"


### PR DESCRIPTION
## Summary
- add teacher fine-tuning defaults to `configs/minimal.yaml`
- respect YAML defaults in `scripts/fine_tuning.py`
- allow overriding epochs and lr via env vars in `scripts/run_ibkd.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864cc718e0083218f571fa6e27cc753