### PR TITLE
Fix lr/wd override logic in teacher training

### DIFF
--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -100,11 +100,20 @@ def main() -> None:
 
     device = args.device
     model = model.to(device)
+    lr = (
+        cfg.get("finetune_lr", cfg.get("teacher_lr", 1e-4))
+        if args.lr is None
+        else args.lr
+    )
+    wd = (
+        cfg.get("finetune_weight_decay", cfg.get("teacher_weight_decay", 5e-4))
+        if args.wd is None
+        else args.wd
+    )
     opt = torch.optim.AdamW(
         model.parameters(),
-        lr=args.lr or cfg.get("finetune_lr", cfg.get("teacher_lr", 1e-4)),
-        weight_decay=args.wd
-        or cfg.get("finetune_weight_decay", cfg.get("teacher_weight_decay", 5e-4)),
+        lr=lr,
+        weight_decay=wd,
     )
     crit = torch.nn.CrossEntropyLoss()
 


### PR DESCRIPTION
## Summary
- ensure `--lr` and `--wd` command-line options override config defaults even when zero

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864ce9fdca08321abe79d4aa65814e8