### PR TITLE
Fix weight_decay type in simple_finetune

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -12,7 +12,9 @@ def simple_finetune(model, loader, lr, epochs, device, weight_decay=0.0, cfg=Non
         return
     model.train()
     optimizer = torch.optim.Adam(
-        model.parameters(), lr=lr, weight_decay=weight_decay
+        model.parameters(),
+        lr=lr,
+        weight_decay=float(weight_decay),
     )
     autocast_ctx, scaler = get_amp_components(cfg or {})
     criterion = torch.nn.CrossEntropyLoss()


### PR DESCRIPTION
## Summary
- fix runtime error when `weight_decay` is provided as a string by casting to float in `simple_finetune`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864ce95677483218321ee39e08c1cfc