### PR TITLE
Enhance fine-tuning loop and script

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -53,11 +53,23 @@ def main() -> None:
         small_input=True,
     ).to(args.device)
 
-    epochs = args.finetune_epochs or cfg.get("finetune_epochs", 3)
-    lr = args.finetune_lr or cfg.get("finetune_lr", 1e-4)
-    wd = args.finetune_weight_decay
-    if wd is None:
-        wd = cfg.get("finetune_weight_decay", 0.0)
+    epochs = (
+        args.finetune_epochs
+        if args.finetune_epochs is not None
+        else cfg.get("finetune_epochs", 3)
+    )
+    lr = (
+        args.finetune_lr
+        if args.finetune_lr is not None
+        else cfg.get("finetune_lr", 1e-4)
+    )
+    wd = (
+        args.finetune_weight_decay
+        if args.finetune_weight_decay is not None
+        else cfg.get("finetune_weight_decay", 0.0)
+    )
+
+    os.makedirs(os.path.dirname(args.finetune_ckpt_path) or ".", exist_ok=True)
 
     simple_finetune(
         model,
@@ -67,10 +79,10 @@ def main() -> None:
         device=args.device,
         weight_decay=wd,
         cfg=cfg,
+        ckpt_path=args.finetune_ckpt_path,
     )
 
-    torch.save(model.state_dict(), args.finetune_ckpt_path)
-    print(f"[FINETUNE] saved => {args.finetune_ckpt_path}")
+    # best and final checkpoints are saved within ``simple_finetune``
 
 
 if __name__ == "__main__":

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -25,14 +25,16 @@ def get_amp_components(cfg: dict):
     """Return autocast context and scaler based on config."""
     from contextlib import nullcontext
 
-    from torch.cuda.amp import GradScaler, autocast
+    from torch.amp import GradScaler, autocast
 
     use_amp = cfg.get("use_amp", False)
     if use_amp and torch.cuda.is_available():
         dtype = cfg.get("amp_dtype", "float16")
         if dtype == "bfloat16" and not torch.cuda.is_bf16_supported():
             dtype = "float16"
-        autocast_ctx = autocast(dtype=getattr(torch, dtype, torch.float16))
+        autocast_ctx = autocast(
+            device_type="cuda", dtype=getattr(torch, dtype, torch.float16)
+        )
         scaler = GradScaler(init_scale=cfg.get("grad_scaler_init_scale", 1024))
     else:
         autocast_ctx = nullcontext()


### PR DESCRIPTION
## Summary
- improve `simple_finetune` with best-model saving, progress prints and AMP updates
- use `torch.amp` utilities in `get_amp_components`
- revise `fine_tuning.py` to delegate checkpoint handling to the trainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864d14e947883219fe29cd30cb0548a