### PR TITLE
Make paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The project only requires **torch**, **torchvision**, **PyYAML** and **tqdm**.
 1. **Fine-tune teachers** with cross entropy:
 
 ```bash
-python scripts/train_teacher.py --teacher resnet152 --ckpt ckpts/resnet152_ft.pth
-python scripts/train_teacher.py --teacher efficientnet_b2 --ckpt ckpts/efficientnet_b2_ft.pth
+python scripts/train_teacher.py --teacher resnet152 --ckpt checkpoints/resnet152_ft.pth
+python scripts/train_teacher.py --teacher efficientnet_b2 --ckpt checkpoints/efficientnet_b2_ft.pth
 ```
 
 2. **Run IB-KD** using the provided checkpoints:
@@ -33,7 +33,7 @@ Both scripts read default options from `configs/minimal.yaml`.
 ```
 configs/
     minimal.yaml        # experiment settings
-ckpts/                  # teacher checkpoints
+checkpoints/            # teacher checkpoints
 models/                 # teacher and student architectures
 scripts/
     train_teacher.py    # CE fine-tuning

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -4,6 +4,18 @@
 # ─ 기본 ────────────────────────────────────────────
 device: "cuda"
 dataset_name: "cifar100"
+seed: 42
+
+# ─ Data ────────────────────────────────────────────
+dataset_root: "./data"
+batch_size: 128
+num_workers: 2
+
+# ─ 결과 ────────────────────────────────────────────
+results_dir: "results"
+checkpoint_dir: "checkpoints"
+teacher1_ckpt: "checkpoints/resnet152_ft.pth"
+teacher2_ckpt: "checkpoints/efficientnet_b2_ft.pth"
 
 # ─ 모델 ────────────────────────────────────────────
 teacher1_type: "resnet152"

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ parser = argparse.ArgumentParser(description="IB-KD entry point")
 parser.add_argument('--cfg', default='configs/minimal.yaml', help='YAML config')
 parser.add_argument('--teacher1_ckpt', type=str, help='Path to teacher-1 checkpoint')
 parser.add_argument('--teacher2_ckpt', type=str, help='Path to teacher-2 checkpoint')
-parser.add_argument('--results_dir', type=str, help='Where to save logs / ckpts')
+parser.add_argument('--results_dir', type=str, help='Where to save logs / checkpoints')
 parser.add_argument('--batch_size', type=int, help='Mini-batch size for training')
 args = parser.parse_args()
 cfg = yaml.safe_load(open(args.cfg))
@@ -36,6 +36,7 @@ set_random_seed(cfg.get('seed', 42))
 
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(
+    root=cfg.get('dataset_root', './data'),
     batch_size=cfg.get('batch_size', 128),
     num_workers=cfg.get('num_workers', 0),
 )

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -21,7 +21,7 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Teacher fine-tuning")
     p.add_argument("--config", default="configs/minimal.yaml")
     p.add_argument("--teacher_type", choices=TEACHER_CHOICES, required=True)
-    p.add_argument("--finetune_ckpt_path", required=True)
+    p.add_argument("--finetune_ckpt_path")
     p.add_argument("--finetune_epochs", type=int)
     p.add_argument("--finetune_lr", type=float)
     p.add_argument("--finetune_weight_decay", type=float)
@@ -41,7 +41,14 @@ def main() -> None:
     cfg = load_cfg(args.config)
     set_random_seed(cfg.get("seed", 42))
 
+    if args.finetune_ckpt_path is None:
+        ckpt_dir = cfg.get("checkpoint_dir", "checkpoints")
+        args.finetune_ckpt_path = os.path.join(
+            ckpt_dir, f"{args.teacher_type}_ft.pth"
+        )
+
     loader, _ = get_cifar100_loaders(
+        root=cfg.get("dataset_root", "./data"),
         batch_size=cfg.get("batch_size", 128),
         num_workers=cfg.get("num_workers", 0),
     )

--- a/scripts/run_ibkd.sh
+++ b/scripts/run_ibkd.sh
@@ -20,8 +20,8 @@ import torch, sys; print("[DEBUG] torch", torch.__version__, "| CUDA =", torch.c
 PY
 
 # 1) 경로 설정
-T1_CKPT="ckpts/resnet152_ft.pth"
-T2_CKPT="ckpts/efficientnet_b2_ft.pth"
+T1_CKPT="checkpoints/resnet152_ft.pth"
+T2_CKPT="checkpoints/efficientnet_b2_ft.pth"
 JOB_ID=${SLURM_JOB_ID:-local}
 OUT_DIR="$HOME/exp_outputs/ibkd_${JOB_ID}"
 mkdir -p "${OUT_DIR}"

--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -86,7 +86,9 @@ def main() -> None:
 
     batch_size = args.batch_size or cfg.get("batch_size", 128)
     train_loader, test_loader = get_cifar100_loaders(
-        batch_size=batch_size, num_workers=cfg.get("num_workers", 2)
+        root=cfg.get("dataset_root", "./data"),
+        batch_size=batch_size,
+        num_workers=cfg.get("num_workers", 2)
     )
     num_cls = len(train_loader.dataset.classes)
 


### PR DESCRIPTION
## Summary
- move hard-coded paths to `configs/minimal.yaml`
- default fine-tuning results to `checkpoints/`
- load dataset root from config in training scripts
- update README and run scripts for new directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864d821edd88321b1f121c6d32f450c