### PR TITLE
Add checkpoint overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ python scripts/train_teacher.py --teacher resnet152 --ckpt checkpoints/resnet152
 python scripts/train_teacher.py --teacher efficientnet_b2 --ckpt checkpoints/efficientnet_b2_ft.pth
 ```
 
+Pass `--overwrite` to `scripts/fine_tuning.py` to remove an existing checkpoint
+before starting a new run:
+
+```bash
+python scripts/fine_tuning.py --teacher_type resnet152 --overwrite
+```
+
 2. **Run IB-KD** using the provided checkpoints:
 
 ```bash

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -26,6 +26,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--finetune_lr", type=float)
     p.add_argument("--finetune_weight_decay", type=float)
     p.add_argument("--device", default="cuda")
+    p.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Delete existing checkpoint before fine-tuning",
+    )
     return p.parse_args()
 
 
@@ -77,6 +82,13 @@ def main() -> None:
     )
 
     os.makedirs(os.path.dirname(args.finetune_ckpt_path) or ".", exist_ok=True)
+
+    if args.overwrite:
+        if os.path.exists(args.finetune_ckpt_path):
+            os.remove(args.finetune_ckpt_path)
+        last_path = args.finetune_ckpt_path.replace(".pth", "_last.pth")
+        if os.path.exists(last_path):
+            os.remove(last_path)
 
     simple_finetune(
         model,


### PR DESCRIPTION
## Summary
- add `--overwrite` flag to `scripts/fine_tuning.py`
- document the new option in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864da074e8c83219def45d9c2c6c272