### PR TITLE
Fix simple_finetune args

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,8 +49,24 @@ t2 = create_efficientnet_b2(pretrained=True, small_input=True).to(device)
 ft_epochs = cfg.get('finetune_epochs', 0)
 ft_lr = cfg.get('finetune_lr', 1e-4)
 if ft_epochs > 0:
-    simple_finetune(t1, train_loader, ft_lr, ft_epochs, device, cfg)
-    simple_finetune(t2, train_loader, ft_lr, ft_epochs, device, cfg)
+    simple_finetune(
+        t1,
+        train_loader,
+        ft_lr,
+        ft_epochs,
+        device,
+        weight_decay=cfg.get("finetune_weight_decay", 0.0),
+        cfg=cfg,
+    )
+    simple_finetune(
+        t2,
+        train_loader,
+        ft_lr,
+        ft_epochs,
+        device,
+        weight_decay=cfg.get("finetune_weight_decay", 0.0),
+        cfg=cfg,
+    )
 freeze_all(t1)
 freeze_all(t2)
 t1.eval()


### PR DESCRIPTION
## Summary
- pass teacher fine-tune weight decay by keyword
- include cfg when calling `simple_finetune`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864dbaffd948321a0191b4a7a539dca