### PR TITLE
Fix training mode reset in fine-tuning loop

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -38,6 +38,7 @@ def simple_finetune(
     best_acc = 0.0
 
     for ep in range(1, epochs + 1):
+        model.train()
         running_loss = 0.0
         count = 0
         for x, y in loader:
@@ -59,6 +60,7 @@ def simple_finetune(
             count += x.size(0)
 
         acc = evaluate_acc(model, eval_loader, device=device)
+        model.train()
         avg_loss = running_loss / max(count, 1)
 
         tag = ""


### PR DESCRIPTION
## Summary
- ensure the model switches back to training mode each epoch in `simple_finetune`
- restore training mode right after evaluation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864dbbdf29083219453468412260428