### PR TITLE
Add simple_finetune test

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+from .trainer import simple_finetune
+
+__all__ = ["simple_finetune"]

--- a/tests/test_simple_finetune.py
+++ b/tests/test_simple_finetune.py
@@ -1,0 +1,23 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from ASMB_KD import simple_finetune
+
+
+def test_simple_finetune_runs(tmp_path):
+    model = torch.nn.Linear(4, 2)
+    x = torch.randn(8, 4)
+    y = torch.randint(0, 2, (8,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=2)
+    ckpt = tmp_path / "ft.pth"
+    simple_finetune(
+        model,
+        loader,
+        lr=0.1,
+        epochs=1,
+        device="cpu",
+        weight_decay=0.1,
+        cfg={},
+        ckpt_path=str(ckpt),
+    )
+    assert model.training

--- a/trainer.py
+++ b/trainer.py
@@ -60,6 +60,8 @@ def simple_finetune(
 
         acc = evaluate_acc(model, eval_loader, device=device)
         avg_loss = running_loss / max(count, 1)
+        # return to train mode after evaluation
+        model.train()
 
         tag = ""
         if acc > best_acc:
@@ -77,6 +79,7 @@ def simple_finetune(
     print(
         f"[FineTune] done \u2192 best={best_acc:.2f}% ({ckpt_path}), last={last_path}"
     )
+    model.train()
 
 
 def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer):


### PR DESCRIPTION
## Summary
- expose `simple_finetune` as a package export
- ensure `simple_finetune` returns the model in training mode
- add a regression test for `simple_finetune`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864dbb5c7148321817ec5a4ec198537