### PR TITLE
Fix LR cast in teacher training

### DIFF
--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -114,8 +114,8 @@ def main() -> None:
     )
     opt = torch.optim.AdamW(
         model.parameters(),
-        lr=lr,
-        weight_decay=wd,
+        lr=float(lr),
+        weight_decay=float(wd),
     )
     crit = torch.nn.CrossEntropyLoss()
 


### PR DESCRIPTION
## Summary
- cast learning rate and weight decay to float in teacher training script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6864eb523fac8321bfb97e1ce3f39e18