### PR TITLE
Add per-epoch accuracy logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ bash scripts/run_ibkd.sh
 ```
 
 Both scripts read default options from `configs/minimal.yaml`.
+Set `disable_tqdm: true` in that file to suppress progress bars during training.
 
 ## Directory Layout
 

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -2,6 +2,7 @@
 
 batch_size: 128              # ↑ 가능하면 256 (GPU 여유 시)
 num_workers: 2
+disable_tqdm: true
 
 student_type: "convnext_tiny"
 

--- a/main.py
+++ b/main.py
@@ -132,8 +132,28 @@ opt_s = AdamW(
 )
 
 # ---------- training ----------
-teacher_vib_update(t1, t2, mbm, train_loader, cfg, opt_t)
-student_vib_update(t1, t2, student, mbm, proj, train_loader, cfg, opt_s)
+teacher_vib_update(
+    t1,
+    t2,
+    mbm,
+    train_loader,
+    cfg,
+    opt_t,
+    test_loader=test_loader,
+    logger=logger,
+)
+student_vib_update(
+    t1,
+    t2,
+    student,
+    mbm,
+    proj,
+    train_loader,
+    cfg,
+    opt_s,
+    test_loader=test_loader,
+    logger=logger,
+)
 
 if cfg.get("eval_after_train", True):
     acc = evaluate_acc(

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -22,3 +22,24 @@ def evaluate_acc(model, loader, device="cuda", cfg=None, mixup_active: bool = Fa
         correct += (preds == y).sum().item()
         total += y.size(0)
     return 100.0 * correct / total
+
+
+@torch.no_grad()
+def evaluate_mbm_acc(teacher1, teacher2, vib_mbm, loader, device="cuda"):
+    """Evaluate classification accuracy of ``vib_mbm`` using frozen teachers."""
+    vib_mbm.eval()
+    teacher1.eval()
+    teacher2.eval()
+    correct = 0
+    total = 0
+    for x, y in loader:
+        x, y = x.to(device), y.to(device)
+        out1 = teacher1(x)
+        out2 = teacher2(x)
+        t1_dict = out1[0] if isinstance(out1, tuple) else out1
+        t2_dict = out2[0] if isinstance(out2, tuple) else out2
+        logits = vib_mbm(t1_dict["feat_2d"], t2_dict["feat_2d"])[1]
+        preds = logits.argmax(dim=1)
+        correct += (preds == y).sum().item()
+        total += y.size(0)
+    return 100.0 * correct / total


### PR DESCRIPTION
## Summary
- compute train/test accuracy each epoch
- pass logger and test loader to training loops
- expose an option to suppress tqdm progress bars
- document new option in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686521f268e4832194aa70f645701951