### PR TITLE
Fix KD schedule debug output

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -294,7 +294,7 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
             T        = init_T     * (1 - prog_p) + final_T     * prog_p
 
             # ─────────────── DEBUG: 스케줄 값 모니터링 ───────────────
-            if batch_idx == 0 and ep in {0, 5, 10, 20, 39}:
+            if batch_idx == 0 and ep in {0, 5, 10, 20, total_epochs - 1}:
                 print(f"[KD-sched] ep{ep:02d} α={alpha_kd:.3f}, T={T:.2f}, prog={prog_p:.2f}")
 
             # ─ Losses ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update KD schedule debug monitoring to show final epoch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68660b3ac778832198ad44f32c929a3a