### PR TITLE
Flatten input in StudentProj forward

### DIFF
--- a/models/ib/proj_head.py
+++ b/models/ib/proj_head.py
@@ -31,5 +31,6 @@ class StudentProj(nn.Module):
         self._normalize = normalize
 
     def forward(self, x):
+        x = x.flatten(1)
         z = self.net(x)
         return F.normalize(z) if self._normalize else z

--- a/models/students/student_proj.py
+++ b/models/students/student_proj.py
@@ -31,5 +31,6 @@ class StudentProj(nn.Module):
         self._normalize = normalize
 
     def forward(self, x):
+        x = x.flatten(1)
         z = self.net(x)
         return F.normalize(z) if self._normalize else z


### PR DESCRIPTION
## Summary
- flatten inputs before passing through the StudentProj projection network

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686733f4c90c8321b25d4092d00a3eb9