### PR TITLE
Fix BatchNorm layer order

### DIFF
--- a/models/ib/proj_head.py
+++ b/models/ib/proj_head.py
@@ -25,7 +25,7 @@ class StudentProj(nn.Module):
 
         layers.append(nn.Linear(in_dim, out_dim, bias=not use_bn))
         if use_bn:
-            layers.insert(1, nn.BatchNorm1d(out_dim))
+            layers.append(nn.BatchNorm1d(out_dim))
 
         self.net = nn.Sequential(*layers)
         self._normalize = normalize

--- a/models/students/student_proj.py
+++ b/models/students/student_proj.py
@@ -25,7 +25,7 @@ class StudentProj(nn.Module):
 
         layers.append(nn.Linear(in_dim, out_dim, bias=not use_bn))
         if use_bn:
-            layers.insert(1, nn.BatchNorm1d(out_dim))
+            layers.append(nn.BatchNorm1d(out_dim))
 
         self.net = nn.Sequential(*layers)
         self._normalize = normalize


### PR DESCRIPTION
## Summary
- attach BatchNorm after Linear layer in `proj_head` and `student_proj`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686738179ff08321aed34978c638f83d