### PR TITLE
Add mixup flag to eval and fix RandAug defaults

### DIFF
--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -21,8 +21,8 @@ def get_cifar100_loaders(
         aug_ops = [T.RandomCrop(32, padding=4), T.RandomHorizontalFlip()]
         if randaug_N > 0 and randaug_M > 0:
             aug_ops.append(T.RandAugment(num_ops=randaug_N, magnitude=randaug_M))
-        else:
-            aug_ops.append(T.RandAugment())
+        else:                                   # 기본 N=2, M=9 고정
+            aug_ops.append(T.RandAugment(num_ops=2, magnitude=9))
         aug_ops.extend([
             T.ToTensor(),
             T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -22,8 +22,8 @@ def get_imagenet100_loaders(
         aug_ops = [T.RandomResizedCrop(224), T.RandomHorizontalFlip()]
         if randaug_N > 0 and randaug_M > 0:
             aug_ops.append(T.RandAugment(num_ops=randaug_N, magnitude=randaug_M))
-        else:
-            aug_ops.append(T.RandAugment())
+        else:                                   # 기본 N=2, M=9 고정
+            aug_ops.append(T.RandAugment(num_ops=2, magnitude=9))
         aug_ops.extend([
             T.ToTensor(),
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -3,7 +3,12 @@
 import torch
 
 @torch.no_grad()
-def evaluate_acc(model, loader, device="cuda", cfg=None, mixup_active: bool = False):
+def evaluate_acc(
+    model,
+    loader,
+    device: str = "cuda",
+    mixup_active: bool = False,   # NEW – 호출 처리를 위한 더미 플래그
+):
     model.eval()
     correct = 0
     total = 0
@@ -15,6 +20,8 @@ def evaluate_acc(model, loader, device="cuda", cfg=None, mixup_active: bool = Fa
         y = y.squeeze()
         if mixup_active and y.ndim > 1:
             y = y.argmax(dim=1)
+        # 학습-평가 공통 호출을 위해 mixup_active 플래그만 받는다.
+        # 평가 시엔 실제 MixUp 입력이 없으므로 로직 변화 없음.
         out = model(x)
         if isinstance(out, tuple):
             logits = out[1]


### PR DESCRIPTION
## Summary
- update `evaluate_acc` API to allow `mixup_active` usage in both train/test
- clarify that `mixup_active` doesn't alter inference path
- use fixed `RandAugment` defaults when unspecified for CIFAR100 and ImageNet100

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68674d54d0f08321a67d5a321490f512