### PR TITLE
Fix Optional type hints

### DIFF
--- a/methods/crd.py
+++ b/methods/crd.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn.functional as F
+from typing import Optional
 from tqdm.auto import tqdm
 
 from modules.losses import kd_loss_fn, ce_loss_fn
@@ -20,7 +21,7 @@ class CRDDistiller:
         alpha: float = 0.5,
         temperature: float = 0.07,
         label_smoothing: float = 0.0,
-        config: dict | None = None,
+        config: Optional[dict] = None,
     ) -> None:
         self.teacher = teacher_model
         self.student = student_model
@@ -37,7 +38,7 @@ class CRDDistiller:
         lr: float = 5e-4,
         weight_decay: float = 5e-4,
         device: str = "cuda",
-        cfg: dict | None = None,
+        cfg: Optional[dict] = None,
     ) -> float:
         cfg = {**self.cfg, **(cfg or {})}
         device = device or cfg.get("device", "cuda")

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -1,6 +1,7 @@
 """Simplified Decoupled Knowledge Distillation."""
 
 import torch
+from typing import Optional
 from tqdm.auto import tqdm
 
 from modules.losses import dkd_loss
@@ -21,7 +22,7 @@ class DKDDistiller:
         temperature: float = 4.0,
         warmup: int = 5,
         label_smoothing: float = 0.0,
-        config: dict | None = None,
+        config: Optional[dict] = None,
     ) -> None:
         self.teacher = teacher_model
         self.student = student_model
@@ -40,7 +41,7 @@ class DKDDistiller:
         lr: float = 5e-4,
         weight_decay: float = 5e-4,
         device: str = "cuda",
-        cfg: dict | None = None,
+        cfg: Optional[dict] = None,
     ) -> float:
         cfg = {**self.cfg, **(cfg or {})}
         device = device or cfg.get("device", "cuda")

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -1,6 +1,7 @@
 """Standard knowledge distillation helper."""
 
 import torch
+from typing import Optional
 from tqdm.auto import tqdm
 
 from modules.losses import kd_loss_fn, ce_loss_fn
@@ -18,7 +19,7 @@ class VanillaKDDistiller:
         student_model,
         alpha: float = 0.5,
         temperature: float = 4.0,
-        config: dict | None = None,
+        config: Optional[dict] = None,
     ) -> None:
         self.teacher = teacher_model
         self.student = student_model
@@ -34,7 +35,7 @@ class VanillaKDDistiller:
         lr: float = 5e-4,
         weight_decay: float = 5e-4,
         device: str = "cuda",
-        cfg: dict | None = None,
+        cfg: Optional[dict] = None,
     ) -> float:
         cfg = {**self.cfg, **(cfg or {})}
         device = device or cfg.get("device", "cuda")


### PR DESCRIPTION
## Summary
- fix `config: Optional[dict]` pattern for distillers
- import Optional in distiller modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68675d9db5848321b9e6c74db9ef9b41