### PR TITLE
Update distillers with nn.Module and detach

### DIFF
--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -50,7 +50,7 @@ class DKDDistiller:
 
     def forward(self, x, y, warm):
         with torch.no_grad():
-            t_logits = self._get_logits(self.teacher(x))
+            t_logits = self._get_logits(self.teacher(x)).detach()
         s_logits = self._get_logits(self.student(x))
 
         ce = self.ce_weight * cross_entropy(


### PR DESCRIPTION
## Summary
- inherit `CRDDistiller` from `nn.Module`
- create projection head once in CRD init
- train projection parameters and move to device
- detach teacher logits in DKD forward

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68676ba283148321a424feea165de83c