### PR TITLE
Apply training loop fixes for KD distillers

### DIFF
--- a/methods/crd.py
+++ b/methods/crd.py
@@ -86,7 +86,7 @@ class CRDDistiller(nn.Module):
     ) -> float:
         cfg = {**self.cfg, **(cfg or {})}
         device = device or cfg.get("device", "cuda")
-        self.teacher.eval()
+        self.teacher.to(device).eval()
         self.student.to(device)
         self.proj.to(device)
         optimizer = torch.optim.AdamW(
@@ -97,6 +97,7 @@ class CRDDistiller(nn.Module):
         autocast_ctx, scaler = get_amp_components(cfg)  # ce_criterion 제거
         for ep in range(epochs):
             self.student.train()
+            self.proj.train()          # <- 권장 (선택)
             running = 0.0
             correct = 0
             count = 0

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -79,7 +79,7 @@ class DKDDistiller:
     ) -> float:
         cfg = {**self.cfg, **(cfg or {})}
         device = device or cfg.get("device", "cuda")
-        self.teacher.eval()
+        self.teacher.to(device).eval()
         self.student.to(device)
         optimizer = torch.optim.AdamW(
             self.student.parameters(), lr=float(lr), weight_decay=float(weight_decay)


### PR DESCRIPTION
## Summary
- ensure teacher models are moved to the target device before eval in DKD/CRD
- set projection head to train mode during CRD distillation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68676da2d2908321a63e08e1acb2beb0