### PR TITLE
Update logs and show hyperparams

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,19 @@ set_random_seed(cfg.get('seed', 42))
 method = cfg.get('method', 'vib').lower()
 assert method in {'vib', 'dkd', 'crd', 'vanilla'}, "unknown method"
 
+# ----- pretty-print key hyper-params -----
+important_keys = [
+    "method", "batch_size", "student_lr", "teacher_lr",
+    "proj_hidden_dim", "z_dim",
+    "kd_alpha_init", "kd_alpha_final", "kd_T_init", "kd_T_final",
+    "latent_alpha", "randaug_N", "randaug_M",
+]
+print("┌─ Hyper-parameters (" + str(len(important_keys)) + ")")
+for k in important_keys:
+    if k in cfg:
+        print(f"│ {k:18s}: {cfg[k]}")
+print("└───────────────────────────────────────")
+
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(
     root=cfg.get('dataset_root', './data'),

--- a/trainer.py
+++ b/trainer.py
@@ -200,14 +200,15 @@ def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer, test
             from utils.eval import evaluate_mbm_acc
 
             test_acc = evaluate_mbm_acc(teacher1, teacher2, vib_mbm, test_loader, device)
-        print(
+        msg = (
             f"[Teacher] ep {ep + 1:03d}/{cfg.get('teacher_iters', 1)} "
-            f"loss {avg_loss:.4f} kl {avg_kl:.4f} "
-            f"train_acc {train_acc:.2f}%  student_acc {test_acc:.2f}%"
+            f"loss {avg_loss:.4f} kl {avg_kl:.4f} train_acc {train_acc:.2f}%  "
+            f"test_acc {test_acc:.2f}%"
         )
+        print(msg)
         if logger is not None:
             logger.update_metric(f"teacher_ep{ep + 1}_train_acc", float(train_acc))
-            logger.update_metric(f"teacher_ep{ep + 1}_test_acc", float(test_acc))
+            logger.update_metric(f"teacher_ep{ep + 1}_test_acc",    float(test_acc))
 
         # ────────── DEBUG ④ synergy acc 첫 epoch 후 한 번 출력 ──────────
         if ep == 0:
@@ -414,7 +415,8 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
 
         msg = (
             f"[Student] ep {ep + 1:03d}/{cfg.get('student_iters', 1)} "
-            f"loss {avg_loss:.4f} train_acc {train_acc:.2f}%  student_acc {student_acc:.2f}%"
+            f"loss {avg_loss:.4f} train_acc {train_acc:.2f}%  "
+            f"test_acc {student_acc:.2f}%"
         )
         if ema_acc is not None:
             msg += f"  ema_acc {ema_acc:.2f}%"
@@ -422,7 +424,7 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
 
         if logger is not None:
             logger.update_metric(f"student_ep{ep + 1}_train_acc", float(train_acc))
-            logger.update_metric("student_acc",  float(student_acc), step=ep + 1)
+            logger.update_metric("test_acc",     float(student_acc), step=ep + 1)
             if ema_acc is not None:
                 logger.update_metric("ema_acc",  float(ema_acc),    step=ep + 1)
 


### PR DESCRIPTION
## Summary
- improve teacher and student log output
- rename logged metrics to use `test_acc`
- print important hyperparameters at startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68678347d4c4832188072a7c759b1401