### PR TITLE
Implement per-epoch accuracy logging

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -423,10 +423,16 @@ def student_vib_update(teacher1, teacher2, student_model, vib_mbm, student_proj,
         print(msg)
 
         if logger is not None:
-            logger.update_metric(f"student_ep{ep + 1}_train_acc", float(train_acc))
-            logger.update_metric("test_acc",     float(student_acc), step=ep + 1)
+            logger.update_metric(
+                f"student_ep{ep + 1}_train_acc", float(train_acc)
+            )
+            logger.update_metric(
+                f"student_ep{ep + 1}_test_acc",  # ← 에폭 구분용 별도 키
+                float(student_acc),
+                step=ep + 1,
+            )
             if ema_acc is not None:
-                logger.update_metric("ema_acc",  float(ema_acc),    step=ep + 1)
+                logger.update_metric("ema_acc", float(ema_acc), step=ep + 1)
 
 # ─ 최종 EMA 성능 저장 ──────────────────────────────
     if cfg.get("use_ema", False) and test_loader is not None:

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -165,7 +165,7 @@ class ExperimentLogger:
 
         # ── 한 줄 summary ───────────────────────
         tr = self.config.get("train_acc", "-")
-        te = self.config.get("test_acc",  "-")
+        te = self.config.get("final_test_acc", self.config.get("test_acc", "-"))
         self.info(
             f"SUMMARY │ {self.exp_id} │ train {tr} │ test {te} │ "
             f"time {total_time/60:.1f} min"


### PR DESCRIPTION
## Summary
- track student test accuracy for each epoch
- display `final_test_acc` when summarizing results

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68678954ccf4832194c7dc139fce5d0d