### PR TITLE
Add ConvNeXt-Small model option

### DIFF
--- a/utils/model_factory.py
+++ b/utils/model_factory.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 from models.teachers.teacher_resnet import create_resnet152
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
-from models.students.student_convnext import create_convnext_tiny
+from models.students.student_convnext import (
+    create_convnext_tiny,
+    create_convnext_small,
+)
 
 __all__ = [
     "create_teacher_by_name",
@@ -57,7 +60,14 @@ def create_student_by_name(
             small_input=small_input,
             cfg=cfg,
         )
+    if student_type == "convnext_small":
+        return create_convnext_small(
+            num_classes=num_classes,
+            pretrained=pretrained,
+            small_input=small_input,
+            cfg=cfg,
+        )
     raise ValueError(
-        f"Unknown student_type: {student_type} (expected 'convnext_tiny')"
+        f"Unknown student_type: {student_type} (expected 'convnext_tiny' or 'convnext_small')"
     )
 


### PR DESCRIPTION
## Summary
- expand `student_convnext` with timm-based ConvNeXt-Small helper
- expose new helper in `model_factory`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68680b2722448321bf5d071d3ffd92fb