### PR TITLE
Enable torchvision ConvNeXt models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
-torchvision
+torchvision>=0.15
 PyYAML
 tqdm
 pandas


### PR DESCRIPTION
## Summary
- switch ConvNeXt student implementations to `torchvision`
- support both tiny and small architectures
- update requirement for torchvision

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68680f2e7754832196e57b9c9f3238a9