### PR TITLE
Fix convnext loading and add student factory

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from utils.eval import evaluate_acc
 from data.cifar100 import get_cifar100_loaders
 from models.teachers.teacher_resnet import create_resnet152
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
-from models.students.student_convnext import create_convnext_tiny
+from utils.model_factory import create_student_by_name               # NEW
 from trainer import teacher_vib_update, student_vib_update, simple_finetune
 from utils.freeze import freeze_all
 from utils.logger import ExperimentLogger
@@ -137,7 +137,13 @@ in1 = t1.get_feat_dim(); in2 = t2.get_feat_dim()
 mbm = VIB_MBM(in1, in2, cfg['z_dim'], n_cls=100).to(device)
 
 # ---------- student ----------
-student = create_convnext_tiny(num_classes=100, small_input=True).to(device)
+student = create_student_by_name(
+    cfg.get("student_type", "convnext_tiny"),   # ex) "convnext_small"
+    num_classes=100,
+    pretrained=True,
+    small_input=True,
+    cfg=cfg,
+).to(device)
 proj = StudentProj(
     in_dim        = student.get_feat_dim(),
     out_dim       = cfg['z_dim'],

--- a/models/students/student_convnext.py
+++ b/models/students/student_convnext.py
@@ -81,7 +81,11 @@ def create_convnext_tiny(
     cfg: Optional[dict] = None,
 ):
     w = ConvNeXt_Tiny_Weights.IMAGENET1K_V1 if pretrained else None
-    model = convnext_tiny(weights=w, num_classes=num_classes)
+    if pretrained:
+        # ① 가중치만 불러오고, num_classes는 건드리지 않는다.
+        model = convnext_tiny(weights=w)              # 1000‑cls head
+    else:
+        model = convnext_tiny(weights=None, num_classes=num_classes)
 
     if small_input:
         _patch_cifar_stem(model)
@@ -101,7 +105,10 @@ def create_convnext_small(
     cfg: Optional[dict] = None,
 ):
     w = ConvNeXt_Small_Weights.IMAGENET1K_V1 if pretrained else None
-    model = convnext_small(weights=w, num_classes=num_classes)
+    if pretrained:
+        model = convnext_small(weights=w)
+    else:
+        model = convnext_small(weights=None, num_classes=num_classes)
 
     if small_input:
         _patch_cifar_stem(model)


### PR DESCRIPTION
## Summary
- fix pretrained handling for ConvNeXt students so torchvision loads with 1000-class head
- select student architecture via factory in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686883a4396c83219341eb27be0931d0