### PR TITLE
Remove unused features attribute

### DIFF
--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -19,8 +19,6 @@ class TeacherEfficientNetWrapper(nn.Module):
     def __init__(self, backbone, cfg: Optional[dict] = None):
         super().__init__()
         self.backbone = backbone
-        # expose backbone for feature hooks
-        self.features = self.backbone
         self.criterion_ce = nn.CrossEntropyLoss()
 
         # 추가: EffNet-B2의 글로벌 피처 차원(1408)

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -24,8 +24,6 @@ class TeacherResNetWrapper(nn.Module):
     def __init__(self, backbone: nn.Module, cfg: Optional[dict] = None):
         super().__init__()
         self.backbone = backbone
-        # expose backbone for feature hooks
-        self.features = self.backbone
         self.criterion_ce = nn.CrossEntropyLoss()
 
         # 추가: ResNet101의 글로벌 피처 차원 (기본 2048)


### PR DESCRIPTION
## Summary
- remove leftover `features` attribute from teacher models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868d44e88a88321b05c3a30f1a82be6