### PR TITLE
Expose randaug defaults via config

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -55,6 +55,8 @@ latent_alpha: 0.8         # feature 정렬 가중 ↑
 label_smoothing: 0.05         # 🔹 CE 안정화
 randaug_N: 2                 # 🔹 RandAug(N,M)
 randaug_M: 7
+randaug_default_N: 2         # fallback RandAug(N,M) N
+randaug_default_M: 9         # fallback RandAug(N,M) M
  
 teacher_weight_decay: 5e-4
 student_weight_decay: 5e-4

--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -3,6 +3,7 @@
 import torch
 import torchvision
 import torchvision.transforms as T
+from typing import Mapping, Any, Optional
 
 def get_cifar100_loaders(
     root: str = "./data",
@@ -11,6 +12,9 @@ def get_cifar100_loaders(
     augment: bool = True,
     randaug_N: int = 0,
     randaug_M: int = 0,
+    cfg: Optional[Mapping[str, Any]] = None,
+    randaug_default_N: int = 2,
+    randaug_default_M: int = 9,
 ):
     """
     CIFAR-100 size = (32x32)
@@ -19,10 +23,13 @@ def get_cifar100_loaders(
     """
     if augment:
         aug_ops = [T.RandomCrop(32, padding=4), T.RandomHorizontalFlip()]
+        if cfg is not None:
+            randaug_default_N = cfg.get("randaug_default_N", randaug_default_N)
+            randaug_default_M = cfg.get("randaug_default_M", randaug_default_M)
         if randaug_N > 0 and randaug_M > 0:
             aug_ops.append(T.RandAugment(num_ops=randaug_N, magnitude=randaug_M))
-        else:                                   # 기본 N=2, M=9 고정
-            aug_ops.append(T.RandAugment(num_ops=2, magnitude=9))
+        else:
+            aug_ops.append(T.RandAugment(num_ops=randaug_default_N, magnitude=randaug_default_M))
         aug_ops.extend([
             T.ToTensor(),
             T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -1,6 +1,7 @@
 # data/imagenet100.py
 
 import os
+from typing import Mapping, Any, Optional
 import torch
 import torchvision
 import torchvision.transforms as T
@@ -12,6 +13,9 @@ def get_imagenet100_loaders(
     augment: bool = True,
     randaug_N: int = 0,
     randaug_M: int = 0,
+    cfg: Optional[Mapping[str, Any]] = None,
+    randaug_default_N: int = 2,
+    randaug_default_M: int = 9,
 ):
     """    
     ImageNet100 size = (224×224)
@@ -20,10 +24,13 @@ def get_imagenet100_loaders(
     """
     if augment:
         aug_ops = [T.RandomResizedCrop(224), T.RandomHorizontalFlip()]
+        if cfg is not None:
+            randaug_default_N = cfg.get("randaug_default_N", randaug_default_N)
+            randaug_default_M = cfg.get("randaug_default_M", randaug_default_M)
         if randaug_N > 0 and randaug_M > 0:
             aug_ops.append(T.RandAugment(num_ops=randaug_N, magnitude=randaug_M))
-        else:                                   # 기본 N=2, M=9 고정
-            aug_ops.append(T.RandAugment(num_ops=2, magnitude=9))
+        else:
+            aug_ops.append(T.RandAugment(num_ops=randaug_default_N, magnitude=randaug_default_M))
         aug_ops.extend([
             T.ToTensor(),
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),


### PR DESCRIPTION
## Summary
- add `randaug_default_N` and `randaug_default_M` to minimal config
- let CIFAR100 and ImageNet100 loaders fetch fallback RandAug values from config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a01881d00832194b909a77bfdf0ba