### PR TITLE
Make teacher dropout configurable

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -61,6 +61,7 @@ randaug_default_M: 9         # fallback RandAug(N,M) M
 teacher_weight_decay: 5e-4
 student_weight_decay: 5e-4
 teacher_lr: 1e-3        # MBM Adam LR ↑
+teacher_dropout_p: 0.3      # teacher classifier dropout
 student_lr: 1.0e-3          # convnext_tiny 는 1e‑3 이상에서 더 잘 수렴
 lr_schedule: "cosine"
 # 학습률 warm‑up

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -82,6 +82,9 @@ def create_efficientnet_b2(
     small_input=True 시, CIFAR-100과 같은 작은 이미지에 맞게 stem stride를 1로 수정
     => TeacherEfficientNetWrapper로 감싸서 반환
     """
+    if cfg is not None:
+        dropout_p = cfg.get("teacher_dropout_p", dropout_p)
+
     if pretrained:
         model = efficientnet_b2(weights=EfficientNet_B2_Weights.IMAGENET1K_V1)
     else:

--- a/utils/model_factory.py
+++ b/utils/model_factory.py
@@ -25,6 +25,8 @@ def create_teacher_by_name(
     cfg: Optional[dict] = None,
 ):
     """Factory for teacher models in this minimal repo."""
+    if cfg is not None:
+        dropout_p = cfg.get("teacher_dropout_p", dropout_p)
     if teacher_type == "resnet152":
         return create_resnet152(
             num_classes=num_classes,


### PR DESCRIPTION
## Summary
- add `teacher_dropout_p` to the minimal config
- use `teacher_dropout_p` from the config when constructing teacher models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a02e35c0483219bfbed1a9e1f0687