### PR TITLE
Expose scheduler ratios via config

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -79,6 +79,8 @@ cutmix_alpha_distill: 0.5
 
 teacher_iters: 20       # MBM 더 학습
 student_iters: 90       # 정규화로 안정 ⇒ epoch 확장
+student_warmup_epochs: 3    # cosine warm-up length for student training
+min_lr_ratio_student: 0.05  # cosine scheduler minimum LR ratio
 
 # ─ EMA 평가 ─────────────
 use_ema: true
@@ -92,6 +94,7 @@ finetune_weight_decay: 3e-4  # WD ↓
 # ─ Teacher fine‑tune scheduler ─
 finetune_warmup: 5           # NEW – warm‑up epoch
 finetune_sched: "cosine"     # linear‑warmup + cosine
+min_lr_ratio_finetune: 0.1   # cosine scheduler minimum LR ratio
 
 # ─ Fine‑tune aug ─
 finetune_randaug_N: 2

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -93,7 +93,12 @@ class CRDDistiller(nn.Module):
             list(self.student.parameters()) + list(self.proj.parameters()),
             lr=float(lr), weight_decay=float(weight_decay)
         )
-        scheduler = cosine_lr_scheduler(optimizer, epochs)
+        scheduler = cosine_lr_scheduler(
+            optimizer,
+            epochs,
+            warmup_epochs=cfg.get("student_warmup_epochs", 0),
+            min_lr_ratio=cfg.get("min_lr_ratio_student", 0.05),
+        )
         autocast_ctx, scaler = get_amp_components(cfg)  # ce_criterion 제거
         for ep in range(epochs):
             self.student.train()

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -84,7 +84,12 @@ class DKDDistiller:
         optimizer = torch.optim.AdamW(
             self.student.parameters(), lr=float(lr), weight_decay=float(weight_decay)
         )
-        scheduler = cosine_lr_scheduler(optimizer, epochs)
+        scheduler = cosine_lr_scheduler(
+            optimizer,
+            epochs,
+            warmup_epochs=cfg.get("student_warmup_epochs", 0),
+            min_lr_ratio=cfg.get("min_lr_ratio_student", 0.05),
+        )
         autocast_ctx, scaler = get_amp_components(cfg)  # criterion_ce 삭제
         for ep in range(epochs):
             self.student.train()

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -46,7 +46,12 @@ class VanillaKDDistiller:
         optimizer = torch.optim.AdamW(
             self.student.parameters(), lr=float(lr), weight_decay=float(weight_decay)
         )
-        scheduler = cosine_lr_scheduler(optimizer, epochs)
+        scheduler = cosine_lr_scheduler(
+            optimizer,
+            epochs,
+            warmup_epochs=cfg.get("student_warmup_epochs", 0),
+            min_lr_ratio=cfg.get("min_lr_ratio_student", 0.05),
+        )
         autocast_ctx, scaler = get_amp_components(cfg)
         ce_criterion = torch.nn.CrossEntropyLoss(label_smoothing=cfg.get("label_smoothing", 0.0))
         for ep in range(epochs):

--- a/trainer.py
+++ b/trainer.py
@@ -49,7 +49,7 @@ def simple_finetune(
         optimizer,
         epochs,
         warmup_epochs=(cfg or {}).get("finetune_warmup", 0),
-        min_lr_ratio=0.1,
+        min_lr_ratio=(cfg or {}).get("min_lr_ratio_finetune", 0.1),
     )
     autocast_ctx, scaler = get_amp_components(cfg or {})
 
@@ -272,12 +272,11 @@ def student_vib_update(
     ema_model = None
     total_epochs = cfg.get("student_iters", 1)
     if scheduler is None:
-        # warm-up 3 epochs + cosine
         scheduler = cosine_lr_scheduler(
             optimizer,
             total_epochs,
-            warmup_epochs=3,
-            min_lr_ratio=0.05,
+            warmup_epochs=cfg.get("student_warmup_epochs", 3),
+            min_lr_ratio=cfg.get("min_lr_ratio_student", 0.05),
         )
 
     # 총 업데이트 횟수 (스케줄 계산용)


### PR DESCRIPTION
## Summary
- add `min_lr_ratio_finetune`, `min_lr_ratio_student` and `student_warmup_epochs` options in `minimal.yaml`
- wire these configs to `cosine_lr_scheduler` inside `simple_finetune` and `student_vib_update`
- allow all distiller classes to respect the new scheduler settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a03903960832192dbaa945d6ea5e0