### PR TITLE
Add EMA warmup configuration

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -87,6 +87,8 @@ min_lr_ratio_student: 0.05  # cosine scheduler minimum LR ratio
 # ─ EMA 평가 ─────────────
 use_ema: true
 ema_decay: 0.992
+ema_warmup_iters: 5
+ema_initial_decay: 0.90
 
 # --- Teacher fine‑tune ---
 finetune_epochs: 30          # +10 epoch

--- a/trainer.py
+++ b/trainer.py
@@ -433,8 +433,9 @@ def student_vib_update(
                 # warm-up: 초기에는 빠르게, 점점 느리게
                 base = cfg.get("ema_decay", 0.995)     # 최종 목표치
                 warm = cfg.get("ema_warmup_iters", 5)  # 앞 N epoch
+                init = cfg.get("ema_initial_decay", 0.90)  # 초기 decay
                 cur  = min(ep, warm) / warm
-                d = base * cur + (1 - cur) * 0.90      # 0.90 → base 로 선형 전환
+                d = base * cur + (1 - cur) * init      # init → base 로 선형 전환
                 for p_ema, p in zip(ema_model.parameters(),
                                     student_model.parameters()):
                     p_ema.data.mul_(d).add_(p.data, alpha=1 - d)


### PR DESCRIPTION
## Summary
- expose `ema_warmup_iters` and `ema_initial_decay` in `minimal.yaml`
- honor those values in `student_vib_update`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a05163dd08321ac086ca40c05b642