### PR TITLE
Add AMP grad scaler init scale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ bash scripts/run_ibkd.sh
 
 Both scripts read default options from `configs/minimal.yaml`.
 Set `disable_tqdm: true` in that file to suppress progress bars during training.
+Set `grad_scaler_init_scale` to control the initial scale used by the AMP grad
+scaler.
 
 ## Directory Layout
 

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -69,6 +69,7 @@ lr_schedule: "cosine"
 # 학습률 warm‑up
 lr_warmup_epochs: 5        # 필요 시 숫자 조정
 grad_clip_norm: 1.0
+grad_scaler_init_scale: 1024  # AMP GradScaler initial scale
 
 # run evaluation after training loop by default
 eval_after_train: true

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -33,6 +33,7 @@ def get_amp_components(cfg: dict):
     from torch.amp import GradScaler, autocast
 
     use_amp = cfg.get("use_amp", False)
+    init_scale = cfg.get("grad_scaler_init_scale", 1024)
     if use_amp and torch.cuda.is_available():
         dtype = cfg.get("amp_dtype", "float16")
         if dtype == "bfloat16" and not torch.cuda.is_bf16_supported():
@@ -40,7 +41,7 @@ def get_amp_components(cfg: dict):
         autocast_ctx = autocast(
             device_type="cuda", dtype=getattr(torch, dtype, torch.float16)
         )
-        scaler = GradScaler(init_scale=cfg.get("grad_scaler_init_scale", 1024))
+        scaler = GradScaler(init_scale=init_scale)
     else:
         autocast_ctx = nullcontext()
         scaler = None


### PR DESCRIPTION
## Summary
- support `grad_scaler_init_scale` config option
- pass that option through `utils.get_amp_components`
- document AMP scaler scale in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a05baa76c8321bce2b260b9105c06