### PR TITLE
Add config printing utility

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from utils.model_factory import create_student_by_name               # NEW
 from trainer import teacher_vib_update, student_vib_update, simple_finetune
 from utils.freeze import freeze_all
 from utils.logger import ExperimentLogger
+from utils.print_cfg import print_hparams
 
 # ---------- CLI ----------
 parser = argparse.ArgumentParser(description="IB-KD entry point")
@@ -49,18 +50,8 @@ set_random_seed(cfg.get('seed', 42))
 method = cfg.get('method', 'vib').lower()
 assert method in {'vib', 'dkd', 'crd', 'vanilla'}, "unknown method"
 
-# ----- pretty-print key hyper-params -----
-important_keys = [
-    "method", "batch_size", "student_lr", "teacher_lr",
-    "proj_hidden_dim", "z_dim",
-    "kd_alpha_init", "kd_alpha_final", "kd_T_init", "kd_T_final",
-    "latent_alpha", "randaug_N", "randaug_M",
-]
-print("┌─ Hyper-parameters (" + str(len(important_keys)) + ")")
-for k in important_keys:
-    if k in cfg:
-        print(f"│ {k:18s}: {cfg[k]}")
-print("└───────────────────────────────────────")
+# ----- print all hyper-parameters -----
+print_hparams(cfg)
 
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(

--- a/utils/print_cfg.py
+++ b/utils/print_cfg.py
@@ -1,0 +1,55 @@
+# utils/print_cfg.py
+
+def print_hparams(cfg, title="Hyper-parameters"):
+    """Pretty-print flattened hyperparameters in a table.
+
+    Parameters
+    ----------
+    cfg : dict | Namespace | OmegaConf | yacs CfgNode
+        Configuration object. Nested structures are flattened using
+        dot notation.
+    title : str, optional
+        Table title displayed at the top. Defaults to ``"Hyper-parameters"``.
+    """
+    # 1) cfg to python dict -------------------------------------------------
+    try:
+        from omegaconf import OmegaConf  # ΩConf?
+        if isinstance(cfg, (OmegaConf,)):
+            cfg = OmegaConf.to_container(cfg, resolve=True)
+    except ModuleNotFoundError:
+        pass
+    try:
+        from yacs.config import CfgNode  # yacs?
+        if isinstance(cfg, CfgNode):
+            cfg = cfg.clone().freeze(False)
+            cfg = cfg.dump() if isinstance(cfg, str) else dict(cfg)
+    except ModuleNotFoundError:
+        pass
+    if not isinstance(cfg, dict):
+        cfg = vars(cfg)  # Namespace -> dict
+
+    # 2) flatten ------------------------------------------------------------
+    flat = {}
+
+    def _walk(d, prefix=""):
+        for k, v in d.items():
+            key = f"{prefix}{k}"
+            if isinstance(v, dict):
+                _walk(v, key + ".")
+            else:
+                flat[key] = v
+
+    _walk(cfg)
+
+    # 3) pretty print -------------------------------------------------------
+    keys, vals = zip(*sorted(flat.items())) if flat else ([], [])
+    k_width = max((len(k) for k in keys), default=0) + 2
+    v_width = max((len(str(v)) for v in vals), default=0) + 2
+    bar = "┌" + "─" * (k_width + v_width + 1) + "┐"
+    print(bar)
+    print(f"│ {title} ({len(keys)})".ljust(k_width + v_width + 2) + "│")
+    print("├" + "─" * k_width + "┬" + "─" * v_width + "┤")
+    for k in keys:
+        v = flat[k]
+        print(f"│ {k.ljust(k_width-1)}│ {str(v).ljust(v_width-1)}│")
+    print("└" + "─" * k_width + "┴" + "─" * v_width + "┘")


### PR DESCRIPTION
## Summary
- add `print_hparams` utility to pretty print config dictionaries
- use the new helper in `main.py` instead of ad-hoc key printing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a07b7b36883218a4626733b89dd79