### PR TITLE
Fix logger initialization and improve config printing

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,20 +38,25 @@ if not isinstance(cfg, dict):
     )
 
 os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
-logger = ExperimentLogger(cfg, exp_name="ibkd")
 
-for k in ('teacher1_ckpt', 'teacher2_ckpt', 'results_dir', 'batch_size', 'method'):
+for k in (
+    'teacher1_ckpt', 'teacher2_ckpt', 'results_dir',
+    'batch_size', 'method'
+):
     v = getattr(args, k, None)
     if v is not None:
         cfg[k] = v
+
+# logger는 **최종 cfg**가 완성된 뒤에 생성
+logger = ExperimentLogger(cfg, exp_name="ibkd")
+
+# 전체 하이퍼파라미터 테이블 출력
+print_hparams(cfg)
 
 device = cfg.get('device', 'cuda')
 set_random_seed(cfg.get('seed', 42))
 method = cfg.get('method', 'vib').lower()
 assert method in {'vib', 'dkd', 'crd', 'vanilla'}, "unknown method"
-
-# ----- print all hyper-parameters -----
-print_hparams(cfg)
 
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(

--- a/utils/print_cfg.py
+++ b/utils/print_cfg.py
@@ -1,6 +1,6 @@
 # utils/print_cfg.py
 
-def print_hparams(cfg, title="Hyper-parameters"):
+def print_hparams(cfg, title="Hyper‑parameters", ascii_only=False):
     """Pretty-print flattened hyperparameters in a table.
 
     Parameters
@@ -45,11 +45,15 @@ def print_hparams(cfg, title="Hyper-parameters"):
     keys, vals = zip(*sorted(flat.items())) if flat else ([], [])
     k_width = max((len(k) for k in keys), default=0) + 2
     v_width = max((len(str(v)) for v in vals), default=0) + 2
-    bar = "┌" + "─" * (k_width + v_width + 1) + "┐"
-    print(bar)
-    print(f"│ {title} ({len(keys)})".ljust(k_width + v_width + 2) + "│")
-    print("├" + "─" * k_width + "┬" + "─" * v_width + "┤")
+    h = "-" if ascii_only else "─"
+    tl, tr, bl, br, vertical = (
+        "+", "+", "+", "+", "|"
+    ) if ascii_only else ("┌", "┐", "└", "┘", "│")
+
+    print(tl + h * (k_width + v_width + 1) + tr)
+    print(f"{vertical} {title} ({len(keys)})".ljust(k_width + v_width + 2) + vertical)
+    print(("+" if ascii_only else "├") + h * k_width + ("+" if ascii_only else "┬") + h * v_width + ("+" if ascii_only else "┤"))
     for k in keys:
-        v = flat[k]
-        print(f"│ {k.ljust(k_width-1)}│ {str(v).ljust(v_width-1)}│")
-    print("└" + "─" * k_width + "┴" + "─" * v_width + "┘")
+        val = flat[k]
+        print(f"{vertical} {k.ljust(k_width-1)}{vertical} {str(val).ljust(v_width-1)}{vertical}")
+    print(bl + h * k_width + ("+" if ascii_only else "┴") + h * v_width + br)


### PR DESCRIPTION
## Summary
- move ExperimentLogger initialization until after CLI overrides
- print hyperparameters once logger is ready
- allow ASCII-only mode in `print_hparams`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a0abc5c6c832198ec49e526092186