### PR TITLE
Use logger for hyperparameter printing

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,8 @@ os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
 # logger는 **최종 cfg**가 완성된 뒤에 생성
 logger = ExperimentLogger(cfg, exp_name="ibkd")
 
-# 전체 하이퍼파라미터 테이블 출력
-print_hparams(cfg)
+# 전체 하이퍼파라미터 테이블 출력 (logger 사용)
+print_hparams(cfg, log_fn=logger.info)
 
 device = cfg.get('device', 'cuda')
 set_random_seed(cfg.get('seed', 42))

--- a/utils/print_cfg.py
+++ b/utils/print_cfg.py
@@ -1,6 +1,11 @@
 # utils/print_cfg.py
 
-def print_hparams(cfg, title="Hyper‑parameters", ascii_only=False):
+def print_hparams(
+    cfg,
+    title="Hyper‑parameters",
+    ascii_only=False,
+    log_fn=print,
+):
     """Pretty-print flattened hyperparameters in a table.
 
     Parameters
@@ -50,10 +55,10 @@ def print_hparams(cfg, title="Hyper‑parameters", ascii_only=False):
         "+", "+", "+", "+", "|"
     ) if ascii_only else ("┌", "┐", "└", "┘", "│")
 
-    print(tl + h * (k_width + v_width + 1) + tr)
-    print(f"{vertical} {title} ({len(keys)})".ljust(k_width + v_width + 2) + vertical)
-    print(("+" if ascii_only else "├") + h * k_width + ("+" if ascii_only else "┬") + h * v_width + ("+" if ascii_only else "┤"))
+    log_fn(tl + h * (k_width + v_width + 1) + tr)
+    log_fn(f"{vertical} {title} ({len(keys)})".ljust(k_width + v_width + 2) + vertical)
+    log_fn(("+" if ascii_only else "├") + h * k_width + ("+" if ascii_only else "┬") + h * v_width + ("+" if ascii_only else "┤"))
     for k in keys:
         val = flat[k]
-        print(f"{vertical} {k.ljust(k_width-1)}{vertical} {str(val).ljust(v_width-1)}{vertical}")
-    print(bl + h * k_width + ("+" if ascii_only else "┴") + h * v_width + br)
+        log_fn(f"{vertical} {k.ljust(k_width-1)}{vertical} {str(val).ljust(v_width-1)}{vertical}")
+    log_fn(bl + h * k_width + ("+" if ascii_only else "┴") + h * v_width + br)


### PR DESCRIPTION
## Summary
- update `print_hparams` to accept `log_fn` argument
- call `print_hparams` with `logger.info` to send table to logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a116bd82c832188972df56af72a87