### PR TITLE
Apply CE baseline optimizations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
-from .trainer import simple_finetune
+from .utils.train import simple_finetune
 
 __all__ = ["simple_finetune"]

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 import yaml
 import torch
 from torch.optim import Adam, AdamW
@@ -15,7 +16,8 @@ from data.cifar100 import get_cifar100_loaders
 from models.teachers.teacher_resnet import create_resnet152
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
 from utils.model_factory import create_student_by_name               # NEW
-from trainer import teacher_vib_update, student_vib_update, simple_finetune
+from trainer import teacher_vib_update, student_vib_update
+from utils.train import simple_finetune
 from utils.freeze import freeze_all
 from utils.logger import ExperimentLogger
 from utils.print_cfg import print_hparams
@@ -154,13 +156,16 @@ student = create_student_by_name(
     small_input=True,
     cfg=cfg,
 ).to(device)
-proj = StudentProj(
-    in_dim        = student.get_feat_dim(),
-    out_dim       = cfg['z_dim'],
-    hidden_dim    = cfg.get('proj_hidden_dim'),
-    normalize     = True,
-    use_bn        = cfg.get('proj_use_bn', False),
-).to(device)
+if method != 'ce':
+    proj = StudentProj(
+        in_dim        = student.get_feat_dim(),
+        out_dim       = cfg['z_dim'],
+        hidden_dim    = cfg.get('proj_hidden_dim'),
+        normalize     = True,
+        use_bn        = cfg.get('proj_use_bn', False),
+    ).to(device)
+else:
+    proj = None            # CE baseline은 필요 없음
 
 if method != 'ce':
     opt_t = Adam(
@@ -170,22 +175,23 @@ if method != 'ce':
     )
 else:
     opt_t = None
-base_lr = float(cfg.get("student_lr", 5e-4))
-opt_s = AdamW(
-    list(student.parameters()) + list(proj.parameters()),
-    lr=base_lr,
-    weight_decay=float(cfg.get("student_weight_decay", 0.0)),
-)
+if method != 'ce':
+    base_lr = float(cfg.get("student_lr", 5e-4))
+    opt_s = AdamW(
+        list(student.parameters()) + list(proj.parameters()),
+        lr=base_lr,
+        weight_decay=float(cfg.get("student_weight_decay", 0.0)),
+    )
 
-# ─ warm‑up scheduler (cosine 기본) ─
-warm_epochs = cfg.get("lr_warmup_epochs", 5)
-total_epochs = student_iters
-def lr_lambda(cur_epoch):
-    if cur_epoch < warm_epochs:
-        return (cur_epoch + 1) / warm_epochs
-    t = (cur_epoch - warm_epochs) / max(1, total_epochs - warm_epochs)
-    return 0.5 * (1 + math.cos(math.pi * t))
-scheduler = torch.optim.lr_scheduler.LambdaLR(opt_s, lr_lambda)
+    # ─ warm‑up scheduler (cosine 기본) ─
+    warm_epochs = cfg.get("lr_warmup_epochs", 5)
+    total_epochs = student_iters
+    def lr_lambda(cur_epoch):
+        if cur_epoch < warm_epochs:
+            return (cur_epoch + 1) / warm_epochs
+        t = (cur_epoch - warm_epochs) / max(1, total_epochs - warm_epochs)
+        return 0.5 * (1 + math.cos(math.pi * t))
+    scheduler = torch.optim.lr_scheduler.LambdaLR(opt_s, lr_lambda)
 
 # ---------- training ----------
 if method == 'vib':
@@ -291,6 +297,8 @@ elif method == 'ce':
     )
     acc = evaluate_acc(student, test_loader, device)
     logger.update_metric("student_acc", float(acc))
+    logger.finalize()
+    sys.exit(0)
 
 if cfg.get("eval_after_train", True):
     acc = evaluate_acc(

--- a/utils/train.py
+++ b/utils/train.py
@@ -1,0 +1,3 @@
+from trainer import simple_finetune
+
+__all__ = ["simple_finetune"]


### PR DESCRIPTION
## Summary
- load `simple_finetune` from new `utils.train` module
- skip projection head, student optimizer and scheduler when running `method: ce`
- exit immediately after CE baseline training to skip extra work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `ruff check .` *(fails: found 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a4e82ca0883219d6fb8e12edee0b5