### PR TITLE
Document CE baseline and update method config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ python scripts/fine_tuning.py --teacher_type resnet152 --overwrite
 bash scripts/run_ibkd.sh
 ```
 
+3. **(Optional) CE baseline** without distillation:
+
+```bash
+python main.py --cfg configs/minimal.yaml --method ce
+```
+
 Both scripts read default options from `configs/minimal.yaml`.
 Set `disable_tqdm: true` in that file to suppress progress bars during training.
 Set `grad_scaler_init_scale` to control the initial scale used by the AMP grad

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -14,7 +14,7 @@ student_type: "convnext_tiny"
 patch_stride2: false       # true 로 바꾸면 stride 2
 
 # ─ Distillation method 선택 ──────────────────────
-method: vib        # {vib | dkd | crd | vanilla}
+method: vib        # {vib | dkd | crd | vanilla | ce}
 
 # ─ CRD 전용 ─
 crd_alpha: 0.5

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ parser.add_argument('--teacher1_ckpt', type=str, help='Path to teacher-1 checkpo
 parser.add_argument('--teacher2_ckpt', type=str, help='Path to teacher-2 checkpoint')
 parser.add_argument('--results_dir', type=str, help='Where to save logs / checkpoints')
 parser.add_argument('--batch_size', type=int, help='Mini-batch size for training')
-parser.add_argument('--method', type=str, help='vib | dkd | crd | vanilla')
+parser.add_argument('--method', type=str, help='vib | dkd | crd | vanilla | ce')
 args = parser.parse_args()
 with open(args.cfg, "r") as f:
     cfg_raw = list(yaml.safe_load_all(f))  # 여러 문서 대비


### PR DESCRIPTION
## Summary
- document how to run the CE baseline
- list `ce` as a supported method in the configuration and CLI help

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a5c6271088321b26829db5fc59c39