### PR TITLE
Apply vib method and improve GateMBM

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -14,7 +14,7 @@ student_type: "convnext_tiny"
 patch_stride2: false       # true 로 바꾸면 stride 2
 
 # ─ Distillation method 선택 ──────────────────────
-method: ce        # {vib | dkd | crd | vanilla | ce}
+method: vib        # {vib | dkd | crd | vanilla | ce}
 
 # ─ CRD 전용 ─
 crd_alpha: 0.5

--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -3,13 +3,15 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 class GateMBM(nn.Module):
-    def __init__(self, c_in1: int, c_in2: int, z_dim: int = 512, n_cls: int = 100, beta: float = 1e-3):
+    def __init__(self, c_in1: int, c_in2: int, z_dim: int = 512, n_cls: int = 100,
+                 beta: float = 1e-3, dropout_p: float = 0.1):
         super().__init__()
-        c = min(c_in1, c_in2)
-        self.proj1 = nn.Conv2d(c_in1, c, 1)
+        c = max(c_in1, c_in2)                        # 정보 보존
+        self.proj1 = nn.Conv2d(c_in1, c, 1)          # 업/다운 자동 해결
         self.proj2 = nn.Conv2d(c_in2, c, 1)
         self.gate = nn.Parameter(torch.zeros(1, c, 1, 1))  # 0 -> 0.5 after sigmoid
         self.pool = nn.AdaptiveAvgPool2d(1)
+        self.dropout = nn.Dropout(dropout_p)
         self.mu = nn.Linear(c, z_dim)
         self.log = nn.Linear(c, z_dim)
         self.head = nn.Linear(z_dim, n_cls)
@@ -20,6 +22,7 @@ class GateMBM(nn.Module):
         f2 = self.proj2(f2)
         g = torch.sigmoid(self.gate)
         fused = g * f1 + (1 - g) * f2
+        fused = self.dropout(fused)
         v = self.pool(fused).flatten(1)
         mu = self.mu(v)
         log = self.log(v)


### PR DESCRIPTION
## Summary
- switch minimal example to use VIB distillation
- enhance `GateMBM` with a dropout layer and flexible channel handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b36a441e88321b1e27f43dc38c0d5