### PR TITLE
Add config options for previously hardcoded values

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -8,6 +8,14 @@ results_dir: "results"
 device: "cuda"
 seed: 42
 checkpoint_dir: "checkpoints"
+use_amp: false                 # mixed precision training
+amp_dtype: "float16"           # AMP data type
+log_kl: false                  # log KL divergence each step
+teacher1_ckpt: "checkpoints/resnet152_ft.pth"
+teacher2_ckpt: "checkpoints/efficientnet_b2_ft.pth"
+student_ce_ckpt: "student_ce_best.pth"
+finetune_partial_freeze: false
+num_classes: 100
 
 student_type: "convnext_tiny"
 # Conv stem stride

--- a/main.py
+++ b/main.py
@@ -147,7 +147,7 @@ if method != 'ce':
         in1,
         in2,
         cfg['z_dim'],
-        100,
+        cfg.get('num_classes', 100),
         beta=cfg.get('beta_bottleneck', 1e-3),
         dropout_p=cfg.get('gate_dropout', 0.1),
     ).to(device)
@@ -157,7 +157,7 @@ else:
 # ---------- student ----------
 student = create_student_by_name(
     cfg.get("student_type", "convnext_tiny"),   # ex) "convnext_small"
-    num_classes=100,
+    num_classes=cfg.get('num_classes', 100),
     pretrained=True,
     small_input=True,
     cfg=cfg,
@@ -317,7 +317,10 @@ elif method == 'vanilla':
     logger.update_metric("student_acc", float(acc))
 
 elif method == 'ce':
-    ce_ckpt = os.path.join(cfg.get('results_dir', 'results'), 'student_ce_best.pth')
+    ce_ckpt = os.path.join(
+        cfg.get('results_dir', 'results'),
+        cfg.get('student_ce_ckpt', 'student_ce_best.pth'),
+    )
     simple_finetune(
         student,
         train_loader,

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -64,9 +64,10 @@ def main() -> None:
 
     model = create_teacher_by_name(
         args.teacher_type,
-        num_classes=100,
+        num_classes=cfg.get("num_classes", 100),
         pretrained=True,
         small_input=True,
+        cfg=cfg,
     ).to(args.device)
 
     epochs = (


### PR DESCRIPTION
## Summary
- expose additional training parameters in `configs/minimal.yaml`
- load dataset class count and CE checkpoint name from config
- allow teacher fine-tuning script to respect configured class count

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b3b0d0540832189000afc2de61e03