### PR TITLE
Remove defunct KD branch and adjust bottleneck handling

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -15,7 +15,7 @@ teacher1_ckpt: "checkpoints/resnet152_ft.pth"
 teacher2_ckpt: "checkpoints/efficientnet_b2_ft.pth"
 student_ce_ckpt: "student_ce_best.pth"
 finetune_partial_freeze: false
-num_classes: 100
+num_classes: 100        # 고정 클래스 수
 
 student_type: "convnext_tiny"
 # Conv stem stride
@@ -72,7 +72,7 @@ teacher_weight_decay: 5e-4
 student_weight_decay: 5e-4
 teacher_lr: 1e-3        # MBM Adam LR ↑
 teacher_dropout_p: 0.3      # teacher classifier dropout
-gate_dropout: 0.1
+gate_dropout: 0.1       # GateMBM dropout 확정
 student_lr: 1.0e-3          # convnext_tiny 는 1e‑3 이상에서 더 잘 수렴
 lr_schedule: "cosine"
 # 학습률 warm‑up

--- a/main.py
+++ b/main.py
@@ -231,27 +231,6 @@ if method == 'vib':
         scheduler=scheduler,
     )
 
-elif method == 'kd':
-    from methods.feature_kd import FeatureKD
-    distiller = FeatureKD(
-        teacher_model=t1,
-        student_model=student,
-        alpha=cfg.get('kd_alpha', 1.0),
-        temperature=cfg.get('kd_T', 4.0),
-        label_smoothing=cfg.get('label_smoothing', 0.0),
-        config=cfg,
-    )
-    acc = distiller.train_distillation(
-        train_loader,
-        test_loader,
-        epochs=cfg.get('student_iters', 60),
-        lr=cfg.get('student_lr', 5e-4),
-        weight_decay=cfg.get('student_weight_decay', 5e-4),
-        device=device,
-        cfg=cfg,
-    )
-    logger.update_metric("student_acc", float(acc))
-
 elif method == 'crd':
     from methods.crd import CRDDistiller
     distiller = CRDDistiller(

--- a/methods/__init__.py
+++ b/methods/__init__.py
@@ -2,11 +2,9 @@
 from .crd import CRDDistiller
 from .dkd import DKDDistiller
 from .vanilla_kd import VanillaKDDistiller
-from .feature_kd import FeatureKD
 
 __all__ = [
     "CRDDistiller",
     "DKDDistiller",
     "VanillaKDDistiller",
-    "FeatureKD",
 ]

--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -17,7 +17,7 @@ class GateMBM(nn.Module):
         self.mu = nn.Linear(c, z_dim)
         self.log = nn.Linear(c, z_dim)
         self.head = nn.Linear(z_dim, n_cls)
-        self.beta = beta
+        # (self.beta 필드 삭제)  ← 외부에서 β를 곱해 사용
 
     def forward(self, f1: torch.Tensor, f2: torch.Tensor, log_kl: bool = False):
         f1 = self.proj1(f1)

--- a/trainer.py
+++ b/trainer.py
@@ -186,7 +186,7 @@ def teacher_vib_update(teacher1, teacher2, vib_mbm, loader, cfg, optimizer, test
                     f2,
                     log_kl=cfg.get("log_kl", False),
                 )
-                loss = F.cross_entropy(logit_syn, y) + beta * kl_z.mean()
+                loss = F.cross_entropy(logit_syn, y) + beta * kl_z        # kl_z 는 이미 mean
             optimizer.zero_grad()
             if scaler is not None:
                 scaler.scale(loss).backward()


### PR DESCRIPTION
## Summary
- revise teacher loss to rely on pre-averaged KL value
- drop unused `self.beta` field from `GateMBM`
- remove obsolete `kd` training branch and `FeatureKD` reference
- document fixed class count and gate dropout in minimal config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b3db99dd08321921fa0a6171f26a6