### PR TITLE
Handle flat inputs in GateMBM

### DIFF
--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -20,6 +20,13 @@ class GateMBM(nn.Module):
         # (self.beta 필드 삭제)  ← 외부에서 β를 곱해 사용
 
     def forward(self, f1: torch.Tensor, f2: torch.Tensor, log_kl: bool = False):
+        # ── ① (N,C) → (N,C,1,1) 로 변환해 Conv 1×1 입력 보장 ──────────
+        if f1.dim() == 2:
+            f1 = f1.unsqueeze(-1).unsqueeze(-1)
+        if f2.dim() == 2:
+            f2 = f2.unsqueeze(-1).unsqueeze(-1)
+
+        # ── ② 1×1 Conv 로 channel 맞추기 ─────────────────────────────
         f1 = self.proj1(f1)
         f2 = self.proj2(f2)
         g = torch.sigmoid(self.gate)

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -9,3 +9,11 @@ def test_forward():
     f2 = torch.randn(4, 16, 4, 4)
     z, logit, kl, _ = mbm(f1, f2)
     assert logit.shape == (4, 100)
+
+
+def test_forward_flattened_inputs():
+    mbm = GateMBM(16, 16, 256, 100)
+    f1 = torch.randn(4, 16)
+    f2 = torch.randn(4, 16)
+    _, logit, _, _ = mbm(f1, f2)
+    assert logit.shape == (4, 100)


### PR DESCRIPTION
## Summary
- accept 2D tensors in `GateMBM.forward`
- add regression test for flattened features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b41189d0083218959f2ce1de42b9e