### PR TITLE
Fix pandas dependency and create result dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This repository provides a lightweight implementation of **Adaptive Synergy Mani
 Install the minimal dependencies:
 
 ```bash
-pip install -r requirements.txt
+# The analysis scripts rely on pandas.
+pip install torch torchvision PyYAML tqdm pandas
 ```
-The project only requires **torch**, **torchvision**, **PyYAML** and **tqdm**.
+The project only requires **torch**, **torchvision**, **PyYAML**, **tqdm** and **pandas**.
 
 ## Workflow
 

--- a/analysis/compare_ablation.py
+++ b/analysis/compare_ablation.py
@@ -40,6 +40,8 @@ def parse_args():
 
 def main():
     args = parse_args()
+    # --- 출력 폴더 자동 생성 ---------------------------------------------
+    os.makedirs(os.path.dirname(args.out_path) or ".", exist_ok=True)
     # 예: results/summary.csv 에는 여러 파라미터/성과가 정리돼 있다고 가정
     summary_path = args.summary_csv
     if not os.path.exists(summary_path):

--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -84,6 +84,9 @@ def main() -> None:
     cfg = load_cfg(args.config)
     set_random_seed(cfg.get("seed", 42))
 
+    # --- 경로 보장 ---------------------------------------------------------
+    os.makedirs(os.path.dirname(args.ckpt) or ".", exist_ok=True)
+
     batch_size = args.batch_size or cfg.get("batch_size", 128)
     train_loader, test_loader = get_cifar100_loaders(
         root=cfg.get("dataset_root", "./data"),


### PR DESCRIPTION
## Summary
- document pandas dependency in README
- create checkpoint directory if missing when training teachers
- auto-create results directory for ablation summaries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b5a6e205c8321a96b046b4d3d1b00