### PR TITLE
Enable optional persistent workers and improved mixup handling

### DIFF
--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -8,13 +8,14 @@ from typing import Mapping, Any, Optional
 def get_cifar100_loaders(
     root: str = "./data",
     batch_size: int = 128,
-    num_workers: int = 2,
+    num_workers: int = 0,
     augment: bool = True,
     randaug_N: int = 0,
     randaug_M: int = 0,
     cfg: Optional[Mapping[str, Any]] = None,
     randaug_default_N: int = 2,
     randaug_default_M: int = 9,
+    persistent: bool = False,
 ):
     """
     CIFAR-100 size = (32x32)
@@ -66,7 +67,7 @@ def get_cifar100_loaders(
         shuffle=True,
         num_workers=num_workers,
         pin_memory=True,
-        persistent_workers=(num_workers > 0)
+        persistent_workers=persistent and num_workers > 0,
     )
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
@@ -74,6 +75,6 @@ def get_cifar100_loaders(
         shuffle=False,
         num_workers=num_workers,
         pin_memory=True,
-        persistent_workers=(num_workers > 0)
+        persistent_workers=persistent and num_workers > 0,
     )
     return train_loader, test_loader

--- a/main.py
+++ b/main.py
@@ -38,6 +38,10 @@ if not isinstance(cfg, dict):
         f"{args.cfg} 루트는 dict 여야 합니다 (현재: {type(cfg).__name__})"
     )
 
+# cuDNN 자동 튜닝 활성 (deterministic 모드가 아니라면)
+if not cfg.get("deterministic", False):
+    torch.backends.cudnn.benchmark = True
+
 for k in (
     'teacher1_ckpt', 'teacher2_ckpt', 'results_dir',
     'batch_size', 'method'
@@ -67,6 +71,7 @@ train_loader, test_loader = get_cifar100_loaders(
     num_workers=cfg.get('num_workers', 0),
     randaug_N=cfg.get('randaug_N', 0),
     randaug_M=cfg.get('randaug_M', 0),
+    persistent=cfg.get('persistent_workers', False),
 )
 
 # ---------- teachers ----------
@@ -111,6 +116,7 @@ if method != 'ce' and ft_epochs > 0:
         num_workers=cfg.get('num_workers', 0),
         randaug_N=cfg.get('finetune_randaug_N', 0),
         randaug_M=cfg.get('finetune_randaug_M', 0),
+        persistent=cfg.get('persistent_workers', False),
     )
     if not loaded1:
         simple_finetune(


### PR DESCRIPTION
## Summary
- add `persistent` option to CIFAR100 data loader
- enable cuDNN benchmark when deterministic mode is off
- pass persistent flag from config when building loaders
- extend student training to handle optional MixUp/CutMix via helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b5c2793648321bf5979848dd30f99