### PR TITLE
Update data loader config

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -2,6 +2,7 @@
 
 batch_size: 128              # ↑ 가능하면 256 (GPU 여유 시)
 num_workers: 2
+persistent_workers: true   # 데이터 로더 워커 유지 여부
 disable_tqdm: true
 dataset_root: "./data"
 results_dir: "results"


### PR DESCRIPTION
## Summary
- enable persistent workers in minimal config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b5de9b94083219c3127859ef6a954