### PR TITLE
Enable spawn context for persistent DataLoader workers

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -1,7 +1,7 @@
 # configs/minimal.yaml
 
 batch_size: 128              # ↑ 가능하면 256 (GPU 여유 시)
-num_workers: 2
+num_workers: 2           # 0이면 persistent 의미가 없어집니다
 persistent_workers: true   # 데이터 로더 워커 유지 여부
 disable_tqdm: true
 dataset_root: "./data"

--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -61,6 +61,10 @@ def get_cifar100_loaders(
         transform=transform_test
     )
 
+    mp_ctx = (
+        torch.multiprocessing.get_context("spawn")
+        if persistent and num_workers > 0 else None
+    )
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=batch_size,
@@ -68,6 +72,7 @@ def get_cifar100_loaders(
         num_workers=num_workers,
         pin_memory=True,
         persistent_workers=persistent and num_workers > 0,
+        multiprocessing_context=mp_ctx,
     )
     test_loader = torch.utils.data.DataLoader(
         test_dataset,
@@ -76,5 +81,6 @@ def get_cifar100_loaders(
         num_workers=num_workers,
         pin_memory=True,
         persistent_workers=persistent and num_workers > 0,
+        multiprocessing_context=mp_ctx,
     )
     return train_loader, test_loader

--- a/main.py
+++ b/main.py
@@ -64,6 +64,12 @@ set_random_seed(cfg.get('seed', 42))
 method = cfg.get('method', 'vib').lower()
 assert method in {'vib', 'dkd', 'crd', 'vanilla', 'ce'}, "unknown method"
 
+# persistent_workers 사용 시: fork → spawn 전환 (dead-lock 방지)
+if cfg.get("persistent_workers", False):
+    import torch.multiprocessing as mp
+    if mp.get_start_method(allow_none=True) != "spawn":
+        mp.set_start_method("spawn", force=True)
+
 # ---------- data ----------
 train_loader, test_loader = get_cifar100_loaders(
     root=cfg.get('dataset_root', './data'),


### PR DESCRIPTION
## Summary
- avoid deadlocks when `persistent_workers=True` by forcing `spawn` start method
- pass multiprocessing context to CIFAR100 DataLoader
- clarify `num_workers` usage in minimal config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b61d0bfa0832190e6ab031b97c503