### PR TITLE
Implement GateMBM beta scaling and checkpointing

### DIFF
--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -40,7 +40,9 @@ class GateMBM(nn.Module):
         mu = self.mu(v)
         log = self.log(v)
         z = mu + torch.randn_like(mu) * (0.5 * log).exp()
-        kl_raw = -0.5 * (1 + log - mu.pow(2) - log.exp()).mean()
-        kl = self.beta * kl_raw              # ← 실제 사용
+        # KL per-sample  → mean
+        kl = -0.5 * (1 + log - mu.pow(2) - log.exp()).mean()
+        kl_scaled = self.beta * kl               # <-- 가중치 적용
         out = self.head(z)
-        return z, out, kl, None              # kl 은 이미 beta 가 곱해진 값
+        # (z, logits, scaled_KL, raw_KL)
+        return z, out, kl_scaled, kl

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,7 +1,6 @@
 # tests/test_forward.py
 
-import pytest
-pytest.importorskip("torch")
+import pytest; pytest.importorskip("torch")
 import torch
 from models.ib.gate_mbm import GateMBM
 

--- a/tests/test_simple_finetune.py
+++ b/tests/test_simple_finetune.py
@@ -1,5 +1,4 @@
-import pytest
-pytest.importorskip("torch")
+import pytest; pytest.importorskip("torch")
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 


### PR DESCRIPTION
## Summary
- implement internal beta scaling in `GateMBM`
- modify trainer to use scaled KL directly
- add checkpoint saving for student training
- skip tests if torch not installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b69bc01f48321a53fd9783d3ab046