### PR TITLE
Fix dataloader persistent worker handling

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -60,6 +60,7 @@ def main() -> None:
         num_workers=cfg.get("num_workers", 0),
         randaug_N=cfg.get("finetune_randaug_N", 0),
         randaug_M=cfg.get("finetune_randaug_M", 0),
+        persistent_train=cfg.get("persistent_workers", False),
     )
 
     model = create_teacher_by_name(

--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -91,7 +91,9 @@ def main() -> None:
     train_loader, test_loader = get_cifar100_loaders(
         root=cfg.get("dataset_root", "./data"),
         batch_size=batch_size,
-        num_workers=cfg.get("num_workers", 2)
+        num_workers=cfg.get("num_workers", 2),
+        persistent_train=cfg.get("persistent_workers", False),
+        persistent_test=False,
     )
     num_cls = len(train_loader.dataset.classes)
 


### PR DESCRIPTION
## Summary
- set PyTorch multiprocessing start method to spawn once at the top of `main.py`
- add `persistent_train` and `persistent_test` options to CIFAR100 loader
- disable persistent workers for test loader and when num_workers=0
- update main script and helper scripts to use the new loader API

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b6fbce7cc8321bcf6b0d7135bdc8b