### PR TITLE
Update FitNet and AT with runtime teacher handling

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -25,6 +25,16 @@ patch_stride2: false       # true 로 바꾸면 stride 2
 # ─ Distillation method 선택 ──────────────────────
 method: vib        # {vib | dkd | crd | vanilla | ce}
 
+# --- AT --------------------------
+method: at
+alpha: 1000          # ← 기존 1 에서 ↑
+layer_key: feat_4d_layer3
+
+# --- FitNet ----------------------
+method: fitnet
+alpha_hint: 50       # ← 기존 1 에서 ↑
+alpha_ce: 1
+
 # ─ CRD 전용 ─
 crd_alpha: 0.5
 crd_T: 0.07

--- a/methods/at.py
+++ b/methods/at.py
@@ -68,7 +68,9 @@ class ATDistiller(nn.Module):
     def forward(self, x, y):
         # 1) teacher
         with torch.no_grad():
-            t_dict = self.teacher(x)
+            t_out = self.teacher(x)
+            # teacher 가 (dict, logits, …) 형태로 반환될 수도 있음
+            t_dict = t_out[0] if isinstance(t_out, tuple) else t_out
         # 2) student
         s_dict, s_logit, _ = self.student(x)
 


### PR DESCRIPTION
## Summary
- make FitNet regressor lazily initialized at runtime
- handle tuple teacher outputs in AT and FitNet
- show AT/FitNet weight tuning in configs/minimal.yaml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba5b840848321b5eac6a2874f3aaf