### PR TITLE
Register FitNet regressor with scheduler

### DIFF
--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -152,6 +152,7 @@ class FitNetDistiller(nn.Module):
                 # regressor 가 생성된 뒤 한 번만 param‑group 추가
                 if (not regressor_added) and (self.regressor is not None):
                     optimizer.add_param_group({"params": self.regressor.parameters()})
+                    scheduler.base_lrs.append(scheduler.base_lrs[0])  # 새 그룹 LR 등록
                     regressor_added = True
 
                 optimizer.step()


### PR DESCRIPTION
## Summary
- ensure learning rate scheduler tracks new parameter group in FitNet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcd82161c83218680fc0d43750023