### PR TITLE
Add intermediate stage features to model wrappers

### DIFF
--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -56,6 +56,9 @@ class TeacherEfficientNetWrapper(nn.Module):
         feat_dict = {
             "feat_4d": f4d,
             "feat_2d": fpool,
+            "feat_4d_layer1": feat_layer1,
+            "feat_4d_layer2": feat_layer2,
+            "feat_4d_layer3": feat_layer3,
         }
         return feat_dict, logit, None
 

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -63,6 +63,9 @@ class TeacherResNetWrapper(nn.Module):
         feat_dict = {
             "feat_4d": f4d,
             "feat_2d": feat_2d,
+            "feat_4d_layer1": feat_layer1,
+            "feat_4d_layer2": feat_layer2,
+            "feat_4d_layer3": feat_layer3,
         }
         return feat_dict, logit, None
 


### PR DESCRIPTION
## Summary
- expose intermediate stage outputs in student/teacher wrappers
- ensure consistent keys `feat_4d_layer1`, `feat_4d_layer2`, and `feat_4d_layer3`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch', tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686bdd2664f88321b35f7c5245350f65