### PR TITLE
Fix FitNet scheduler param group handling

### DIFF
--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -150,7 +150,11 @@ class FitNetDistiller(nn.Module):
                 # regressor 가 생성된 뒤 한 번만 param‑group 추가
                 if (not regressor_added) and (self.regressor is not None):
                     optimizer.add_param_group({"params": self.regressor.parameters()})
-                    scheduler.base_lrs.append(scheduler.base_lrs[0])  # 새 그룹 LR 등록
+                    # update lr fields so schedulers like CosineAnnealingLR
+                    # can handle the newly added parameter group
+                    optimizer.param_groups[-1]["initial_lr"] = scheduler.base_lrs[0]
+                    scheduler.optimizer = optimizer
+                    scheduler.base_lrs.append(scheduler.base_lrs[0])
                     regressor_added = True
 
                 optimizer.step()


### PR DESCRIPTION
## Summary
- update learning rate fields after registering the regressor
  so `CosineAnnealingLR` and others see the added group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be376b2308321bee8dd154ed2d036