### PR TITLE
Update FitNet distillation config handling

### DIFF
--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -104,16 +104,12 @@ class FitNetDistiller(nn.Module):
         """
         self.to(device)
 
-        if cfg is not None:
-            lr = cfg.get("student_lr", lr)
-            weight_decay = cfg.get("student_weight_decay", weight_decay)
-            lr_schedule = cfg.get("lr_schedule", "cosine")
-            step_size = cfg.get("student_step_size", 10)
-            gamma = cfg.get("student_gamma", 0.1)
-        else:
-            lr_schedule = "cosine"
-            step_size = 10
-            gamma = 0.1
+        cfg = {**self.cfg, **(cfg or {})}
+        lr = cfg.get("student_lr", lr)
+        weight_decay = cfg.get("student_weight_decay", weight_decay)
+        lr_schedule = cfg.get("lr_schedule", "cosine")
+        step_size = cfg.get("student_step_size", 10)
+        gamma = cfg.get("student_gamma", 0.1)
 
         # 처음에는 student 파라미터만 등록
         optimizer = optim.AdamW(


### PR DESCRIPTION
## Summary
- merge runtime config with defaults when calling `train_distillation`
- simplify FitNet runtime config override logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be5c04b0c8321a4fdddc5d3d2e0e1