### PR TITLE
Update teacher_iters configuration defaults

### DIFF
--- a/configs/method/vib.yaml
+++ b/configs/method/vib.yaml
@@ -1,6 +1,7 @@
 # configs/method/vib.yaml
 
 method: vib
+teacher_iters: 20
 mbm_type: GATE
 z_dim: 512
 beta_bottleneck: 1e-3

--- a/configs/scenario/standard.yaml
+++ b/configs/scenario/standard.yaml
@@ -1,7 +1,7 @@
 # configs/scenario/standard.yaml
 
 train_mode   : standard
-teacher_iters: 20
+teacher_iters: 0
 
 # ─ Fine‑tune(교사+Gate) 설정 ─
 finetune_epochs      : 30


### PR DESCRIPTION
## Summary
- set `teacher_iters` to 0 in `configs/scenario/standard.yaml`
- specify `teacher_iters: 20` for `vib` method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca2c9337883218956eab2937ab9e1