### PR TITLE
Fix run_ibkd.sh reference to minimal config

### DIFF
--- a/scripts/run_ibkd.sh
+++ b/scripts/run_ibkd.sh
@@ -42,7 +42,7 @@ ft_teacher () {
   else
       echo "[INFO] fine-tuning $MODEL → $CKPT"
         python scripts/fine_tuning.py \
-            --config configs/minimal.yaml \
+            --config configs/base.yaml \
             --teacher_type "$MODEL" \
             --finetune_ckpt_path "$CKPT" \
             ${FINETUNE_EPOCHS:+--finetune_epochs "$FINETUNE_EPOCHS"} \


### PR DESCRIPTION
## Summary
- use `configs/base.yaml` when fine-tuning teachers in `run_ibkd.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cac475c748321af5fb59635041c66