### PR TITLE
Add cumulative evaluation to continual learning

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ def main() -> None:
 
     if mode == 'continual':
         from trainer_continual import run_continual
-        run_continual(cfg, method)
+        run_continual(cfg, method, logger=logger)
         return
 
     # ---------- data ----------


### PR DESCRIPTION
## Summary
- support configurable class order and caching in CIFAR100 continual loader
- return both current-task and cumulative test loaders
- update continual trainer to evaluate on current and seen classes
- pass logger into continual training mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd4f3574483219968db5e9890c4cf