### PR TITLE
Update run_sweep script with defaults and slurm headers

### DIFF
--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+#SBATCH --job-name=kd_sweep          # SLURM 이름
+#SBATCH --output=logs/slurm_%j.out   # SLURM 로그 저장 경로
+#SBATCH --gres=gpu:1                 # GPU 1장 고정
+#SBATCH --cpus-per-task=4            # 여유 CPU
+#SBATCH --time=3-00:00:00            # 최대 3일 (필요시 조정)
+
 # scripts/run_sweep.py
 import argparse
 import itertools
@@ -5,33 +12,36 @@ import os
 import subprocess
 import yaml
 import time
+import pathlib
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("--base",  required=True,
-                   help="고정 YAML (예: configs/base.yaml)")
-    p.add_argument("--sweep", required=True,
-                   help="값이 list 인 항목만 들어있는 YAML")
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    p.add_argument("--base",  default=repo_root / "configs/base.yaml",
+                   help="(기본) configs/base.yaml")
+    p.add_argument("--sweep", default=repo_root / "configs/ablation/kd_sweep.yaml",
+                   help="(기본) configs/ablation/kd_sweep.yaml")
     # GPU·병렬 수 고정  ─ 변경 금지(실수 방지용)
-    p.add_argument("--gpus",  default="0",
-                   help="(고정) GPU id = 0  ‑ 다른 값 넣으면 오류")
-    p.add_argument("--max_parallel", type=int, default=1,
-                   help="(고정) 동시 실행 = 1  ‑ 다른 값 넣으면 오류")
+    p.add_argument("--gpus",  default="0",    # GPU 1장 강제
+                   help="쉼표로 구분된 GPU ID 리스트")
+    p.add_argument("--max_parallel", type=int, default=1,  # 동시 1개
+                   help="동시 실행 최대 프로세스 수")
     # ───────── Sweep 전략 선택 ─────────
     #   full   : 모든 list 변수의 Cartesian product (기존 동작)
     #   single : list 변수를 하나씩만 바꿔서 ‘기본+α’ 실험
-    p.add_argument("--mode", choices=["full", "single"], default="full",
+    p.add_argument("--mode", choices=["full", "single"], default="single",
                    help="'full': 전체 조합,  'single': 변수별 개별 실험")
     #   필요한 변수만 골라서 sweep 하고 싶을 때
-    p.add_argument("--keys", default="",
+    p.add_argument("--keys", default="beta_bottleneck,kd_alpha_init",
                    help="콤마로 구분된 sweep 대상 key (비워두면 전부)")
     p.add_argument("--extra", nargs=argparse.REMAINDER,
                    help="main.py 에 그대로 넘길 추가 CLI 인수")
     args = p.parse_args()
 
     # ─────── 고정 값 검증 ───────
-    if args.gpus.strip() not in {"0", "0,"}:
-        raise ValueError("이 스크립트는 GPU 0 한​장만 사용하도록 고정되었습니다.")
+    gpu_ids = [g.strip() for g in args.gpus.split(',') if g.strip()]
+    if len(gpu_ids) != 1:
+        raise ValueError("이 스크립트는 GPU 1장만 사용하도록 고정되었습니다.")
     if args.max_parallel != 1:
         raise ValueError("max_parallel 은 1 로 고정하시길 바랍니다.")
 
@@ -57,9 +67,8 @@ def main():
             for v in v_list:
                 param_sets.append({k: v})
 
-    # 항상 GPU 0, 동시 1
-    gpu_id   = "0"
-    max_jobs = 1
+    # 항상 GPU 1, 동시 1
+    max_jobs = args.max_parallel
     procs    = []
 
     for idx, params in enumerate(param_sets):
@@ -71,7 +80,7 @@ def main():
         os.makedirs("logs", exist_ok=True)
 
         env = os.environ.copy()
-        env["CUDA_VISIBLE_DEVICES"] = gpu_id   # GPU 0 한​장만 노출
+        env["CUDA_VISIBLE_DEVICES"] = gpu_ids[idx % len(gpu_ids)]
 
         cmd = ["python", "main.py",
                "--cfg", args.base,


### PR DESCRIPTION
## Summary
- add slurm header and shebang to `run_sweep.py`
- set default config paths and sweep options
- enforce single GPU via generic GPU id handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce99dc8f08321b477b16f8783d53d