### PR TITLE
Fix SLURM working directories

### DIFF
--- a/scripts/run_ibkd.sh
+++ b/scripts/run_ibkd.sh
@@ -13,9 +13,14 @@
 #-------------------------------------------------------------------
 set -euo pipefail
 
-# (1) 프로젝트 루트 자동 판정
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-ROOT_DIR="${PROJECT_ROOT:-${SCRIPT_DIR%/scripts}}"
+# (1) 프로젝트 루트:  --chdir 덕분에 이미 루트
+ROOT_DIR=$(pwd)
+
+# 안전: 그래도 환경변수로 덮어쓰기 허용
+if [ -n "${PROJECT_ROOT:-}" ]; then
+    ROOT_DIR="${PROJECT_ROOT}"
+    cd "$ROOT_DIR"
+fi
 
 # (2) 출력 디렉터리
 JOB_ID=${SLURM_JOB_ID:-local}

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -12,7 +12,7 @@
 import argparse, itertools, os, subprocess, yaml, time
 import pathlib
 
-ROOT_DIR   = os.getcwd()   # SLURM --chdir 덕분에 항상 프로젝트 루트
+ROOT_DIR   = os.getcwd()   # ( --chdir 로 고정됨 )
 
 def main():
     # ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- ensure `run_ibkd.sh` starts in the repo root and honors `$PROJECT_ROOT`
- clarify `run_sweep.py` comment about fixed working directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d425b05e48321b9fec6477e20e035