### PR TITLE
Refactor VIB config loading

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -1,0 +1,43 @@
+# configs/method/vib/continual.yaml
+
+method: vib
+teacher_iters: 20
+mbm_type: GATE
+z_dim: 512
+beta_bottleneck: 0.001
+proj_hidden_dim: 1024
+proj_use_bn: true
+log_kl: false
+student_iters: 25
+
+# ─ Teacher(VIB‑MBM) 학습 ─
+teacher_lr          : 1e-3
+teacher_weight_decay: 5e-4
+gate_dropout        : 0.1
+teacher_dropout_p   : 0.3
+
+# ─ KD 스케줄 (α, T) ─
+kd_alpha_init : 0.5
+kd_alpha_final: 0.5
+kd_T_init     : 7
+kd_T_final    : 2
+kd_warmup_frac: 0.01
+kd_schedule_granularity: step
+kd_sched_pow  : 0.5
+ce_alpha      : 1.0
+
+# ─ Latent 정렬 ─
+latent_alpha        : 0.5
+latent_mse_weight   : 0.7
+latent_angle_weight : 0.3
+
+# ─ Feature distillation ─
+feat_layers   : [2, 3]
+feat_weights  : [0.5, 0.5]
+feat_loss_weight: [0.2, 0.15, 0.1]
+
+# ───── 추가 override (base.yaml 값을 덮어쓰기) ─────
+cutmix_alpha_distill: 1.0        # 강한 CutMix 유지
+ema_decay           : 0.992      # EMA 버퍼 빠르게 반영
+buffer_size         : 100
+n_tasks            : 10

--- a/configs/method/vib/standard.yaml
+++ b/configs/method/vib/standard.yaml
@@ -1,4 +1,4 @@
-# configs/method/vib.yaml
+# configs/method/vib/standard.yaml
 
 method: vib
 teacher_iters: 20
@@ -39,4 +39,3 @@ feat_loss_weight: [0.2, 0.15, 0.1]
 # ───── 추가 override (base.yaml 값을 덮어쓰기) ─────
 cutmix_alpha_distill: 1.0        # 강한 CutMix 유지
 ema_decay           : 0.992      # EMA 버퍼 빠르게 반영
-buffer_size         : 100

--- a/configs/scenario/continual.yaml
+++ b/configs/scenario/continual.yaml
@@ -1,8 +1,6 @@
 # configs/scenario/continual.yaml
 
 train_mode   : continual
-n_tasks      : 10
-buffer_size  : 100
 teacher_iters: 3
 student_iters: 10
 randaug_N    : 1


### PR DESCRIPTION
## Summary
- move vib.yaml to method/vib/standard.yaml and method/vib/continual.yaml
- load method configs via helper that enforces continual mode guard-rail
- drop buffer_size and n_tasks from scenario config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd2d7fb9883218902c970b9918df5