### PR TITLE
Implement new training assertions and sweep defaults

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,11 +135,26 @@ def main() -> None:
     }, f"unknown method: {method}"
     assert mode   in {'standard', 'continual'}, "unknown train_mode"
 
+    # ──────────────────────────────────────────────────────────────
+    # Continual 학습은 현재 VIB‑KD 전용
+    # ─ mode 가 continual 인데 method 가 vib 가 아니면 즉시 중단
+    # ----------------------------------------------------------------
+    if mode == 'continual' and method != 'vib':
+        raise NotImplementedError(
+            "Continual learning currently supports only the 'vib' method."
+        )
+
     # ───────────────────────────────────────────
     # VIB-KD 전용 하이퍼파라미터는 필요할 때만 읽기
     # -------------------------------------------
     if method == 'vib':
-        z_dim       = cfg.get('z_dim', 512)
+        z_dim = cfg.get('z_dim', 512)
+        # ── DEBUG: z_dim 값 및 타입 모니터링 ───────────────────────
+        print(f"[DBG] resolved z_dim = {z_dim} (type={type(z_dim).__name__})")
+        assert isinstance(z_dim, int), (
+            f"z_dim must be an int after config merge, "
+            f"but got {type(z_dim).__name__}: {z_dim}"
+        )
         mbm_type    = cfg.get('mbm_type', 'GATE')
         beta        = cfg.get('beta_bottleneck', 1e-3)
         proj_hidden = cfg.get('proj_hidden_dim', 1024)

--- a/scripts/run_sweep.py
+++ b/scripts/run_sweep.py
@@ -46,8 +46,10 @@ def main():
     p.add_argument("--mode", choices=["full", "single"], default="single",
                    help="'full': 전체 조합,  'single': 변수별 개별 실험")
     #   필요한 변수만 골라서 sweep 하고 싶을 때
-    p.add_argument("--keys", default="beta_bottleneck,kd_alpha_init",
-                   help="콤마로 구분된 sweep 대상 key (비워두면 전부)")
+    #   ─ 기본값을 '' 로 두어 모든 list 항목을 sweep 대상으로 삼는다.
+    p.add_argument("--keys", default="",
+                   help="콤마로 구분된 sweep 대상 key "
+                        "(비워두면 list‑항목 전부 sweep)")
     p.add_argument("--extra", nargs=argparse.REMAINDER,
                    help="main.py 에 그대로 넘길 추가 CLI 인수")
     args = p.parse_args()
@@ -79,8 +81,8 @@ def main():
     # list 가 아닌 값은 무시
     sweep_vars = {k: v for k, v in sweep_cfg.items() if isinstance(v, list)}
 
-    # --keys 필터링
-    if args.keys:
+    # --keys 필터링 (빈 문자열이면 생략)
+    if args.keys.strip():
         wanted = [k.strip() for k in args.keys.split(',') if k.strip()]
         sweep_vars = {k: v for k, v in sweep_vars.items() if k in wanted}
 


### PR DESCRIPTION
## Summary
- adjust sweep key default to include all list items by default
- check for empty keys before filtering when running sweeps
- prevent continual training for non-VIB methods
- add debug output and type assertion for `z_dim`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dda88cbe48321ae3d9f2bab6bacdc