### PR TITLE
Add sweep_mode config and CLI override

### DIFF
--- a/experiments/sweep_<topic>.yaml
+++ b/experiments/sweep_<topic>.yaml
@@ -9,6 +9,8 @@ imports:
   - configs/scenario/standard.yaml      # ★ 규칙: sweep 은 standard 전용
 
 exp_id: <주제_설명용_ID>                # 예) vib_hparam_search
+# sweep_mode: full | single  – 생략하면 'full'
+sweep_mode: full
 tags:
   - sweep
   - grid

--- a/experiments/sweep_seed_study.yaml
+++ b/experiments/sweep_seed_study.yaml
@@ -3,6 +3,7 @@ imports:
   - configs/method/vib.yaml
   - configs/scenario/standard.yaml
 
+sweep_mode: full  # full|single
 exp_id: seed_repro
 sweep:
   seed: [0, 1, 2]

--- a/experiments/sweep_vib_standard.yaml
+++ b/experiments/sweep_vib_standard.yaml
@@ -3,6 +3,7 @@ imports:
   - configs/method/vib.yaml
   - configs/scenario/standard.yaml
 
+sweep_mode: full  # full|single
 exp_id: vib_std_sweep
 sweep:
   beta_bottleneck: [1e-4, 3e-4, 1e-3, 3e-3, 1e-2]


### PR DESCRIPTION
## Summary
- allow `sweep_mode` to be configured in experiments YAML
- add `--mode` CLI arg in `scripts/launcher.py` that overrides YAML
- generate parameter sets based on sweep mode (full or single)
- show sweep mode in launcher output
- document sweep mode in sweep templates and example sweeps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df20154e88321b59b07c3fbebda9b