### PR TITLE
Add future annotations for Python 3.8 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 # main.py
+from __future__ import annotations
 
 import argparse
 import os

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 # scripts/launcher.py
 # ------------------------------------------------------------
 # Unified launcher  - single run & hyper-parameter sweep

--- a/utils/print_cfg.py
+++ b/utils/print_cfg.py
@@ -1,4 +1,5 @@
 # utils/print_cfg.py
+from __future__ import annotations
 
 # ────────────────────────────────────────
 # NEW ①  공통 테이블 렌더러 (단일 그룹·가로 정렬)


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations for union type hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df4d059bc83219941ab5713c24497