### PR TITLE
Apply sweep_mode and method YAML tweaks

### DIFF
--- a/experiments/run_<method>_<scenario>.yaml
+++ b/experiments/run_<method>_<scenario>.yaml
@@ -10,11 +10,14 @@ imports:
   # (필수) 프로젝트 공통 기본값
   - configs/base.yaml
 
-  # (필수) ‘방법론’ 선택  ─ vib/dkd/crd/vanilla/fitnet/at/ce … 중 하나
-  - configs/method/<METHOD>.yaml        # 예) vib.yaml
+  # ‘방법론’ YAML은 import 하지 말고 아래 method 키로 지정
 
   # (필수) ‘시나리오’ 선택  ─ standard or continual
   - configs/scenario/<SCENARIO>.yaml    # 예) continual.yaml
+
+# ---------------------------------------------------------------------
+# 방법론 선택 (빈 칸에 vib / dkd / … 기입)
+method: <METHOD>
 
 # ────────────────────────────── ② 메타 정보(선택) ────────────────────────────
 exp_id: <원하는_실험_이름>    # 결과 폴더·TensorBoard 런 이름. 공백·한글 OK.

--- a/experiments/sweep_<topic>.yaml
+++ b/experiments/sweep_<topic>.yaml
@@ -7,12 +7,15 @@
 
 imports:
   - configs/base.yaml
-  - configs/method/<METHOD>.yaml        # 예) vib.yaml
   - configs/scenario/standard.yaml      # ★ 규칙: sweep 은 standard 전용
 
+# 방법론 지정
+method: <METHOD>                        # 예) vib
+
 exp_id: <주제_설명용_ID>                # 예) vib_hparam_search
-# sweep_mode: full | single  – 생략하면 'full'
-sweep_mode: full
+
+# full: 모든 조합 / single: 변수별 단독 변화
+sweep_mode: full                        # full | single
 tags:
   - sweep
   - grid
@@ -25,9 +28,6 @@ batch_size   : 128
 # ────────────────────────────── ② Sweep 정의(필수) ───────────────────────────
 # 리스트로 쓰인 항목만 “변수”로 인식합니다. 스칼라(단일 값)는 그대로 고정.
 
-+sweep_mode: single        
-# sweep_mode: full        # ← 모든 조합, 카테시안곱 (기본값)
-# sweep_mode: single      # ← 변수별 단독 변화만 테스트하고 싶을 때
 
 
 sweep:

--- a/experiments/sweep_seed_study.yaml
+++ b/experiments/sweep_seed_study.yaml
@@ -4,9 +4,11 @@ imports:
   - configs/base.yaml
   - configs/scenario/standard.yaml
 
-sweep_mode: full  # full|single
+# 방법론
+method: vib
 
-method: vib 
+# sweep 모드
+sweep_mode: full
 
 exp_id: seed_repro
 sweep:

--- a/experiments/sweep_vib_standard.yaml
+++ b/experiments/sweep_vib_standard.yaml
@@ -4,10 +4,13 @@ imports:
   - configs/base.yaml
   - configs/scenario/standard.yaml
 
-sweep_mode: full  # full|single
-exp_id: vib_std_sweep
+# 방법론
+method: vib
 
-method: vib 
+# sweep 모드
+sweep_mode: full
+
+exp_id: vib_std_sweep
 
 sweep:
   beta_bottleneck: [1e-4, 3e-4, 1e-3, 3e-3, 1e-2]


### PR DESCRIPTION
## Summary
- implement sweep_mode handling in launcher output and param set generation
- update YAML experiment templates to specify `method:` key
- document sweep mode and method settings in sweep experiments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0208bf348321b9eff1711d1057db