### PR TITLE
Fix log handle cleanup in launcher

### DIFF
--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -144,20 +144,24 @@ def main() -> None:
             f"[LAUNCH] ▶ {idx+1}/{len(param_sets)} param={param or '—'} GPU={env['CUDA_VISIBLE_DEVICES']} log={log_path}",
             flush=True,
         )
-        procs.append(
-            subprocess.Popen(
-                cmd,
-                env=env,
-                stdout=open(log_path, "w"),
-                stderr=subprocess.STDOUT,
-            )
+        # ✅ with‑context로 열고, fp 수명 = Popen 종료까지
+        fp = open(log_path, "w")
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=fp,
+            stderr=subprocess.STDOUT,
         )
+        proc._log_fp = fp            # 종료 후 닫기 위해 보관
+        procs.append(proc)
 
         while len([p for p in procs if p.poll() is None]) >= args.max_parallel:
             time.sleep(10)
 
     for p in procs:
         p.wait()
+        if hasattr(p, "_log_fp") and not p._log_fp.closed:
+            p._log_fp.close()        # 🧹 열려 있던 로그 핸들 확실히 닫기
     print("[LAUNCH] all subprocesses finished ✅", flush=True)
 
 

--- a/scripts/run_launcher.sh
+++ b/scripts/run_launcher.sh
@@ -76,3 +76,4 @@ srun --chdir="$ROOT_DIR" python scripts/launcher.py "$@"
 
 # ➜ 주의: 다른 인자(실험 id, 추가 override 등)는
 #     ./run_ibkd.sh --batch_size 256 처럼 이어서 넘기면 됩니다.
+trap 'pkill -P $$ || true' EXIT   # 자식 프로세스(예: TensorBoard) 강제 종료


### PR DESCRIPTION
## Summary
- ensure subprocess log files close after execution
- keep background processes from lingering in SLURM launcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0911b4408321b6dbcb965404ba1e