### PR TITLE
Add future annotations import to trainer_continual

### DIFF
--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -1,5 +1,6 @@
 """Minimal continual-learning loop that re-uses KD modules."""
 # trainer_continual.py
+from __future__ import annotations
 
 import os
 import torch


### PR DESCRIPTION
## Summary
- ensure annotations are deferred by adding `from __future__ import annotations` to `trainer_continual.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686e156bf12083219d479256d0994aa5