### PR TITLE
Add latent weight warmup

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -28,6 +28,7 @@ ce_alpha      : 1.0
 
 # ─ Latent 정렬 ─
 latent_alpha        : 0.5
+latent_warmup_frac  : 0.3
 latent_mse_weight   : 0.7
 latent_angle_weight : 0.3
 cw_mse_eps: 1e-6                 # 확신도‑가중 MSE용 ε (분모 보호)

--- a/configs/method/vib/standard.yaml
+++ b/configs/method/vib/standard.yaml
@@ -28,6 +28,7 @@ ce_alpha      : 1.0
 
 # ─ Latent 정렬 ─
 latent_alpha        : 0.5
+latent_warmup_frac  : 0.3
 latent_mse_weight   : 0.7
 latent_angle_weight : 0.3
 cw_mse_eps: 1e-6                 # 확신도‑가중 MSE용 ε (분모 보호)


### PR DESCRIPTION
## Summary
- support `latent_warmup_frac` to ramp latent loss weight
- update configs with `latent_warmup_frac` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec6fec9b48321bf7fc7abc8fb7abd