### PR TITLE
Add latent-loss scaling defaults

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -32,7 +32,9 @@ latent_warmup_frac  : 0.3
 latent_mse_weight   : 0.7
 latent_angle_weight : 0.3
 cw_mse_eps: 1e-6                 # 확신도‑가중 MSE용 ε (분모 보호)
-latent_norm: "dim"          # "dim" | "sqrt" | "none"
+
+# ─ latent-loss 정규화 방식 ─────────────────────────────────────
+latent_norm: "dim"        # 1/ z_dim  로 스케일 (√ 혹은 none 도 가능)
 
 # ─ Feature distillation ─
 feat_layers   : [2, 3]

--- a/trainer.py
+++ b/trainer.py
@@ -605,7 +605,7 @@ def student_vib_update(
                 + latent_angle_weight * latent_angle
             )
 
-            scale_mode = cfg.get("latent_norm", "none")  # yaml에서 설정
+            scale_mode = cfg.get("latent_norm", "dim")   # ← default = "dim"
             if scale_mode == "dim":  # 1 / z_dim
                 latent = latent_raw / z_s.size(1)
             elif scale_mode == "sqrt":  # 1 / √z_dim


### PR DESCRIPTION
## Summary
- tweak VIB continual config to show latent-loss normalization
- default to `latent_norm: dim` in trainer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686edc005d80832194aa57c9389f0556