### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -1,7 +1,10 @@
 # trainer.py
 
+from __future__ import annotations
+
 import os
 import copy
+from typing import Optional
 
 import torch
 import torch.nn.functional as F   # loss 함수(F.cross_entropy 등)용
@@ -159,7 +162,7 @@ def teacher_vib_update(
     wandb_run=None,
     *,
     global_step_offset: int = 0,
-    ewc_bank: list | None = None,
+    ewc_bank: Optional[list] = None,
 ):
     """Train the VIB module using frozen teachers.
 
@@ -334,7 +337,7 @@ def student_vib_update(
     wandb_run=None,
     *,
     global_step_offset: int = 0,
-    ewc_bank: list | None = None,
+    ewc_bank: Optional[list] = None,
 ):
     """Update the student network to mimic the VIB representation.
 


### PR DESCRIPTION
## Summary
- ensure `trainer.py` works on Python 3.8
- declare optional EWC bank with `Optional[list]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee43d5fb483219f022cf7dbaad829