### PR TITLE
Fix duplicate argument in trainer_continual

### DIFF
--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -195,7 +195,7 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
                 vib_mbm,
                 proj,
                 train_loader,
-                cfg,
+                cfg,               # cfg is passed once as a positional argument
                 opt_s,
                 test_loader=test_cur,
                 logger=logger,
@@ -204,7 +204,6 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
                 wandb_run=wandb_run,
                 global_step_offset=global_step_counter,
                 ewc_bank=ewc_bank,
-                cfg=cfg,
             )
 
             if cfg.get("use_ewc", False):


### PR DESCRIPTION
## Summary
- pass `cfg` to `student_vib_update` only once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef52f61f0832193384a75c8241aab