### PR TITLE
Finalize Balanced Replay, DER++, and latent clamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -292,6 +292,8 @@ def main() -> None:
             cfg.get('num_classes', 100),
             beta=beta,
             dropout_p=cfg.get('gate_dropout', 0.1),
+            clamp_min=cfg.get('latent_clamp_min', -6),
+            clamp_max=cfg.get('latent_clamp_max', 2),
         ).to(device)
     else:
         vib_mbm = None


### PR DESCRIPTION
## Summary
- extend CIFAR-100 continual loader to optionally return split indices
- build DataLoader with BalancedReplaySampler when running continual mode
- apply mixup only on current samples and compute DER++ replay loss
- allow GateMBM latent clamp range via config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2136ffbc832181ddd8c4ab145264