### PR TITLE
Implement clamp tuple for GateMBM

### DIFF
--- a/main.py
+++ b/main.py
@@ -288,12 +288,14 @@ def main() -> None:
         vib_mbm = GateMBM(
             in1,
             in2,
-            z_dim,
             cfg.get('num_classes', 100),
+            z_dim,
             beta=beta,
+            clamp=(
+                cfg.get('latent_clamp_min', -6),
+                cfg.get('latent_clamp_max', 2),
+            ),
             dropout_p=cfg.get('gate_dropout', 0.1),
-            clamp_min=cfg.get('latent_clamp_min', -6),
-            clamp_max=cfg.get('latent_clamp_max', 2),
         ).to(device)
     else:
         vib_mbm = None

--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -9,14 +9,21 @@ class GateMBM(nn.Module):
     *beta*  : KL 항에 곱해지는 가중치 (teacher_vib_update 등 외부에서 다시
               scale 하지 않아도 되도록 내부에서 적용)
     """
-    def __init__(self, c_in1: int, c_in2: int, z_dim: int = 512, n_cls: int = 100,
-                 beta: float = 1e-3, dropout_p: float = 0.1,
-                 clamp_min: float = -6.0, clamp_max: float = 2.0):
+    def __init__(
+        self,
+        c_in1: int,
+        c_in2: int,
+        n_cls: int = 100,
+        z_dim: int = 512,
+        beta: float = 1e-3,
+        *,
+        clamp: tuple[float, float] = (-6.0, 2.0),
+        dropout_p: float = 0.1,
+    ):
         super().__init__()
         # ensure scalar value to avoid list * Tensor errors
         self.beta = float(beta)
-        self.clamp_min = clamp_min
-        self.clamp_max = clamp_max
+        self.cmin, self.cmax = clamp
         c = max(c_in1, c_in2)                        # 정보 보존
         self.proj1 = nn.Conv2d(c_in1, c, 1)          # 업/다운 자동 해결
         self.proj2 = nn.Conv2d(c_in2, c, 1)
@@ -42,9 +49,9 @@ class GateMBM(nn.Module):
         fused = self.dropout(fused)
         v = self.pool(fused).flatten(1)
         mu = self.mu(v)
-        min_c = getattr(self, "clamp_min", -6.0)
-        max_c = getattr(self, "clamp_max", 2.0)
-        log = self.log(v).clamp(min=min_c, max=max_c)
+        min_c = getattr(self, "cmin", -6.0)
+        max_c = getattr(self, "cmax", 2.0)
+        log = self.log(v).clamp(min_c, max_c)
         std = torch.exp(0.5 * log)
         z = mu + torch.randn_like(mu) * std
         # KL per-sample  → mean

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -5,7 +5,7 @@ import torch
 from models.ib.gate_mbm import GateMBM
 
 def test_forward():
-    mbm = GateMBM(16, 16, 256, 100)
+    mbm = GateMBM(16, 16, 100, 256)
     f1 = torch.randn(4, 16, 4, 4)
     f2 = torch.randn(4, 16, 4, 4)
     z, logit, kl, _, mu, log_var = mbm(f1, f2)
@@ -13,7 +13,7 @@ def test_forward():
 
 
 def test_forward_flattened_inputs():
-    mbm = GateMBM(16, 16, 256, 100)
+    mbm = GateMBM(16, 16, 100, 256)
     f1 = torch.randn(4, 16)
     f2 = torch.randn(4, 16)
     _, logit, _, _, _, _ = mbm(f1, f2)

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -60,11 +60,13 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
         vib_mbm = GateMBM(
             t1.get_feat_dim(),                # teacher-1 feat dim
             t2.get_feat_dim(),                # teacher-2 feat dim
-            cfg["z_dim"],                     # latent z
             num_cls_total,                    # 100-way (확정)
+            cfg["z_dim"],                     # latent z
             beta=cfg.get("beta_bottleneck", 1e-3),
-            clamp_min=cfg.get("latent_clamp_min", -6),
-            clamp_max=cfg.get("latent_clamp_max", 2),
+            clamp=(
+                cfg.get("latent_clamp_min", -6),
+                cfg.get("latent_clamp_max", 2),
+            ),
         ).to(device)
     else:
         vib_mbm = None


### PR DESCRIPTION
## Summary
- update GateMBM to accept a clamp tuple
- wire up clamp range in main and continual trainer
- adjust forward test for new constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f235506a883219477fc347d050dd4