### PR TITLE
Fix BalancedReplaySampler, prev KD handling

### DIFF
--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -49,9 +49,7 @@ class GateMBM(nn.Module):
         fused = self.dropout(fused)
         v = self.pool(fused).flatten(1)
         mu = self.mu(v)
-        min_c = getattr(self, "cmin", -6.0)
-        max_c = getattr(self, "cmax", 2.0)
-        log = self.log(v).clamp(min_c, max_c)
+        log = self.log(v).clamp(self.cmin, self.cmax)
         std = torch.exp(0.5 * log)
         z = mu + torch.randn_like(mu) * std
         # KL per-sample  → mean

--- a/trainer.py
+++ b/trainer.py
@@ -575,7 +575,10 @@ def student_vib_update(
 
             if rep_x is not None and prev_student is not None:
                 with torch.no_grad():
-                    logits_prev_full = prev_student(rep_x)[-1]
+                    prev_out = prev_student(rep_x)
+                    logits_prev_full = (
+                        prev_out[-1] if isinstance(prev_out, tuple) else prev_out
+                    )
                 kd_rep = F.kl_div(
                     F.log_softmax(logit_kd_s[:rep_x.size(0)] / T, dim=1),
                     F.softmax(logits_prev_full / T, dim=1),

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -32,4 +32,5 @@ class BalancedReplaySampler(torch.utils.data.Sampler):
             cur_ptr += self.cc
 
     def __len__(self):
-        return len(self.cur) // self.cc * self.bs
+        # 전체 샘플 수 (replay + current)
+        return len(self.cur) + len(self.rep)


### PR DESCRIPTION
## Summary
- fix BalancedReplaySampler length to include replay samples
- handle tuple output when using previous student for KD
- simplify GateMBM forward by clamping with stored limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2a74a7c48321a664641418d7d7bb