### PR TITLE
Add future annotations imports

### DIFF
--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -1,5 +1,7 @@
 # models/ib/gate_mbm.py
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/models/ib/proj_head.py
+++ b/models/ib/proj_head.py
@@ -1,5 +1,7 @@
 # models/ib/proj_head.py
 
+from __future__ import annotations
+
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Optional

--- a/models/ib/vib_mbm.py
+++ b/models/ib/vib_mbm.py
@@ -1,5 +1,7 @@
 # models/ib/vib_mbm.py
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/models/vib_head.py
+++ b/models/vib_head.py
@@ -1,5 +1,7 @@
 # models/vib_head.py
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -1,5 +1,7 @@
 # utils/dataloader.py
 
+from __future__ import annotations
+
 import torch
 import random
 


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to various model and dataloader modules
- ensure consistent future import usage across codebase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f30fdf6a08321ac69656d704c1bb5