### PR TITLE
Fix sampler length

### DIFF
--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import torch
 import random
+import math
 
 class BalancedReplaySampler(torch.utils.data.Sampler):
     """Sample from replay and current indices to keep a given ratio per batch."""
@@ -34,5 +35,6 @@ class BalancedReplaySampler(torch.utils.data.Sampler):
             cur_ptr += self.cc
 
     def __len__(self):
-        # 전체 샘플 수 (replay + current)
-        return len(self.cur) + len(self.rep)
+        # 전체 배치 수를 계산하여 샘플 수를 구하기
+        batches = math.ceil(len(self.cur) / max(1, self.cc))
+        return batches * self.bs


### PR DESCRIPTION
## Summary
- update `__len__` logic in `BalancedReplaySampler`
- compute total sample count using the batch count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3556b6ec8321a8b998adcbd98035