### PR TITLE
Fix continual evaluation accuracy

### DIFF
--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -355,8 +355,15 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
         torch.save(student.state_dict(), f"{ckpt_dir}/task{task}_student.pth")
 
         # ───────── Task 종료 요약 ─────────
-        acc_cur  = evaluate_acc(student, test_cur,  device=device)  # 현재 task
-        acc_seen = evaluate_acc(student, test_seen, device=device)  # 전체 class
+        cur_cls  = _task_classes(task, n_tasks)
+        seen_cls = sum((_task_classes(t, n_tasks) for t in range(task + 1)), [])
+
+        acc_cur  = evaluate_acc(
+            student, test_cur, device=device, classes=cur_cls
+        )  # 현재 task
+        acc_seen = evaluate_acc(
+            student, test_seen, device=device, classes=seen_cls
+        )  # 전체 class
 
         acc_seen_hist.append(acc_seen)
 

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -8,6 +8,7 @@ def evaluate_acc(
     loader,
     device: str = "cuda",
     mixup_active: bool = False,   # NEW – 호출 처리를 위한 더미 플래그
+    classes: list[int] | None = None,
 ):
     model.eval()
     correct = 0
@@ -29,6 +30,14 @@ def evaluate_acc(
             logits = out.get("logit", out)
         else:
             logits = out
+
+        # --------------------------------------------------------------
+        # Continual-learning: slice logits/labels for a subset of classes
+        # --------------------------------------------------------------
+        if classes is not None:
+            from trainer_continual import _remap_for_task  # local import
+            logits, y = _remap_for_task(logits, y, classes)
+
         preds = logits.argmax(dim=1)
         correct += (preds == y).sum().item()
         total += y.size(0)


### PR DESCRIPTION
## Summary
- support class slicing in `utils.evaluate_acc`
- evaluate only relevant classes in `trainer_continual.run_continual`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f5fd7e37c8321a0eaff3ac92e445a