### PR TITLE
Fix label mapping during continual evaluation

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -762,7 +762,8 @@ def student_vib_update(
             hook_s.clear(); hook_t1.clear(); hook_t2.clear()
             running_loss += loss.item() * x.size(0)
             n_samples    += x.size(0)
-            correct += (logit_s.argmax(1) == y).sum().item()
+            # ⬇︎ 현재 task 기준으로 재맵핑된 y_local 사용
+            correct += (logit_s.argmax(1) == y_local).sum().item()
             count += x.size(0)
 
             # ── DEBUG: 5 epoch 간격, 첫 버치만 ───────────────

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -34,9 +34,12 @@ def evaluate_acc(
         # --------------------------------------------------------------
         # Continual-learning: slice logits/labels for a subset of classes
         # --------------------------------------------------------------
-        if classes is not None:
-            from trainer_continual import _remap_for_task  # local import
-            logits, y = _remap_for_task(logits, y, classes)
+        if classes is not None:                     # ← 클래스‑하위 집합 평가
+            cls_tensor = torch.tensor(
+                classes, dtype=torch.long, device=logits.device
+            )
+            logits = logits.index_select(1, cls_tensor)
+            y = torch.searchsorted(cls_tensor, y, right=False)
 
         preds = logits.argmax(dim=1)
         correct += (preds == y).sum().item()


### PR DESCRIPTION
## Summary
- handle target remapping inside `evaluate_acc` when a subset of classes is evaluated
- use remapped `y_local` targets when computing training accuracy in `student_vib_update`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb7e911208321a3ed22a3d22226d8