### PR TITLE
Update continual training parameters

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -8,7 +8,8 @@ beta_bottleneck: 0.001
 proj_hidden_dim: 1024
 proj_use_bn: true
 log_kl: false
-student_iters: 25
+student_iters: 35
+use_amp: true
 
 # ─ Teacher(VIB‑MBM) 학습 ─
 teacher_lr          : 1e-3
@@ -17,9 +18,9 @@ gate_dropout        : 0.1
 teacher_dropout_p   : 0.3
 
 # ─ KD 스케줄 (α, T) ─
-kd_alpha_init : 0.5
+kd_alpha_init : 0.3
 kd_alpha_final: 0.5
-kd_T_init     : 7
+kd_T_init     : 5
 kd_T_final    : 2
 kd_warmup_frac: 0.01
 kd_schedule_granularity: step
@@ -27,8 +28,8 @@ kd_sched_pow  : 0.5
 ce_alpha      : 1.0
 
 # ─ Latent 정렬 ─
-latent_alpha        : 0.5
-latent_warmup_frac  : 0.3
+latent_alpha        : 0.2
+latent_warmup_frac  : 0.5
 latent_mse_weight   : 0.7
 latent_angle_weight : 0.3
 cw_mse_eps: 1e-6                 # 확신도‑가중 MSE용 ε (분모 보호)
@@ -46,5 +47,9 @@ feat_loss_weight: [0.2, 0.15, 0.1]
 # ───── 추가 override (base.yaml 값을 덮어쓰기) ─────
 cutmix_alpha_distill: 1.0        # 강한 CutMix 유지
 ema_decay           : 0.992      # EMA 버퍼 빠르게 반영
-buffer_size         : 100
+buffer_size         : 2000
+replay_ratio       : 0.5
 n_tasks            : 10
+use_ewc           : true
+ewc_lambda        : 10.0
+ewc_online        : true

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -265,11 +265,10 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
             for p in head.parameters():
                 p.requires_grad_(True)
 
-            # ③ Task 0,1 은 backbone 도 학습 (feature 적응 단계)
-            if task < 2:
-                for name, p in student.named_parameters():
-                    if name.startswith(("backbone.", "stem.", "features.", "blocks.")):
-                        p.requires_grad_(True)
+            # ③ 모든 task에서 ConvNeXt stage-3(=최상위)만 학습
+            for name, p in student.named_parameters():
+                if name.startswith(("backbone.stages.3", "backbone.downsample_layers.3")):
+                    p.requires_grad_(True)
 
             if logger:
                 trainable = [n for n, p in student.named_parameters() if p.requires_grad]


### PR DESCRIPTION
## Summary
- refine which student layers are unfrozen in CL
- adjust VIB continual config for larger replay buffer and EWC

## Testing
- `pytest -q`
- `mypy . | head` *(fails: missing torch, pandas stubs)*

------
https://chatgpt.com/codex/tasks/task_e_687055e238f08321af7331c05e4dd05b