### PR TITLE
Disable EWC for VIB continual

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -50,6 +50,7 @@ ema_decay           : 0.992      # EMA 버퍼 빠르게 반영
 buffer_size         : 2000
 replay_ratio       : 0.5
 n_tasks            : 10
-use_ewc           : true
-ewc_lambda        : 10.0
-ewc_online        : true
+use_ewc           : false      # VIB 성능 검증을 위해 EWC 제거
+ewc_lambda        : 0.0        # 아무 영향 없도록 0
+ewc_online        : false
+ewc_decay         : 0.0


### PR DESCRIPTION
## Summary
- turn off EWC usage in VIB continual config for performance tuning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870747d94c88321972aa5af0fbd0db3