### PR TITLE
Implement task-masked KD option

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -9,6 +9,7 @@ proj_hidden_dim: 1024
 proj_use_bn: true
 log_kl: false
 student_iters: 35
+student_lr : 2e-3            # 더 안정적인 학습률
 use_amp: true
 
 # ─ Teacher(VIB‑MBM) 학습 ─
@@ -18,13 +19,14 @@ gate_dropout        : 0.1
 teacher_dropout_p   : 0.3
 
 # ─ KD 스케줄 (α, T) ─
-kd_alpha_init : 0.3
-kd_alpha_final: 0.5
+kd_mask_curr_task: true      # KD KL 을 현재 태스크 클래스에만 적용
+kd_alpha_init    : 0.0       # warm-start (KD off)
+kd_alpha_final   : 0.4       # 이후 천천히 40% 까지
 kd_T_init     : 5
 kd_T_final    : 2
-kd_warmup_frac: 0.01
-kd_schedule_granularity: step
-kd_sched_pow  : 0.5
+kd_warmup_frac   : 0.10      # 앞 10% 구간은 CE 100%
+kd_schedule_granularity: epoch
+kd_sched_pow     : 1.0       # 선형 증가
 ce_alpha      : 1.0
 
 # ─ Latent 정렬 ─
@@ -50,7 +52,7 @@ ema_decay           : 0.992      # EMA 버퍼 빠르게 반영
 buffer_size         : 2000
 replay_ratio       : 0.5
 n_tasks            : 10
-use_ewc           : false      # VIB 성능 검증을 위해 EWC 제거
+use_ewc           : false      # EWC 규제 off (VIB 단독 실험)
 ewc_lambda        : 0.0        # 아무 영향 없도록 0
 ewc_online        : false
 ewc_decay         : 0.0

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -6,8 +6,18 @@ import torch.nn.functional as F
 __all__ = ["kd_loss_fn", "ce_loss_fn", "dkd_loss", "compute_vib_loss"]
 
 
-def kd_loss_fn(student_logits: torch.Tensor, teacher_logits: torch.Tensor, T: float = 1.0) -> torch.Tensor:
-    """Basic knowledge distillation loss (KL divergence)."""
+def kd_loss_fn(
+    student_logits: torch.Tensor,
+    teacher_logits: torch.Tensor,
+    T: float = 1.0,
+    task_classes: list[int] | None = None,
+) -> torch.Tensor:
+    """Knowledge distillation KL loss with optional task masking."""
+    if task_classes is not None:
+        idx = torch.tensor(task_classes, device=student_logits.device)
+        student_logits = student_logits.index_select(1, idx)
+        teacher_logits = teacher_logits.index_select(1, idx)
+
     log_s = F.log_softmax(student_logits / T, dim=1)
     soft_t = F.softmax(teacher_logits / T, dim=1)
     return F.kl_div(log_s, soft_t, reduction="batchmean") * (T * T)


### PR DESCRIPTION
## Summary
- support task masking in `kd_loss_fn`
- apply optional class filtering in the training loop
- tune continual Vib config with new KD schedule and LR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709fcee3008321bd8431b51c904fb5