### PR TITLE
Add task-aware KD KL function

### DIFF
--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -6,7 +6,7 @@ import torch
 from typing import Optional
 from tqdm.auto import tqdm
 
-from modules.losses import kd_loss_fn, ce_loss_fn
+from modules.losses import kd_kl, ce_loss_fn
 from utils.eval import evaluate_acc
 from utils.misc import get_amp_components
 from utils.schedule import cosine_lr_scheduler
@@ -84,7 +84,7 @@ class VanillaKDDistiller:
                     else:
                         s_logits = s_out
                     ce = ce_criterion(s_logits, y)
-                    kd = kd_loss_fn(s_logits, t_logits.detach(), T=self.temperature)
+                    kd = kd_kl(s_logits, t_logits.detach(), T=self.temperature)
                     loss = (1 - self.alpha) * ce + self.alpha * kd
                 if scaler:
                     scaler.scale(loss).backward()

--- a/trainer.py
+++ b/trainer.py
@@ -15,7 +15,7 @@ from utils.schedule import cosine_lr_scheduler
 from utils.misc import get_amp_components, mixup_data, mixup_criterion
 from utils.eval import evaluate_acc
 from utils.distill_loss import feat_mse_pair
-from modules.losses import compute_vib_loss, kd_loss_fn
+from modules.losses import compute_vib_loss, kd_kl
 
 
 def split_current_replay(batch, replay_ratio):
@@ -631,7 +631,7 @@ def student_vib_update(
                 ) * (T_prev * T_prev)
 
             task_classes = task_cls if cfg.get("kd_mask_curr_task", False) else None
-            kd = kd_loss_fn(
+            kd = kd_kl(
                 logit_s,
                 logit_t.detach(),
                 T,


### PR DESCRIPTION
## Summary
- introduce `kd_kl` in `modules.losses` to support optional class masking
- update vanilla KD and main trainer to use the new helper
- keep `kd_loss_fn` as a wrapper for backward compatibility

## Testing
- `pytest -q` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6870a1c88df8832184565c28d454568a