### PR TITLE
Implement CL tuning tweaks

### DIFF
--- a/configs/method/vib/continual.yaml
+++ b/configs/method/vib/continual.yaml
@@ -19,7 +19,7 @@ gate_dropout        : 0.1
 teacher_dropout_p   : 0.3
 
 # ─ KD 스케줄 (α, T) ─
-kd_mask_curr_task  : false
+kd_mask_curr_task  : true      # CL 기본값: 현재 task 10-way KD
 kd_alpha_init      : 0.2  # ← 0 → 0.2  (초기에도 KD 활성)
 kd_alpha_final   : 0.4       # 이후 천천히 40% 까지
 kd_T_init     : 5
@@ -31,7 +31,7 @@ ce_alpha      : 1.0
 
 # ─ Latent 정렬 ─
 latent_alpha       : 0.05 # ← 0.2 보다 작게 시작
-latent_warmup_frac : 0.3  # 30 % 시점까지 선형증가
+latent_warmup_frac : 0.3  # 초기 30 % 동안 0, 이후 선형 증가
 latent_mse_weight   : 0.7
 latent_angle_weight : 0.3
 cw_mse_eps: 1e-6                 # 확신도‑가중 MSE용 ε (분모 보호)

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -274,20 +274,9 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
             )
             prev_student.eval()
 
-            # ───────── Trainable‑scope 설정 ─────────
-            # ① 기본적으로 전체 freeze
+            # (★) partial‑freeze 삭제 → 모든 파라미터 학습
             for p in student.parameters():
-                p.requires_grad_(False)
-
-            # ② Linear head 는 항상 학습
-            head, head_name = _find_linear_head(student)
-            for p in head.parameters():
                 p.requires_grad_(True)
-
-            # ③ 모든 task에서 ConvNeXt stage-3(=최상위)만 학습
-            for name, p in student.named_parameters():
-                if name.startswith(("backbone.stages.3", "backbone.downsample_layers.3")):
-                    p.requires_grad_(True)
 
             if logger:
                 trainable = [n for n, p in student.named_parameters() if p.requires_grad]


### PR DESCRIPTION
## Summary
- train all student params in continual mode
- always mask KD to current task during continual training
- change latent penalty ramp-up
- set CL default config values for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870bc6eff0883218f7bcbca52762ddf