### PR TITLE
Add warning alias for ExperimentLogger

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -105,6 +105,11 @@ class ExperimentLogger:
     def info(self, msg: str):
         logging.info(msg)
 
+    # --- ADD for backward-compatibility ---
+    def warning(self, *args, **kwargs):
+        """Alias of .info(), so old code can call logger.warning."""
+        return self.info(*args, **kwargs)
+
     def finalize(self):
         """
         1) Calculates total_time_sec


### PR DESCRIPTION
## Summary
- ensure ExperimentLogger exposes `warning()` so calls to `logger.warning` don't fail

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6870d05f1cbc832199946241f41becf9