### PR TITLE
Fix SnapshotTeacher averaging and teacher loader

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,7 +216,11 @@ def main() -> None:
                 return m.to(device)
             elif isinstance(src, str):
                 paths = [s.strip() for s in src.split(',')]
-                return SnapshotTeacher(paths, backbone_name=default_name).to(device)
+                return SnapshotTeacher(
+                    paths,
+                    backbone_name=default_name,
+                    n_cls=cfg.get("num_classes", 100),
+                ).to(device)
             else:
                 raise ValueError(f"invalid {cfg_key}: {src}")
 

--- a/models/ensemble/snapshot_teacher.py
+++ b/models/ensemble/snapshot_teacher.py
@@ -20,17 +20,14 @@ class SnapshotTeacher(nn.Module):
             self.models.append(m)
 
     @torch.no_grad()
-    def forward(self, x, return_feat=False):
+    def forward(self, x):
+        """교사‑API 호환: (feat_dict, logits) tuple 반환"""
         logits_all, feat_all = [], []
         for m in self.models:
-            out = m(x)
-            feat = out[0]["feat_2d"] if isinstance(out, tuple) else None
-            log  = out[1]           if isinstance(out, tuple) else out
-            logits_all.append(log)
-            if return_feat:
-                feat_all.append(feat)
+            feat_dict, logit = m(x)
+            logits_all.append(logit)
+            feat_all.append(feat_dict["feat_2d"])
+
         logit_avg = torch.stack(logits_all).mean(0)
-        if return_feat:
-            feat_avg = torch.stack(feat_all).mean(0)
-            return {"feat_2d": feat_avg}, logit_avg
-        return logit_avg
+        feat_avg = torch.stack(feat_all).mean(0)
+        return {"feat_2d": feat_avg}, logit_avg


### PR DESCRIPTION
## Summary
- remove `return_feat` param and always return feature dictionary in `SnapshotTeacher`
- pass class count to `SnapshotTeacher` in `main.py`

## Testing
- `pytest -q` *(fails: 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68747017575c832189bfda88589c82ac