### PR TITLE
Support --config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bash scripts/run_ibkd.sh
 3. **(Optional) CE baseline** without distillation:
 
 ```bash
-python main.py --cfg configs/minimal.yaml --method ce
+python main.py --config configs/minimal.yaml --method ce
 ```
 
 Both scripts read default options from `configs/minimal.yaml`.

--- a/main.py
+++ b/main.py
@@ -57,7 +57,8 @@ def get_method_cfg(method: str, train_mode: str):
 def main() -> None:
     # ---------- CLI ----------
     parser = argparse.ArgumentParser(description="IB-KD entry point")
-    parser.add_argument('--cfg',
+    parser.add_argument('--cfg', '--config',
+                        dest='cfg',
                         default='configs/base.yaml',
                         help='Comma-separated list of YAML files')
     parser.add_argument('--teacher1_ckpt', type=str, help='Path to teacher-1 checkpoint')

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -130,7 +130,7 @@ def main() -> None:
         cmd = [
             "python",
             str(ROOT / "main.py"),
-            "--cfg",
+            "--config",
             cfg_chain,
             "--results_dir",
             str(results_dir),


### PR DESCRIPTION
## Summary
- accept `--config` as an alias for `--cfg`
- use `--config` consistently in README and launcher script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68747962d6948321aff60ee412771cd7