### PR TITLE
Fix BalancedReplaySampler length and add tests

### DIFF
--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,25 @@
+import math
+import pytest; pytest.importorskip("torch")
+import torch
+
+from utils.dataloader import BalancedReplaySampler
+
+
+@pytest.mark.parametrize(
+    "batch_size,ratio,n_cur",
+    [
+        (4, 0.5, 9),
+        (5, 0.3, 7),
+        (3, 0.7, 8),
+        (6, 0.0, 5),
+    ],
+)
+def test_balanced_replay_sampler_len(batch_size, ratio, n_cur):
+    cur_idx = list(range(n_cur))
+    rep_idx = list(range(100))
+    sampler = BalancedReplaySampler(cur_idx, rep_idx, batch_size, ratio, shuffle=False)
+    items = list(iter(sampler))
+    batches = math.ceil(len(cur_idx) / max(1, sampler.cc))
+    expected = len(cur_idx) + batches * sampler.rc
+    assert len(items) == expected
+    assert len(sampler) == expected

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -35,6 +35,8 @@ class BalancedReplaySampler(torch.utils.data.Sampler):
             cur_ptr += self.cc
 
     def __len__(self):
-        # 전체 배치 수를 계산하여 샘플 수를 구하기
+        """Return the number of samples yielded by the sampler."""
+        # number of batches processed based on current data
         batches = math.ceil(len(self.cur) / max(1, self.cc))
-        return batches * self.bs
+        # total samples = current samples + replay samples per batch
+        return len(self.cur) + batches * self.rc


### PR DESCRIPTION
## Summary
- ensure BalancedReplaySampler.__len__ counts current and replay samples correctly
- test sampler length across various configurations

## Testing
- `pytest -q` *(fails: 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687492c7dd988321a58c07ece7160f5b