### PR TITLE
Remove trailing spaces from Python files

### DIFF
--- a/analysis/compare_ablation.py
+++ b/analysis/compare_ablation.py
@@ -48,7 +48,7 @@ def main():
         print(f"[Error] summary.csv not found at {summary_path}")
         return
 
-    df = pd.read_csv(summary_path)  
+    df = pd.read_csv(summary_path)
     # 예: 컬럼 ["method", "teacher_lr", "synergy_ce_alpha", "test_acc", "seed", "epoch"]
 
     # 1) group by key hyperparams => compute mean & std of test_acc

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -17,7 +17,7 @@ def get_imagenet100_loaders(
     randaug_default_N: int = 2,
     randaug_default_M: int = 9,
 ):
-    """    
+    """
     ImageNet100 size = (224×224)
     Returns:
         train_loader, test_loader

--- a/methods/at.py
+++ b/methods/at.py
@@ -138,7 +138,7 @@ class ATDistiller(nn.Module):
                 loss.backward()
                 optimizer.step()
 
-            
+
                 total_loss += loss.item()*x.size(0)
                 total_num  += x.size(0)
 

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -60,7 +60,7 @@ class FitNetDistiller(nn.Module):
         s_dict, s_logit, _ = self.student(x)      # (feat_dict, logit, ce_loss(opt))
 
         # 1) hint/guided MSE
-        t_feat = t_dict[self.hint_key]  # e.g. [N, C_t, H_t, W_t] 
+        t_feat = t_dict[self.hint_key]  # e.g. [N, C_t, H_t, W_t]
         s_feat = s_dict[self.guided_key]
         if self.regressor is None:          # 첫 호출에서만 생성
             self.regressor = nn.Conv2d(
@@ -157,7 +157,7 @@ class FitNetDistiller(nn.Module):
 
                 optimizer.step()
 
-            
+
                 total_loss += loss.item() * x.size(0)
                 total_num  += x.size(0)
 

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -26,7 +26,7 @@ class TeacherEfficientNetWrapper(nn.Module):
         self.feat_channels = 1408
 
         # distillation adapter removed
-    
+
     def forward(self, x, y=None):
         """
         Returns:

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -31,7 +31,7 @@ class TeacherResNetWrapper(nn.Module):
         self.feat_channels = 2048
 
         # distillation adapter removed
-    
+
     def forward(self, x, y=None):
         """
         Returns:

--- a/trainer.py
+++ b/trainer.py
@@ -489,7 +489,7 @@ def student_vib_update(
             else:
                 x = cur_x
                 y_local = cur_y
-            
+
             # ─ Teacher feature → synergy target ─────────────────
             with torch.no_grad():
                 out1 = teacher1(x)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -44,8 +44,8 @@ class ExperimentLogger:
     """
     Handles experiment configuration + result metrics in a single dict (self.config).
     1) Create a unique exp_id for each run
-    2) Save to JSON (entire config) 
-    3) Save to a unique CSV file (subset of fields), 
+    2) Save to JSON (entire config)
+    3) Save to a unique CSV file (subset of fields),
        and also store that csv_filename in the JSON.
     """
 


### PR DESCRIPTION
## Summary
- clean up whitespace in analysis/compare_ablation.py
- clean up whitespace in methods/at.py and methods/fitnet.py
- clean up whitespace in trainer.py
- clean up whitespace in utils/logger.py
- clean up whitespace in teacher wrappers and ImageNet100 data loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749504a8ec8321bb001c709e66e856