### PR TITLE
Update docs and scripts to use base configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ bash scripts/run_ibkd.sh
 3. **(Optional) CE baseline** without distillation:
 
 ```bash
-python main.py --config configs/minimal.yaml --method ce
+python main.py --config configs/base.yaml --method ce
 ```
 
-Both scripts read default options from `configs/minimal.yaml`.
+Both scripts read default options from `configs/base.yaml`.
 Specify comma-separated checkpoint paths under `teacher1_ckpt` or
 `teacher2_ckpt` to load a snapshot ensemble. Place any comments on a separate
 line rather than at the end of the list.
@@ -58,13 +58,13 @@ Use `grad_clip_norm_init`, `grad_clip_norm_final` and
 | `fitnet` | FitNets: Hints for Thin Deep Nets | `methods/fitnet.py` |
 
 Use `--method` to override the selected distillation method when calling `main.py`,
-or set `method` in `configs/minimal.yaml`.
+or set `method` in `configs/base.yaml`.
 
 ## Directory Layout
 
 ```
 configs/
-    minimal.yaml        # experiment settings
+    base.yaml           # experiment settings
 checkpoints/            # teacher checkpoints
 models/                 # teacher and student architectures
 scripts/

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -20,7 +20,7 @@ TEACHER_CHOICES = ["resnet152", "efficientnet_b2"]
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Teacher fine-tuning")
-    p.add_argument("--config", default="configs/minimal.yaml")
+    p.add_argument("--config", default="configs/base.yaml")
     p.add_argument("--teacher_type", choices=TEACHER_CHOICES, required=True)
     p.add_argument("--finetune_ckpt_path")
     p.add_argument("--finetune_epochs", type=int)

--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -28,7 +28,7 @@ def parse_args() -> argparse.Namespace:
 
     ``--config``
         Path to a YAML configuration file. Defaults to
-        ``configs/minimal.yaml``.
+        ``configs/base.yaml``.
     ``--teacher``
         Architecture of the teacher network. Must be one of
         ``resnet152`` or ``efficientnet_b2``.
@@ -48,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     """
 
     p = argparse.ArgumentParser(description="Teacher fine-tuning")
-    p.add_argument("--config", default="configs/minimal.yaml")
+    p.add_argument("--config", default="configs/base.yaml")
     p.add_argument("--teacher", choices=TEACHER_CHOICES, required=True)
     p.add_argument("--epochs", type=int)
     p.add_argument("--lr", type=float)


### PR DESCRIPTION
## Summary
- reference `configs/base.yaml` instead of `configs/minimal.yaml`
- update README usage examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a7c8647483219ac53b62c3504f1c