### PR TITLE
Improve AMP utils with fallback and add test

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,16 @@
+import sys
+import pytest; pytest.importorskip("torch")
+import torch
+
+from utils.misc import get_amp_components
+
+
+def test_get_amp_components_fallback(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch.amp", None)
+    monkeypatch.delattr(torch, "amp", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    ctx, scaler = get_amp_components({"use_amp": True})
+    from torch.cuda.amp import GradScaler, autocast
+    assert isinstance(scaler, GradScaler)
+    assert type(ctx) == type(autocast())
+

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -30,7 +30,10 @@ def get_amp_components(cfg: dict):
     """Return autocast context and scaler based on config."""
     from contextlib import nullcontext
 
-    from torch.amp import GradScaler, autocast
+    try:
+        from torch.amp import GradScaler, autocast
+    except Exception:  # pragma: no cover - fallback for old PyTorch
+        from torch.cuda.amp import GradScaler, autocast
 
     use_amp = cfg.get("use_amp", False)
     init_scale = cfg.get("grad_scaler_init_scale", 1024)


### PR DESCRIPTION
## Summary
- allow `get_amp_components` to import from `torch.cuda.amp` if `torch.amp` is unavailable
- add a regression test for the fallback behaviour using `monkeypatch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a895c9588321a370b901b246744d