### PR TITLE
Add configurable logging settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ pytest
 ## Logging
 
 We rely on Weights & Biases for experiment tracking.
-If you do not wish to use WandB, run with WANDB_MODE=disabled.
+Configure the project name, run name and TensorBoard log directory via
+`wandb_project`, `wandb_run_name` and `tb_log_dir` in `configs/base.yaml`.
+If you do not wish to use WandB, run with `WANDB_MODE=disabled`.
 
 ## License
 

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -51,3 +51,8 @@ ewc_lambda: 30.0
 ewc_samples: 1024
 ewc_online: false
 ewc_decay: 1.0
+
+# ───── Logging options ─────
+wandb_project: kd_monitor
+wandb_run_name: run_001
+tb_log_dir: runs/kd_monitor

--- a/main.py
+++ b/main.py
@@ -134,8 +134,11 @@ def main() -> None:
 
     # logger는 **최종 cfg**가 완성된 뒤에 생성
     logger = ExperimentLogger(cfg, exp_name="ibkd")
-    writer = SummaryWriter(log_dir="runs/kd_monitor")
-    wandb_run = wandb.init(project="kd_monitor", name="run_001")
+    writer = SummaryWriter(log_dir=cfg.get("tb_log_dir", "runs/kd_monitor"))
+    wandb_run = wandb.init(
+        project=cfg.get("wandb_project", "kd_monitor"),
+        name=cfg.get("wandb_run_name", "run_001"),
+    )
     global_step_counter = 0
 
     # ──────────────────────────────────────────────────────────────

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -126,8 +126,11 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
     os.makedirs(ckpt_dir, exist_ok=True)
 
     acc_seen_hist = []
-    writer = SummaryWriter(log_dir="runs/kd_monitor")
-    wandb_run = wandb.init(project="kd_monitor", name="run_001")
+    writer = SummaryWriter(log_dir=cfg.get("tb_log_dir", "runs/kd_monitor"))
+    wandb_run = wandb.init(
+        project=cfg.get("wandb_project", "kd_monitor"),
+        name=cfg.get("wandb_run_name", "run_001"),
+    )
     global_step_counter = 0
     ewc_bank = []
     regularizers = ewc_bank  # alias for optional regularizers


### PR DESCRIPTION
## Summary
- make TensorBoard and WandB settings configurable via `configs/base.yaml`
- use these config values in `main.py` and `trainer_continual.py`
- document new options in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b45058a083219af57d8f50c1f11a