### PR TITLE
Add configurable teacher types

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -5,6 +5,8 @@ num_classes: 100
 student_type: convnext_tiny
 teacher1_ckpt: checkpoints/resnet152_ft.pth
 teacher2_ckpt: checkpoints/efficientnet_b2_ft.pth
+teacher1_type: resnet152
+teacher2_type: efficientnet_b2
 
 batch_size : 128
 replay_ratio: 0.5

--- a/main.py
+++ b/main.py
@@ -207,23 +207,24 @@ def main() -> None:
 
     # ---------- teachers ----------
     if method != 'ce':
-        def _make_teacher(cfg_key, default_name):
+        def _make_teacher(cfg_key, type_key, default_name):
             src = cfg.get(cfg_key, "")
+            teacher_type = cfg.get(type_key, default_name)
             # 1) comma-separated snapshot ensemble
             if isinstance(src, str) and "," in src:
                 src = src.split('#', 1)[0].strip()
                 paths = [p.strip() for p in src.split(',') if p.strip()]
                 return SnapshotTeacher(
                     paths,
-                    backbone_name=default_name,
+                    backbone_name=teacher_type,
                     n_cls=cfg.get("num_classes", 100),
                 ).to(device)
 
             # 2) single checkpoint path
             if isinstance(src, str) and src.endswith('.pth'):
                 m = create_teacher_by_name(
-                    default_name,
-                    num_classes=100,
+                    teacher_type,
+                    num_classes=cfg.get("num_classes", 100),
                     pretrained=False,
                     small_input=True,
                 )
@@ -235,8 +236,8 @@ def main() -> None:
             else:
                 raise ValueError(f"invalid {cfg_key}: {src}")
 
-        t1 = _make_teacher('teacher1_ckpt', 'resnet152')
-        t2 = _make_teacher('teacher2_ckpt', 'efficientnet_b2')
+        t1 = _make_teacher('teacher1_ckpt', 'teacher1_type', 'resnet152')
+        t2 = _make_teacher('teacher2_ckpt', 'teacher2_type', 'efficientnet_b2')
         loaded1 = isinstance(t1, SnapshotTeacher)
         if loaded1:
             print(f"[INFO] Loaded teacher1 snapshot ensemble: {len(t1.models)} models")

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -16,8 +16,7 @@ from trainer import teacher_vib_update, student_vib_update, simple_finetune
 # ============================================================
 from methods.ewc import EWC          # (규제용)
 from methods.lwf import LwF          # (옵션) 추가 실험 대비
-from models.teachers.teacher_resnet import create_resnet152
-from models.teachers.teacher_efficientnet import create_efficientnet_b2
+from utils.model_factory import create_teacher_by_name
 from utils.freeze import freeze_all
 from utils.eval import evaluate_acc
 import torch.nn as nn
@@ -135,8 +134,16 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
     ewc_bank = []
     regularizers = ewc_bank  # alias for optional regularizers
 
-    t1 = create_resnet152(pretrained=True, small_input=True).to(device)
-    t2 = create_efficientnet_b2(pretrained=True, small_input=True).to(device)
+    t1 = create_teacher_by_name(
+        cfg.get("teacher1_type", "resnet152"),
+        pretrained=True,
+        small_input=True,
+    ).to(device)
+    t2 = create_teacher_by_name(
+        cfg.get("teacher2_type", "efficientnet_b2"),
+        pretrained=True,
+        small_input=True,
+    ).to(device)
     freeze_all(t1)
     freeze_all(t2)
     t1.eval()


### PR DESCRIPTION
## Summary
- let teacher model type be configured with `teacher1_type` and `teacher2_type`
- load teacher models in `trainer_continual` using these keys
- respect new keys in `main._make_teacher`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b673caf88321b32658617fca9892