### PR TITLE
Expose experiment name via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ pytest
 We rely on Weights & Biases for experiment tracking.
 Configure the project name, run name and TensorBoard log directory via
 `wandb_project`, `wandb_run_name` and `tb_log_dir` in `configs/base.yaml`.
+The experiment prefix can be set with `exp_name` (defaults to `ibkd`).
 If you do not wish to use WandB, run with `WANDB_MODE=disabled`.
 
 ## License

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -55,6 +55,7 @@ ewc_online: false
 ewc_decay: 1.0
 
 # ───── Logging options ─────
+exp_name: ibkd
 wandb_project: kd_monitor
 wandb_run_name: run_001
 tb_log_dir: runs/kd_monitor

--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ def main() -> None:
     os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)
 
     # logger는 **최종 cfg**가 완성된 뒤에 생성
-    logger = ExperimentLogger(cfg, exp_name="ibkd")
+    logger = ExperimentLogger(cfg, exp_name=cfg.get("exp_name", "ibkd"))
     writer = SummaryWriter(log_dir=cfg.get("tb_log_dir", "runs/kd_monitor"))
     wandb_run = wandb.init(
         project=cfg.get("wandb_project", "kd_monitor"),

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -79,7 +79,8 @@ class ExperimentLogger:
 
     def _generate_exp_id(self, exp_name: str = "exp") -> str:
         """
-        Creates an experiment ID like 'ibkd_noeval_20250704_123456'
+        Creates an experiment ID like '<exp_name>_noeval_20250704_123456'.
+        The prefix comes from ``exp_name`` which defaults to ``"ibkd"``.
         """
         eval_mode = self.config.get("eval_mode", "noeval")
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Summary
- allow setting `exp_name` in `configs/base.yaml`
- use `cfg.get("exp_name", "ibkd")` when creating `ExperimentLogger`
- clarify default experiment prefix in logger and README

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b78d8fcc832181c963d7c8739085