### PR TITLE
Add cfg key for ImageNet100 path

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,6 +1,7 @@
 # configs/base.yaml
 
 dataset_root: ./data
+imagenet100_root: ./data/imagenet100
 num_classes: 100
 student_type: convnext_tiny
 teacher1_ckpt: checkpoints/resnet152_ft.pth

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -7,7 +7,7 @@ import torchvision
 import torchvision.transforms as T
 
 def get_imagenet100_loaders(
-    root: str = "./data/imagenet100",
+    root: Optional[str] = None,
     batch_size: int = 128,
     num_workers: int = 2,
     augment: bool = True,
@@ -22,6 +22,13 @@ def get_imagenet100_loaders(
     Returns:
         train_loader, test_loader
     """
+    if root is None:
+        root = (
+            cfg.get("imagenet100_root", "./data/imagenet100")
+            if cfg is not None
+            else "./data/imagenet100"
+        )
+
     if augment:
         aug_ops = [T.RandomResizedCrop(224), T.RandomHorizontalFlip()]
         if cfg is not None:


### PR DESCRIPTION
## Summary
- add `imagenet100_root` in `configs/base.yaml`
- let `get_imagenet100_loaders` resolve `root` from cfg when not provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b869f82483219aa0d30bcf546284