### PR TITLE
Improve script portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ python scripts/train_teacher.py --teacher resnet152 --ckpt checkpoints/resnet152
 python scripts/train_teacher.py --teacher efficientnet_b2 --ckpt checkpoints/efficientnet_b2_ft.pth
 ```
 
+All helper scripts inside `scripts/` first move to the repository root based on
+their own location, so they can be executed from any working directory.
+
 Pass `--overwrite` to `scripts/fine_tuning.py` to remove an existing checkpoint
 before starting a new run:
 

--- a/scripts/make_snapshots.sh
+++ b/scripts/make_snapshots.sh
@@ -10,6 +10,10 @@
 
 set -euo pipefail
 
+# (1) 프로젝트 루트: 스크립트 위치 기준으로 자동 결정
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
 # ───────── Conda 환경 ─────────
 source ~/anaconda3/etc/profile.d/conda.sh
 conda activate tlqkf              # ← 당신이 만든 env 이름

--- a/scripts/run_launcher.sh
+++ b/scripts/run_launcher.sh
@@ -13,9 +13,9 @@
 #-------------------------------------------------------------------
 set -euo pipefail
 
-# (1) 프로젝트 루트: 제출한 곳으로 직접 이동
-cd "${SLURM_SUBMIT_DIR:-$PWD}"
-ROOT_DIR=$(pwd)
+# (1) 프로젝트 루트: 스크립트 위치 기준으로 자동 결정
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
 
 # 안전: 그래도 환경변수로 덮어쓰기 허용
 if [ -n "${PROJECT_ROOT:-}" ]; then


### PR DESCRIPTION
## Summary
- autodetect project root in helper scripts
- document running scripts from any location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687512935f888321a718cc474a410287