### PR TITLE
Update launcher script references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python scripts/fine_tuning.py --teacher_type resnet152 --overwrite
 2. **Run IB-KD** using the provided checkpoints:
 
 ```bash
-bash scripts/run_ibkd.sh
+bash scripts/run_launcher.sh
 ```
 
 3. **(Optional) CE baseline** without distillation:
@@ -78,7 +78,7 @@ checkpoints/            # teacher checkpoints
 models/                 # teacher and student architectures
 scripts/
     train_teacher.py    # CE fine-tuning
-    run_ibkd.sh         # distillation entry point
+    run_launcher.sh     # distillation entry point
 utils/
 main.py                 # training driver
 trainer.py              # training loops

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # scripts/fine_tuning.py
-"""Lightweight teacher fine-tuning script used by run_ibkd.sh."""
+"""Lightweight teacher fine-tuning script used by run_launcher.sh."""
 import argparse
 import os
 import sys

--- a/scripts/run_launcher.sh
+++ b/scripts/run_launcher.sh
@@ -81,5 +81,5 @@ shift 0   # 인수 필요 없음; 있으면 그대로 Python 쪽으로
 srun --chdir="$ROOT_DIR" "$CONDA_PREFIX/bin/python" scripts/launcher.py "$@"
 
 # ➜ 주의: 다른 인자(실험 id, 추가 override 등)는
-#     ./run_ibkd.sh --batch_size 256 처럼 이어서 넘기면 됩니다.
+#     ./run_launcher.sh --batch_size 256 처럼 이어서 넘기면 됩니다.
 trap 'pkill -P $$ || true' EXIT   # 자식 프로세스(예: TensorBoard) 강제 종료


### PR DESCRIPTION
## Summary
- use `run_launcher.sh` in README workflow section
- show `run_launcher.sh` in directory layout example
- update comment in `scripts/run_launcher.sh`
- refer to `run_launcher.sh` from fine-tuning docstring

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68751ee394d8832193b634cf9da51777