### PR TITLE
Fix snapshot script to use conda python

### DIFF
--- a/scripts/make_snapshots.sh
+++ b/scripts/make_snapshots.sh
@@ -25,9 +25,9 @@ EPOCHS=60                               # 총 epoch
 INTERVAL=20                             # 몇 epoch마다 저장?
 MODEL=resnet152                         # 교사 backbone
 
+# Conda env의 python 바이너리를 쓰고, 새 파일명 fine_tuning.py 사용
 mkdir -p "$CKPT_DIR"
-
-python scripts/train_teacher.py \
+"$CONDA_PREFIX/bin/python"  scripts/fine_tuning.py \
        --teacher_type "$MODEL" \
        --epochs "$EPOCHS" \
        --snapshot_interval "$INTERVAL" \


### PR DESCRIPTION
## Summary
- make make_snapshots.sh use the python interpreter of the active conda environment
- use the new script `fine_tuning.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875bd547e388321b5021408c79dd4d6