### PR TITLE
Fix snapshot script for teacher training

### DIFF
--- a/scripts/make_snapshots.sh
+++ b/scripts/make_snapshots.sh
@@ -29,11 +29,11 @@ EPOCHS=60                               # 총 epoch
 INTERVAL=20                             # 몇 epoch마다 저장?
 MODEL=resnet152                         # 교사 backbone
 
-# Conda env의 python 바이너리를 쓰고, 새 파일명 fine_tuning.py 사용
+# ───────── 교사 스냅샷 트레이닝 ─────────
 mkdir -p "$CKPT_DIR"
-"$CONDA_PREFIX/bin/python"  "$ROOT_DIR/scripts/fine_tuning.py" \
-       --teacher_type "$MODEL" \
+"$CONDA_PREFIX/bin/python"  "$ROOT_DIR/scripts/train_teacher.py" \
+       --teacher "$MODEL" \
        --epochs "$EPOCHS" \
+       --lr 1e-3 \                       # 필요 시 수정
        --snapshot_interval "$INTERVAL" \
-       --ckpt_dir "$CKPT_DIR" \
-       --finetune_lr 1e-3            # 필요 시 수정
+       --ckpt "$CKPT_DIR/${MODEL}_ft.pth"

--- a/scripts/train_teacher.py
+++ b/scripts/train_teacher.py
@@ -55,6 +55,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--wd", type=float)
     p.add_argument("--batch_size", type=int)
     p.add_argument("--ckpt", required=True)
+    # --- NEW: snapshot 옵션 (CLI > YAML) ----------------------------
+    p.add_argument("--snapshot_interval", type=int,
+                   help="Save an extra checkpoint every N epochs")
+    p.add_argument("--snapshot_start", type=int,
+                   help="Start saving snapshots from this epoch")
     p.add_argument("--device", default="cuda")
     return p.parse_args()
 
@@ -154,8 +159,16 @@ def main() -> None:
             best_state = copy.deepcopy(model.state_dict())
 
         # ─ Snapshot‑Ensemble ─
-        snap_int   = cfg.get("snapshot_interval", 10)
-        snap_start = cfg.get("snapshot_start", 20)
+        snap_int   = (
+            args.snapshot_interval
+            if args.snapshot_interval is not None
+            else cfg.get("snapshot_interval", 10)
+        )
+        snap_start = (
+            args.snapshot_start
+            if args.snapshot_start is not None
+            else cfg.get("snapshot_start", 20)
+        )
         if ep >= snap_start and ep % snap_int == 0:
             torch.save(
                 model.state_dict(),


### PR DESCRIPTION
## Summary
- allow overriding snapshot saving via CLI options in `train_teacher.py`
- invoke teacher fine-tuning with `train_teacher.py` from `make_snapshots.sh`

## Testing
- `pytest -q` *(fails: 7 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6875cf5c10d88321afd82635a80d9362