### PR TITLE
Fix line continuation in make_snapshots

### DIFF
--- a/scripts/make_snapshots.sh
+++ b/scripts/make_snapshots.sh
@@ -31,9 +31,9 @@ MODEL=resnet152                         # 교사 backbone
 
 # ───────── 교사 스냅샷 트레이닝 ─────────
 mkdir -p "$CKPT_DIR"
-"$CONDA_PREFIX/bin/python"  "$ROOT_DIR/scripts/train_teacher.py" \
-       --teacher "$MODEL" \
-       --epochs "$EPOCHS" \
-       --lr 1e-3 \                       # 필요 시 수정
-       --snapshot_interval "$INTERVAL" \
-       --ckpt "$CKPT_DIR/${MODEL}_ft.pth"
+"$CONDA_PREFIX/bin/python" "$ROOT_DIR/scripts/train_teacher.py" \
+    --teacher "$MODEL" \
+    --epochs "$EPOCHS" \
+    --lr 1e-3 \
+    --snapshot_interval "$INTERVAL" \
+    --ckpt "$CKPT_DIR/${MODEL}_ft.pth"


### PR DESCRIPTION
## Summary
- fix trailing space/comment after `\` in `scripts/make_snapshots.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d645ac9883219ca6b2b6ba10a394