### PR TITLE
Add adaptive gating option to MBM

### DIFF
--- a/configs/method/vib/standard.yaml
+++ b/configs/method/vib/standard.yaml
@@ -18,6 +18,9 @@ teacher_lr          : 1e-3
 teacher_weight_decay: 5e-4
 gate_dropout        : 0.1
 teacher_dropout_p   : 0.3
+# ─ Adaptive Gate 옵션 추가 ─
+adaptive_gate   : true
+gate_hidden_dim : 128
 
 # ─ KD 스케줄 (안전한 Warm‑start) ─
 kd_alpha_init    : 0.0       # 첫 10 % epoch 은 CE 100 %

--- a/main.py
+++ b/main.py
@@ -372,6 +372,8 @@ def main() -> None:
                 cfg.get('latent_clamp_max', 2),
             ),
             dropout_p=cfg.get('gate_dropout', 0.1),
+            adaptive=cfg.get('adaptive_gate', False),
+            gate_hidden=cfg.get('gate_hidden_dim', 128),
         ).to(device)
     else:
         vib_mbm = None

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -18,3 +18,11 @@ def test_forward_flattened_inputs():
     f2 = torch.randn(4, 16)
     _, logit, _, _, _, _ = mbm(f1, f2)
     assert logit.shape == (4, 100)
+
+
+def test_forward_adaptive_gate():
+    mbm = GateMBM(16, 16, 100, 256, adaptive=True, gate_hidden=32)
+    f1 = torch.randn(2, 16, 4, 4)
+    f2 = torch.randn(2, 16, 4, 4)
+    _, logit, _, _, _, _ = mbm(f1, f2)
+    assert logit.shape == (2, 100)


### PR DESCRIPTION
## Summary
- extend `GateMBM` with optional adaptive gating via small MLP
- pass adaptive parameters from config and CLI
- expose new config options
- test adaptive gate forward

## Testing
- `pytest -q` *(tests skipped: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875eab6c5b88321b224656ae0af8444