### PR TITLE
Fix GateMBM constructor syntax

### DIFF
--- a/models/ib/gate_mbm.py
+++ b/models/ib/gate_mbm.py
@@ -25,7 +25,6 @@ class GateMBM(nn.Module):
         *,
         clamp: tuple[float, float] = (-6.0, 2.0),
         dropout_p: float = 0.1,
-        *,
         adaptive: bool = False,
         gate_hidden: int = 128,
     ):


### PR DESCRIPTION
## Summary
- remove an extra `*` from `GateMBM` constructor so the code is valid Python

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f53914888321adeed6d9ded2848d