### PR TITLE
Update snapshot ckpt parsing

### DIFF
--- a/models/ensemble/snapshot_teacher.py
+++ b/models/ensemble/snapshot_teacher.py
@@ -10,6 +10,7 @@ class SnapshotTeacher(nn.Module):
                  backbone_name: str = "resnet50",
                  n_cls: int = 100):
         super().__init__()
+        assert len(ckpt_paths) > 0, "ckpt_paths 리스트가 비었습니다 (엔셀블 구성 불가)"
         from utils.model_factory import create_teacher_by_name  # delayed import
 
         self.models = nn.ModuleList()

--- a/utils/model_factory.py
+++ b/utils/model_factory.py
@@ -47,11 +47,15 @@ def create_teacher_by_name(
 
     # Snapshot ensemble teacher
     if teacher_type.lower() == "snapshot":
-        ckpt_list = (cfg or {}).get("teacher1_ckpt", "")
-        ckpts = [p.strip() for p in ckpt_list.split(",") if p.strip()]
-        assert ckpts, "[SnapshotTeacher] teacher1_ckpt 가 비었습니다."
+        # cfg 에서 가져온 콤마 구분 문자열 → ['file1.pth', 'file2.pth', …]
+        ckpt_raw = (cfg or {}).get("teacher1_ckpt", "")
+        ckpts = [p.strip() for p in ckpt_raw.split(",") if p.strip()]
+        assert ckpts, (
+            "[SnapshotTeacher] teacher1_ckpt 가 비었습니다. "
+            f"(현재 값='{ckpt_raw}')"
+        )
         base = (cfg or {}).get("snapshot_backbone", "resnet152")
-        return SnapshotTeacher(ckpts, backbone_name=base, n_cls=num_classes)
+        return SnapshotTeacher(ckpt_paths=ckpts, backbone_name=base, n_cls=num_classes)
     raise ValueError(
         f"Unknown teacher_type: {teacher_type} (expected 'resnet152' or 'efficientnet_b2')"
     )


### PR DESCRIPTION
## Summary
- parse comma-separated `teacher1_ckpt` string when creating snapshot teachers
- add guard message when snapshot ensemble receives no checkpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875faa56ae883218e7eec8a4ae9ab29