### PR TITLE
Fix path env expansion

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ import pytest; pytest.importorskip("torch")
 import torch
 
 from utils.misc import get_amp_components
+from utils.path_utils import to_writable
 
 
 def test_get_amp_components_fallback(monkeypatch):
@@ -13,4 +14,10 @@ def test_get_amp_components_fallback(monkeypatch):
     from torch.cuda.amp import GradScaler, autocast
     assert isinstance(scaler, GradScaler)
     assert type(ctx) == type(autocast())
+
+
+def test_to_writable_expands_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = to_writable("$HOME/testfile")
+    assert result == str(tmp_path / "testfile")
 

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -8,12 +8,14 @@ import pathlib
 def to_writable(path: str | os.PathLike, *, env_var: str = "ASMB_KD_ROOT") -> str:
     """Return a writable absolute path.
 
+    - Environment variables inside ``path`` are expanded.
     - Absolute paths are returned unchanged.
     - Relative paths are resolved under ``$ASMB_KD_ROOT`` (or ``$HOME/.asmb_kd``).
     The parent directory is created if it does not exist.
     """
-    # tilde(`~`) 확장 + 이후 절대경로 판단
-    p = pathlib.Path(path).expanduser()
+    # expand env vars then tilde(`~`) and determine absolute path
+    expanded = os.path.expandvars(path)
+    p = pathlib.Path(expanded).expanduser()
     if p.is_absolute():
         abs_path = p
     else:


### PR DESCRIPTION
## Summary
- expand environment variables in `to_writable`
- document behaviour in utils docstring
- test env variable expansion in paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760486be1883219dfa7f18225219e1