### PR TITLE
Add file-not-found check for snapshot_teacher

### DIFF
--- a/models/ensemble/snapshot_teacher.py
+++ b/models/ensemble/snapshot_teacher.py
@@ -21,7 +21,13 @@ class SnapshotTeacher(nn.Module):
                 pretrained=False,
                 allow_empty_ckpt=True,
             )
-            m.load_state_dict(torch.load(p, map_location="cpu"))
+            try:
+                state = torch.load(p, map_location="cpu")
+            except FileNotFoundError as e:
+                raise FileNotFoundError(
+                    f"{p} not found. Ensure ASMB_KD_ROOT points to the directory containing your checkpoints."
+                ) from e
+            m.load_state_dict(state)
             m.eval()
             for param in m.parameters():
                 param.requires_grad_(False)

--- a/tests/test_snapshot_teacher.py
+++ b/tests/test_snapshot_teacher.py
@@ -1,0 +1,13 @@
+import pytest; pytest.importorskip("torch")
+
+from models.ensemble import SnapshotTeacher
+
+
+def test_snapshot_teacher_missing_ckpt(tmp_path):
+    missing = tmp_path / "foo.pt"
+    with pytest.raises(FileNotFoundError) as exc:
+        SnapshotTeacher([str(missing)])
+    # check message mentions path and env variable
+    msg = str(exc.value)
+    assert str(missing) in msg
+    assert "ASMB_KD_ROOT" in msg


### PR DESCRIPTION
## Summary
- raise a helpful `FileNotFoundError` when snapshot checkpoints are missing
- test the new error message

## Testing
- `pytest -q` *(fails: 8 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68760487614483219afbb76be9ec6ce3