### PR TITLE
Add overlapping teacher training utility

### DIFF
--- a/data/overlap.py
+++ b/data/overlap.py
@@ -1,0 +1,94 @@
+# data/overlap.py
+"""Utility to create two overlapping CIFAR-100 loaders."""
+
+from __future__ import annotations
+
+import torch
+import torchvision
+import torchvision.transforms as T
+from typing import Tuple
+
+
+def get_overlap_loaders(
+    rho: float,
+    *,
+    root: str = "./data",
+    batch_size: int = 128,
+    num_workers: int = 0,
+    seed: int = 42,
+) -> Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader]:
+    """Return two train loaders sharing a fraction of data.
+
+    Parameters
+    ----------
+    rho : float
+        Overlap ratio between the two splits (0.0 to 1.0).
+    root : str, optional
+        Dataset root folder, by default ``"./data"``.
+    batch_size : int, optional
+        Mini-batch size, by default ``128``.
+    num_workers : int, optional
+        Data loader worker count, by default ``0``.
+    seed : int, optional
+        Random seed used for the split, by default ``42``.
+
+    Returns
+    -------
+    tuple of DataLoader
+        ``(train_loader1, train_loader2, test_loader)``.
+    """
+    transform_train = T.Compose([
+        T.RandomCrop(32, padding=4),
+        T.RandomHorizontalFlip(),
+        T.ToTensor(),
+        T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
+    ])
+    transform_test = T.Compose([
+        T.ToTensor(),
+        T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
+    ])
+
+    base_train = torchvision.datasets.CIFAR100(
+        root=root, train=True, download=True, transform=transform_train
+    )
+    test_dataset = torchvision.datasets.CIFAR100(
+        root=root, train=False, download=True, transform=transform_test
+    )
+
+    n = len(base_train)
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    indices = torch.randperm(n, generator=generator).tolist()
+
+    overlap_n = int(n * rho)
+    unique_n = (n - overlap_n) // 2
+
+    shared_idx = indices[:overlap_n]
+    unique1 = indices[overlap_n : overlap_n + unique_n]
+    unique2 = indices[overlap_n + unique_n : overlap_n + 2 * unique_n]
+    leftover = indices[overlap_n + 2 * unique_n :]
+    shared_idx.extend(leftover)
+
+    idx1 = unique1 + shared_idx
+    idx2 = unique2 + shared_idx
+
+    ds1 = torch.utils.data.Subset(base_train, idx1)
+    ds2 = torch.utils.data.Subset(base_train, idx2)
+
+    dl_kwargs = dict(
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    train_loader1 = torch.utils.data.DataLoader(ds1, **dl_kwargs)
+    train_loader2 = torch.utils.data.DataLoader(ds2, **dl_kwargs)
+
+    test_loader = torch.utils.data.DataLoader(
+        test_dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    return train_loader1, train_loader2, test_loader

--- a/scripts/train_teacher_overlap.py
+++ b/scripts/train_teacher_overlap.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Train two teachers on overlapping CIFAR-100 splits."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import yaml
+
+sys.path.append(os.path.dirname(__file__) + "/..")
+
+from utils.model_factory import create_teacher_by_name
+from trainer import simple_finetune
+from data.overlap import get_overlap_loaders
+
+TEACHER_CHOICES = ["resnet152", "efficientnet_b2"]
+
+
+def _load_cfg(path: str) -> dict:
+    if os.path.exists(path):
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description="Train two teachers on overlapping CIFAR-100 splits"
+    )
+    ap.add_argument("--config", default="configs/base.yaml")
+    ap.add_argument("--teacher1", choices=TEACHER_CHOICES, default="resnet152")
+    ap.add_argument("--teacher2", choices=TEACHER_CHOICES, default="efficientnet_b2")
+    ap.add_argument("--rho", type=float, required=True, help="Overlap ratio [0,1]")
+    ap.add_argument("--out_dir", required=True, help="Directory to save checkpoints")
+    ap.add_argument("--epochs", type=int)
+    ap.add_argument("--lr", type=float)
+    ap.add_argument("--wd", type=float)
+    ap.add_argument("--batch_size", type=int)
+    ap.add_argument("--device", default="cuda")
+    return ap.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = _load_cfg(args.config)
+
+    batch_size = args.batch_size or cfg.get("batch_size", 128)
+    num_workers = cfg.get("num_workers", 2)
+    train1, train2, test_loader = get_overlap_loaders(
+        args.rho,
+        root=cfg.get("dataset_root", "./data"),
+        batch_size=batch_size,
+        num_workers=num_workers,
+    )
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    ckpt1 = os.path.join(args.out_dir, f"T1_rho{args.rho}.pth")
+    ckpt2 = os.path.join(args.out_dir, f"T2_rho{args.rho}.pth")
+
+    n_cls = len(test_loader.dataset.classes)
+    t1 = create_teacher_by_name(
+        args.teacher1,
+        num_classes=n_cls,
+        pretrained=True,
+        small_input=True,
+        cfg=cfg,
+    ).to(args.device)
+    t2 = create_teacher_by_name(
+        args.teacher2,
+        num_classes=n_cls,
+        pretrained=True,
+        small_input=True,
+        cfg=cfg,
+    ).to(args.device)
+
+    epochs = args.epochs or cfg.get("finetune_epochs", 3)
+    lr = args.lr or cfg.get("finetune_lr", 1e-4)
+    wd = args.wd or cfg.get("finetune_weight_decay", 0.0)
+
+    ft_cfg = dict(cfg)
+    ft_cfg["finetune_eval_loader"] = test_loader
+
+    simple_finetune(
+        t1,
+        train1,
+        lr=lr,
+        epochs=epochs,
+        device=args.device,
+        weight_decay=wd,
+        cfg=ft_cfg,
+        ckpt_path=ckpt1,
+    )
+    simple_finetune(
+        t2,
+        train2,
+        lr=lr,
+        epochs=epochs,
+        device=args.device,
+        weight_decay=wd,
+        cfg=ft_cfg,
+        ckpt_path=ckpt2,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `get_overlap_loaders` helper for overlapping CIFAR-100 splits
- add `scripts/train_teacher_overlap.py` to train two teachers on overlapping data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687607018e3083218a7d60e8b0deaa53