### PR TITLE
Use fixed root env variable for all paths

### DIFF
--- a/experiments/exp_adaptgate.yaml
+++ b/experiments/exp_adaptgate.yaml
@@ -5,11 +5,16 @@ imports:
 
 # ---- 교사 설정 ----
 teacher1_type: snapshot
-teacher1_ckpt: >
-  checkpoints/snapshots/resnet152_ft.pth,
-  checkpoints/snapshots/snap_ep020.pth,
-  checkpoints/snapshots/snap_ep040.pth,
-  checkpoints/snapshots/snap_ep060.pth
+teacher1_ckpt: "${ASMB_KD_ROOT}/checkpoints/snapshots/resnet152_ft.pth,\
+  ${ASMB_KD_ROOT}/checkpoints/snapshots/snap_ep020.pth,\
+  ${ASMB_KD_ROOT}/checkpoints/snapshots/snap_ep040.pth,\
+  ${ASMB_KD_ROOT}/checkpoints/snapshots/snap_ep060.pth"
+
+# (efficientnet-B2 단일 교사 CKPT 예시)
+teacher2_ckpt: "${ASMB_KD_ROOT}/checkpoints/efficientnet_b2_ft.pth"
+
+# 공통 체크포인트 폴더도 동일 변수 사용
+checkpoint_dir: "${ASMB_KD_ROOT}/checkpoints"
 
 # (옵션) 백본명 명시 – 기본은 resnet152
 snapshot_backbone: resnet152

--- a/scripts/make_snapshots.sh
+++ b/scripts/make_snapshots.sh
@@ -23,8 +23,12 @@ cd "$ROOT_DIR" || { echo "[ERROR] cd $ROOT_DIR failed"; exit 1; }
 source ~/anaconda3/etc/profile.d/conda.sh
 conda activate tlqkf              # ← 당신이 만든 env 이름
 
+# ───────── 실험 기본 경로 ─────────
+#  ※ 파이썬 코드의 to_writable() 가 ${ASMB_KD_ROOT} 를 expand 합니다.
+export ASMB_KD_ROOT=/home/suyoung425/ASMB_KD
+
 # ───────── 스냅샷 파라미터 ─────────
-CKPT_DIR="${ASMB_KD_ROOT:-$HOME/.asmb_kd}/checkpoints/snapshots"          # 저장 폴더
+CKPT_DIR="${ASMB_KD_ROOT}/checkpoints/snapshots"
 EPOCHS=60                               # 총 epoch
 INTERVAL=20                             # 몇 epoch마다 저장?
 MODEL=resnet152                         # 교사 backbone

--- a/scripts/run_launcher.sh
+++ b/scripts/run_launcher.sh
@@ -29,14 +29,16 @@ if [ -n "${PROJECT_ROOT:-}" ]; then
     cd "$ROOT_DIR"
 fi
 
-# 저장 경로 환경변수는 외부에서 설정 가능하며,
-# 기본값은 "${HOME}/.asmb_kd" 하위 디렉터리입니다.
-export ASMB_KD_ROOT="${ASMB_KD_ROOT:-$HOME/.asmb_kd}"
+# (2) 출력·체크포인트 디렉터리를 "집" 밑으로 옮긴다
+## 1) Conda
+source ~/anaconda3/etc/profile.d/conda.sh
+conda activate tlqkf
+export ASMB_KD_ROOT=/home/suyoung425/ASMB_KD
 
 # (2) 출력·체크포인트 디렉터리를 "집" 밑으로 옮긴다
 JOB_ID=${SLURM_JOB_ID:-local}
-CKPT_DIR="${ASMB_KD_ROOT:-$HOME/.asmb_kd}/checkpoints"      # ← 쓰기 가능한 위치
-OUT_ROOT="${ASMB_KD_ROOT:-$HOME/.asmb_kd}/outputs"
+CKPT_DIR="${ASMB_KD_ROOT}/checkpoints"      # ← 쓰기 가능한 위치
+OUT_ROOT="${ASMB_KD_ROOT}/outputs"
 OUT_DIR="$OUT_ROOT/ibkd_${JOB_ID}"
 
 # 실제로 만들기
@@ -45,10 +47,6 @@ mkdir -p "$CKPT_DIR" "$OUT_DIR" "$OUT_ROOT/slurm"
 # 0) 디버그용 정보
 echo "[DEBUG] PWD=$(pwd)"
 echo "[DEBUG] HOST=$(hostname)"
-
-## 1) Conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate tlqkf
 
 # (선택) W&B API Key – 있을 때만 ↓ 라인 유지, 없으면 그냥 지워두세요
 export WANDB_API_KEY="ca52ce9b353498922ae0cd78cbb5ae0673494e6b"

--- a/scripts/run_vib_overlap.sh
+++ b/scripts/run_vib_overlap.sh
@@ -21,17 +21,17 @@ else
 fi
 cd "$ROOT_DIR" || { echo "[ERROR] cd $ROOT_DIR failed"; exit 1; }
 
+# Activate conda environment
+source ~/anaconda3/etc/profile.d/conda.sh
+conda activate tlqkf
+export ASMB_KD_ROOT=/home/suyoung425/ASMB_KD
+
 # Output and checkpoint directories
-export ASMB_KD_ROOT="${ASMB_KD_ROOT:-$HOME/.asmb_kd}"
 CKPT_DIR="$ASMB_KD_ROOT/checkpoints"
 OUT_ROOT="$ASMB_KD_ROOT/outputs"
 JOB_ID=${SLURM_ARRAY_JOB_ID:-${SLURM_JOB_ID:-local}}
 OUT_DIR="$OUT_ROOT/vib_overlap_${JOB_ID}"
 mkdir -p "$CKPT_DIR" "$OUT_DIR" "$OUT_ROOT/slurm"
-
-# Activate conda environment
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate tlqkf
 
 # Rho values for the job array
 RHO_VALUES=(0.0 0.2 0.4 0.6 0.8 1.0)


### PR DESCRIPTION
## Summary
- set `ASMB_KD_ROOT` after activating conda in SBATCH scripts
- use that env var for checkpoint paths
- update `exp_adaptgate.yaml` paths to rely on `ASMB_KD_ROOT`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760993a9708321b8824f4d0eda3a82