### PR TITLE
Fix SnapshotTeacher load for CIFAR checkpoints

### DIFF
--- a/models/ensemble/snapshot_teacher.py
+++ b/models/ensemble/snapshot_teacher.py
@@ -19,6 +19,7 @@ class SnapshotTeacher(nn.Module):
                 backbone_name,
                 num_classes=n_cls,
                 pretrained=False,
+                small_input=True,      # CIFAR scale -> conv1 3x3
                 allow_empty_ckpt=True,
             )
             try:


### PR DESCRIPTION
## Summary
- ensure `SnapshotTeacher` loads CIFAR-scale checkpoints by enabling `small_input`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876109335e48321a6b7e48851e38487