### PR TITLE
Fix torchvision RandAugment tensor handling

### DIFF
--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -3,6 +3,7 @@
 import warnings
 from torchvision.datasets import CIFAR100
 import os, torch, torchvision.transforms as T
+from utils.transform_utils import SafeToTensor
 from typing import Mapping, Any, Optional
 
 # ──────────────────────────────────────────────────────────────
@@ -67,18 +68,18 @@ def get_cifar100_loaders(
         else:
             aug_ops.append(T.RandAugment(num_ops=randaug_default_N, magnitude=randaug_default_M))
         aug_ops.extend([
-            T.ToTensor(),
+            SafeToTensor(),
             T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
         ])
         transform_train = T.Compose(aug_ops)
     else:
         transform_train = T.Compose([
-            T.ToTensor(),
+            SafeToTensor(),
             T.Normalize((0.5071,0.4865,0.4409),
                         (0.2673,0.2564,0.2762))
         ])
     transform_test = T.Compose([
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize((0.5071,0.4865,0.4409),
                     (0.2673,0.2564,0.2762))
     ])

--- a/data/cifar100_cl.py
+++ b/data/cifar100_cl.py
@@ -4,6 +4,7 @@
 import torch
 import torchvision
 import torchvision.transforms as T
+from utils.transform_utils import SafeToTensor
 from functools import lru_cache
 
 # ------------------------------------------------------------------
@@ -54,13 +55,13 @@ def get_cifar100_cl_loaders(
     if randaug_N > 0 and randaug_M > 0:
         ops.append(T.RandAugment(num_ops=randaug_N, magnitude=randaug_M))
     ops.extend([
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
     ])
     transform_train = T.Compose(ops)
 
     transform_test = T.Compose([
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
     ])
 
@@ -136,8 +137,12 @@ def get_balanced_loader(
     root: str = "./data",
 ):
     """Return a class-balanced loader using replay buffer and current data."""
-    ops = [T.RandomCrop(32, padding=4), T.RandomHorizontalFlip(), T.ToTensor(),
-           T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762))]
+    ops = [
+        T.RandomCrop(32, padding=4),
+        T.RandomHorizontalFlip(),
+        SafeToTensor(),
+        T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
+    ]
     transform = T.Compose(ops)
 
     base_train = torchvision.datasets.CIFAR100(

--- a/data/cifar100_overlap.py
+++ b/data/cifar100_overlap.py
@@ -7,6 +7,7 @@ from typing import Mapping, Any, Optional, Sequence, Tuple
 import torch
 import torchvision
 import torchvision.transforms as T
+from utils.transform_utils import SafeToTensor
 
 __all__ = ["get_overlap_loaders"]
 
@@ -53,12 +54,12 @@ def get_overlap_loaders(
             aug_ops.append(
                 T.RandAugment(num_ops=randaug_default_N, magnitude=randaug_default_M)
             )
-        aug_ops.extend([T.ToTensor(), T.Normalize(_MEAN, _STD)])
+        aug_ops.extend([SafeToTensor(), T.Normalize(_MEAN, _STD)])
         transform_train = T.Compose(aug_ops)
     else:
-        transform_train = T.Compose([T.ToTensor(), T.Normalize(_MEAN, _STD)])
+        transform_train = T.Compose([SafeToTensor(), T.Normalize(_MEAN, _STD)])
 
-    transform_test = T.Compose([T.ToTensor(), T.Normalize(_MEAN, _STD)])
+    transform_test = T.Compose([SafeToTensor(), T.Normalize(_MEAN, _STD)])
 
     base_train = torchvision.datasets.CIFAR100(
         root=root, train=True, download=True, transform=transform_train

--- a/data/imagenet100.py
+++ b/data/imagenet100.py
@@ -5,6 +5,7 @@ from typing import Mapping, Any, Optional
 import torch
 import torchvision
 import torchvision.transforms as T
+from utils.transform_utils import SafeToTensor
 
 def get_imagenet100_loaders(
     root: Optional[str] = None,
@@ -39,7 +40,7 @@ def get_imagenet100_loaders(
         else:
             aug_ops.append(T.RandAugment(num_ops=randaug_default_N, magnitude=randaug_default_M))
         aug_ops.extend([
-            T.ToTensor(),
+            SafeToTensor(),
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])
         transform_train = T.Compose(aug_ops)
@@ -47,14 +48,14 @@ def get_imagenet100_loaders(
         transform_train = T.Compose([
             T.Resize(256),
             T.CenterCrop(224),
-            T.ToTensor(),
+            SafeToTensor(),
             T.Normalize(mean=[0.485, 0.456, 0.406],
                         std=[0.229, 0.224, 0.225])
         ])
     transform_test = T.Compose([
         T.Resize(256),
         T.CenterCrop(224),
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize(mean=[0.485, 0.456, 0.406],
                     std=[0.229, 0.224, 0.225])
     ])

--- a/data/overlap.py
+++ b/data/overlap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import torch
 import torchvision
 import torchvision.transforms as T
+from utils.transform_utils import SafeToTensor
 from typing import Tuple
 
 
@@ -40,11 +41,11 @@ def get_overlap_loaders(
     transform_train = T.Compose([
         T.RandomCrop(32, padding=4),
         T.RandomHorizontalFlip(),
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
     ])
     transform_test = T.Compose([
-        T.ToTensor(),
+        SafeToTensor(),
         T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
     ])
 

--- a/utils/transform_utils.py
+++ b/utils/transform_utils.py
@@ -1,0 +1,14 @@
+import torch
+from torchvision.transforms.functional import to_tensor
+
+__all__ = ["SafeToTensor"]
+
+class SafeToTensor:
+    """Convert PIL image or ndarray to tensor; pass through tensors."""
+
+    def __call__(self, img):
+        if isinstance(img, torch.Tensor):
+            if img.dtype == torch.uint8:
+                img = img.float().div_(255.0)
+            return img
+        return to_tensor(img)


### PR DESCRIPTION
## Summary
- add `SafeToTensor` transform to handle tensor inputs
- replace `ToTensor` with `SafeToTensor` in CIFAR and ImageNet loaders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878731e49a4832195fc7f4960629eaf