### PR TITLE
Add training sanity checks and one-hot label support

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -34,8 +34,17 @@ def kd_loss_fn(
     return kd_kl(student_logits, teacher_logits, T=T, task_classes=task_classes)
 
 
-def ce_loss_fn(logits: torch.Tensor, labels: torch.Tensor, label_smoothing: float = 0.0) -> torch.Tensor:
-    """Cross-entropy loss with optional label smoothing."""
+def ce_loss_fn(logits: torch.Tensor, labels: torch.Tensor,
+               label_smoothing: float = 0.0) -> torch.Tensor:
+    """
+    Cross‑entropy that 자동판별:
+      • labels int   → 기존 방식
+      • labels float → one‑hot / mixup
+    """
+    if labels.dtype in (torch.float, torch.float16, torch.bfloat16):
+        # mixup / cutmix → soft‑label CE
+        log_p = F.log_softmax(logits, dim=1)
+        return -(labels * log_p).sum(dim=1).mean()
     return F.cross_entropy(logits, labels, label_smoothing=label_smoothing)
 
 

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -15,11 +15,9 @@ def evaluate_acc(
     total = 0
     for x, y in loader:
         x, y = x.to(device), y.to(device)
-        # labels from mixup/cutmix loaders may be one-hot encoded
-        # or have an extra singleton dimension. Squeeze first and
-        # only apply argmax when a class dimension is present.
+        # ─ Label squeeze & one‑hot → index ─
         y = y.squeeze()
-        if mixup_active and y.ndim > 1:
+        if y.ndim > 1:           # one‑hot / soft
             y = y.argmax(dim=1)
         # 학습-평가 공통 호출을 위해 mixup_active 플래그만 받는다.
         # 평가 시엔 실제 MixUp 입력이 없으므로 로직 변화 없음.


### PR DESCRIPTION
## Summary
- check label shapes and gradients in `student_vib_update`
- guard AMP scaler against underflow
- extend `ce_loss_fn` to handle one-hot labels
- adapt eval and trainer logic to new loss

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879195326c08321a89df93630e6c78e