### PR TITLE
Update CE loss function and eval

### DIFF
--- a/main.py
+++ b/main.py
@@ -627,10 +627,6 @@ def main() -> None:
             student,
             test_loader,
             device,
-            mixup_active=(
-                cfg.get("mixup_alpha", 0) > 0
-                or cfg.get("cutmix_alpha_distill", 0) > 0
-            ),
         )
         print(f"Final student accuracy: {acc:.2f}%")
         logger.update_metric("test_acc", float(acc))

--- a/modules/losses.py
+++ b/modules/losses.py
@@ -41,11 +41,15 @@ def ce_loss_fn(logits: torch.Tensor, labels: torch.Tensor,
       • labels int   → 기존 방식
       • labels float → one‑hot / mixup
     """
-    if labels.dtype in (torch.float, torch.float16, torch.bfloat16):
-        # mixup / cutmix → soft‑label CE
+    # soft‑label(=MixUp/one‑hot) ↔ int label 모두 지원
+    if labels.dtype.is_floating_point:
         log_p = F.log_softmax(logits, dim=1)
         return -(labels * log_p).sum(dim=1).mean()
-    return F.cross_entropy(logits, labels, label_smoothing=label_smoothing)
+    return F.cross_entropy(
+        logits,
+        labels,
+        label_smoothing=label_smoothing,
+    )
 
 
 def dkd_loss(student_logits: torch.Tensor, teacher_logits: torch.Tensor, labels: torch.Tensor,

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -7,7 +7,6 @@ def evaluate_acc(
     model,
     loader,
     device: str = "cuda",
-    mixup_active: bool = False,   # NEW – 호출 처리를 위한 더미 플래그
     classes: list[int] | None = None,
 ):
     model.eval()
@@ -17,10 +16,8 @@ def evaluate_acc(
         x, y = x.to(device), y.to(device)
         # ─ Label squeeze & one‑hot → index ─
         y = y.squeeze()
-        if y.ndim > 1:           # one‑hot / soft
+        if y.ndim > 1:           # one‑hot OR soft
             y = y.argmax(dim=1)
-        # 학습-평가 공통 호출을 위해 mixup_active 플래그만 받는다.
-        # 평가 시엔 실제 MixUp 입력이 없으므로 로직 변화 없음.
         out = model(x)
         # (2‑C) ConvNeXt 등에서 feat_dict 포함 3‑tuple 반환 시 2‑번째가 logits
         if isinstance(out, tuple):


### PR DESCRIPTION
## Summary
- support both soft and hard labels in `ce_loss_fn`
- simplify `evaluate_acc` API
- switch trainer to use `ce_loss_fn` for CE computations
- adjust evaluation calls after API change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792378f43c8321ae770909a79da204