### PR TITLE
Set default distillation method in base config

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -68,6 +68,13 @@ ewc_samples: 1024
 ewc_online: false
 ewc_decay: 1.0
 
+##############################
+# 기본 Distillation 방법 기본값
+#  · CE‑파인튜닝 Job   → 그대로 'ce'
+#  · KD  Job          → 아래 YAML에서 'vib' 등으로 다시 덮어씀
+method: ce
+train_mode: standard
+
 # ───── Logging options ─────
 exp_name: ibkd
 wandb_project: kd_monitor


### PR DESCRIPTION
## Summary
- set default `method: ce` and `train_mode: standard` in `configs/base.yaml`

## Testing
- `pytest -q` *(fails: 9 skipped due to missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_687b5dd687dc8321923e6d6d89af1ce1