### PR TITLE
Add logging interval to simple finetune

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -80,3 +80,4 @@ exp_name: ibkd
 wandb_project: kd_monitor
 wandb_run_name: run_001
 tb_log_dir: runs/kd_monitor
+log_interval: 100        # 100 mini-batches마다 한 줄

--- a/main.py
+++ b/main.py
@@ -367,6 +367,8 @@ def main() -> None:
                 weight_decay=cfg.get("finetune_weight_decay", 0.0),
                 cfg={**cfg, "finetune_eval_loader": test_loader},   # NEW
                 ckpt_path=t1_ckpt or "checkpoints/teacher1_ft.pth",
+                logger=logger,
+                writer=writer,
             )
         if not loaded2:
             simple_finetune(
@@ -378,6 +380,8 @@ def main() -> None:
                 weight_decay=cfg.get("finetune_weight_decay", 0.0),
                 cfg={**cfg, "finetune_eval_loader": test_loader},   # NEW
                 ckpt_path=t2_ckpt or "checkpoints/teacher2_ft.pth",
+                logger=logger,
+                writer=writer,
             )
     if method != 'ce':
         freeze_all(t1)
@@ -633,6 +637,8 @@ def main() -> None:
             weight_decay=cfg.get('student_weight_decay', 0.0),
             cfg=cfg,
             ckpt_path=ce_ckpt,
+            logger=logger,
+            writer=writer,
         )
         acc = evaluate_acc(student, test_loader, device)
         logger.update_metric("student_acc", float(acc))

--- a/trainer_continual.py
+++ b/trainer_continual.py
@@ -373,6 +373,8 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
                     device=device,
                     weight_decay=float(cfg.get("student_weight_decay", 5e-4)),
                     cfg=cfg,
+                    logger=logger,
+                    writer=writer,
                 )
             elif kd_method == "dkd":
                 from methods.dkd import DKDDistiller as Distiller
@@ -451,6 +453,8 @@ def run_continual(cfg: dict, kd_method: str, logger=None) -> None:
                 weight_decay=0.0,
                 cfg=cfg,
                 ckpt_path=f"{ckpt_dir}/task{task}_student_ft.pth",
+                logger=logger,
+                writer=writer,
             )
 
         torch.save(student.state_dict(), f"{ckpt_dir}/task{task}_student.pth")


### PR DESCRIPTION
## Summary
- make finetune loop log progress every `log_interval` steps
- allow optional `logger` and `writer` arguments for `simple_finetune`
- expose `log_interval` in the default configuration
- propagate logger/writer in training scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b67538adc832191fad96db30f5246