### PR TITLE
Add IB-MBM support and update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch>=1.12
 torchvision
 timm
 PyYAML


### PR DESCRIPTION
## Summary
- enhance `student_distillation_update` and `teacher_adaptive_update` to work with `IB_MBM`
- include optional information bottleneck loss during training
- adjust MBM type detection to cover LA and IB variants
- pin torch dependency to `>=1.12`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba37e8ff48321b9ce3bf5b47c0f81