### PR TITLE
Use relative path when updating sys.path

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -11,7 +11,7 @@ All fine-tuning options live in `configs/hparams.yaml`.
 
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import argparse
 import copy

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -3,7 +3,7 @@
 """Single-teacher KD runner."""
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import argparse
 import yaml

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -3,7 +3,7 @@
 """Train a student model with cross-entropy only."""
 import sys
 import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import argparse
 import copy


### PR DESCRIPTION
## Summary
- switch `sys.path` manipulation in scripts to use relative paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba5a170688321b55d6bd595078af6