### PR TITLE
Fix ckpt check nesting in eval

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -190,11 +190,11 @@ def main():
             ckpt = torch.load(
                 cfg["ckpt_path"], map_location=device, weights_only=True
             )
-        if "model_state" in ckpt:
-            model.load_state_dict(ckpt["model_state"], strict=False)
-        else:
-            model.load_state_dict(ckpt, strict=False)
-        print(f"[Eval single] loaded from {cfg['ckpt_path']}")
+            if "model_state" in ckpt:
+                model.load_state_dict(ckpt["model_state"], strict=False)
+            else:
+                model.load_state_dict(ckpt, strict=False)
+            print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
 


### PR DESCRIPTION
## Summary
- adjust checkpoint loading logic in `eval.py`
- only check `model_state` when a ckpt path is given

## Testing
- `python -m py_compile eval.py`

------
https://chatgpt.com/codex/tasks/task_e_687baefbbc3c8321bdb77cea10b21c4e