### PR TITLE
Fix ckpt message indent

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -192,7 +192,7 @@ def main():
                 model.load_state_dict(ckpt["model_state"], strict=False)
             else:
                 model.load_state_dict(ckpt, strict=False)
-            print(f"[Eval single] loaded from {cfg['ckpt_path']}")
+        print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
 


### PR DESCRIPTION
## Summary
- ensure eval warns when no ckpt is provided by fixing indentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb11f18448321a7c9699195439efe