### PR TITLE
Apply env-based tqdm disabling and cleanup configs

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -93,8 +93,7 @@ use_distillation_adapter: true
 distill_hidden_dim: 0  # 0 -> use half of teacher feature dim
 distill_out_dim: 0     # 0 -> use quarter of teacher feature dim
 
-# MBM options
-mbm_type: "LA"
+# MBM options (타입은 default.yaml에서 상속/고정)
 mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: true

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,9 @@
 #SBATCH --output=outputs/asmb_%j/run.log
 #SBATCH --error=outputs/asmb_%j/run.log
 
+# tqdm 진행막대 끄기 (로그 청결)
+export TQDM_DISABLE=1
+
 # Create a unique output directory per SLURM job
 JOB_ID=${SLURM_JOB_ID:-manual}
 OUTPUT_DIR="outputs/asmb_${JOB_ID}"

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,7 +1,8 @@
 # utils/progress.py
 
+# tqdm 막대를 전역으로 끄려면  ➜  export TQDM_DISABLE=1
 from tqdm import tqdm
-import sys
+import sys, os
 
 __all__ = ["smart_tqdm"]
 
@@ -25,6 +26,10 @@ def smart_tqdm(iterable, desc=None, **kwargs):
     """
     kwargs.setdefault("file", sys.stdout)
     kwargs.setdefault("leave", False)
+
+    # ── NEW ── 전역 비활성화 플래그 (로그 화면 정리용)
+    env_disable = os.getenv("TQDM_DISABLE", "0") == "1"
+
     if "disable" not in kwargs:
-        kwargs["disable"] = not sys.stdout.isatty()
+        kwargs["disable"] = env_disable or (not sys.stdout.isatty())
     return tqdm(iterable, desc=desc, **kwargs)


### PR DESCRIPTION
## Summary
- allow globally disabling tqdm via `TQDM_DISABLE` in `utils.progress`
- disable tqdm bars in default Slurm run script
- remove conflicting `mbm_type` from `hparams.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbb06c85c8321b6516c8db92c27bb