### PR TITLE
Apply compatibility patches for PyTorch and logger

### DIFF
--- a/tests/test_experiment_logger_finalize.py
+++ b/tests/test_experiment_logger_finalize.py
@@ -13,13 +13,15 @@ def test_finalize_creates_missing_dir(tmp_path):
     cfg = {"results_dir": str(results_dir), "eval_mode": "test"}
     logger = ExperimentLogger(cfg)
     logger.update_metric("train_acc", 0.0)
+    exp_id = logger.exp_id
     logger.finalize()
 
-    json_path = results_dir / "summary.json"
+    json_path = results_dir / f"{exp_id}.json"
     csv_path = results_dir / "summary.csv"
-
+    latest_path = results_dir / "latest.json"
     assert json_path.is_file()
     assert csv_path.is_file()
+    assert latest_path.exists()
 
     # sanity check that files are readable
     with open(json_path) as f:

--- a/utils/data.py
+++ b/utils/data.py
@@ -8,10 +8,10 @@ from torchvision import transforms as T
 
 
 def get_split_cifar100_loaders(
-    root: str = "./data",
     num_tasks: int = 5,
     batch_size: int = 128,
     augment: bool = True,
+    root: str = "./data",
 ) -> List[Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader]]:
     """Split CIFAR100 into ``num_tasks`` tasks of 10 classes each."""
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -110,8 +110,8 @@ class ExperimentLogger:
         # Ensure results directory exists
         os.makedirs(self.results_dir, exist_ok=True)
 
-        # 2) JSON file path (fixed name within results_dir)
-        json_path = os.path.join(self.results_dir, "summary.json")
+        # 2) JSON  ▶  exp_id.json  (+ latest.json link)
+        json_path = os.path.join(self.results_dir, f"{self.exp_id}.json")
 
         # 3) CSV file path (fixed name)
         csv_filename = "summary.csv"
@@ -120,7 +120,18 @@ class ExperimentLogger:
 
         # Save the JSON (all info)
         save_json(self.config, json_path)
-        print(f"[ExperimentLogger] JSON saved => {json_path}")
+        print(f"[ExperimentLogger] JSON saved ⇒ {json_path}")
+
+        # 최신 결과 가리키는 심링크/복사본
+        latest_path = os.path.join(self.results_dir, "latest.json")
+        try:
+            if os.path.islink(latest_path) or os.path.exists(latest_path):
+                os.remove(latest_path)
+            os.symlink(os.path.basename(json_path), latest_path)
+        except OSError:
+            # 심링크가 안 되는 파일시스템이면 그만 복사
+            import shutil
+            shutil.copy2(json_path, latest_path)
 
         # 4) Write CSV
         #   - 기본 열 + 모든 ep* 또는 teacher_ep* key 자동 포함

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -4,6 +4,21 @@ import os
 import torch
 import random
 import numpy as np
+import inspect
+
+# ── NEW: backwards-compatible torch.load ──────────────────────
+if "weights_only" not in inspect.signature(torch.load).parameters:
+    _orig_torch_load = torch.load
+
+    def _patched_torch_load(*args, **kwargs):
+        kwargs.pop("weights_only", None)
+        return _orig_torch_load(*args, **kwargs)
+
+    torch.load = _patched_torch_load
+    print(
+        "[utils.misc]  ⚠  PyTorch <2.1 detected → 'weights_only' patched for torch.load()."
+    )
+# ───────────────────────────────────────────────────────────────
 
 def set_random_seed(seed: int = 42, deterministic: bool = True) -> None:
     """Fix random seeds for reproducibility.


### PR DESCRIPTION
## Summary
- patch `torch.load` to silently drop unsupported `weights_only` argument
- keep latest experiment results via symlink/copy in logger
- expose root option in CIFAR100 helper
- update tests for new logger behaviour

## Testing
- `pytest -q tests/test_experiment_logger_finalize.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbe8e2d608321b463f53943dcaf91