### PR TITLE
Enable PROGRESS toggle and unify distill adapter dims

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -90,8 +90,9 @@ student_epochs_per_stage_list: "40"
 teacher_adapt_alpha_kd: 1.0
 mbm_lr_factor: 2.0
 use_distillation_adapter: true
-distill_hidden_dim: 0  # 0 -> use half of teacher feature dim
-distill_out_dim: 0     # 0 -> use quarter of teacher feature dim
+# Distillation adapter dimension (통일)
+distill_hidden_dim: 1024  # same for 모든 교사
+distill_out_dim: 512      # 모든 교사 512-D
 
 # MBM options (타입은 default.yaml에서 상속/고정)
 mbm_r: 4

--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,8 @@
 #SBATCH --output=outputs/asmb_%j/run.log
 #SBATCH --error=outputs/asmb_%j/run.log
 
-# tqdm 진행막대 끄기 (로그 청결)
-export TQDM_DISABLE=1
+# tqdm 완전 OFF
+export PROGRESS=0
 
 # Create a unique output directory per SLURM job
 JOB_ID=${SLURM_JOB_ID:-manual}

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -60,6 +60,8 @@ generate_config() {
     synergy_head_dropout=${head_dropout} \
     synergy_ce_alpha=${synergy_ce_alpha} \
     hybrid_beta=${hybrid_beta} \
+    distill_hidden_dim=${distill_hidden_dim} \
+    distill_out_dim=${distill_out_dim} \   # NEW
     use_partial_freeze=${use_partial_freeze} \
     teacher1_use_adapter=${teacher1_use_adapter} \
     teacher1_bn_head_only=${teacher1_bn_head_only} \

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,6 +1,6 @@
 # utils/progress.py
 
-# tqdm 막대를 전역으로 끄려면  ➜  export TQDM_DISABLE=1
+# tqdm 표시 기본 OFF ➜ PROGRESS=1 로 켜기
 from tqdm import tqdm
 import sys, os
 
@@ -27,9 +27,9 @@ def smart_tqdm(iterable, desc=None, **kwargs):
     kwargs.setdefault("file", sys.stdout)
     kwargs.setdefault("leave", False)
 
-    # ── NEW ── 전역 비활성화 플래그 (로그 화면 정리용)
-    env_disable = os.getenv("TQDM_DISABLE", "0") == "1"
+    # 터미널 X 또는 환경변수 `PROGRESS=0|false` 이면 끈다
+    env_off = os.environ.get("PROGRESS", "0").lower() in ("0", "false", "off", "no")
 
     if "disable" not in kwargs:
-        kwargs["disable"] = env_disable or (not sys.stdout.isatty())
+        kwargs["disable"] = env_off or (not sys.stdout.isatty())
     return tqdm(iterable, desc=desc, **kwargs)


### PR DESCRIPTION
## Summary
- configure distillation adapter dims globally
- pass distillation adapter dimensions from `run_experiments.sh`
- toggle tqdm progress globally using PROGRESS env var
- disable tqdm by default in `run.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc175b0188321975911a2f330ca33