### PR TITLE
Fix IB_MBM query dimension

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -37,6 +37,7 @@ finetune_ckpt2: "./checkpoints/teacher2_finetuned.pth"
 mbm_type: ib_mbm
 use_ib: true
 ib_beta: 0.01   # β in IB loss
+mbm_query_dim: 2048
 
 # === Continual-Learning ===
 cl_mode: false          # true → Split-CIFAR etc.

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -122,8 +122,15 @@ def build_from_teachers(
 
     mbm_type = cfg.get("mbm_type", "MLP").lower()
     if mbm_type == "ib_mbm" and IB_MBM is not None:
+        qdim = cfg.get("mbm_query_dim")
+        if qdim is None or qdim <= 0:
+            raise ValueError(
+                "[IB_MBM] cfg.mbm_query_dim (student feature dim) 필요합니다 "
+                "(e.g. 2048 for ResNet-152)."
+            )
         mbm = IB_MBM(
-            d_in=max(feat_dims),
+            q_dim=qdim,
+            kv_dim=max(feat_dims),
             d_emb=cfg.get("mbm_out_dim", 512),
             beta=cfg.get("ib_beta", 0.01),
         )

--- a/modules/ib_mbm.py
+++ b/modules/ib_mbm.py
@@ -8,10 +8,16 @@ from torch.distributions import Normal, kl_divergence
 class IB_MBM(nn.Module):
     """Information-Bottleneck Manifold-Bridging-Module."""
 
-    def __init__(self, d_in: int, d_emb: int, beta: float = 1e-2) -> None:
+    def __init__(
+        self,
+        q_dim: int,
+        kv_dim: int,
+        d_emb: int,
+        beta: float = 1e-2,
+    ) -> None:
         super().__init__()
-        self.q_proj = nn.Linear(d_in, d_emb)
-        self.kv_proj = nn.Linear(d_in, d_emb)
+        self.q_proj = nn.Linear(q_dim, d_emb)
+        self.kv_proj = nn.Linear(kv_dim, d_emb)
         self.attn = nn.MultiheadAttention(d_emb, 1, batch_first=True)
         self.mu = nn.Linear(d_emb, d_emb)
         self.logvar = nn.Linear(d_emb, d_emb)

--- a/tests/test_ib_mbm.py
+++ b/tests/test_ib_mbm.py
@@ -4,14 +4,14 @@ torch = pytest.importorskip("torch")
 from modules.ib_mbm import IB_MBM
 
 def test_forward_shape():
-    mbm = IB_MBM(256, 128)
+    mbm = IB_MBM(q_dim=256, kv_dim=256, d_emb=128)
     q = torch.randn(4, 256)
     kv = torch.randn(4, 2, 256)
     z, mu, logvar = mbm(q, kv)
     assert z.shape == (4, 128)
 
 def test_ib_loss_nonneg():
-    mbm = IB_MBM(256, 128, beta=0.01)
+    mbm = IB_MBM(q_dim=256, kv_dim=256, d_emb=128, beta=0.01)
     decoder = torch.nn.Linear(128, 10)
     q = torch.randn(4, 256)
     kv = torch.randn(4, 2, 256)


### PR DESCRIPTION
## Summary
- fix input dimension mismatch in `IB_MBM`
- ensure MBM builder requires `mbm_query_dim`
- update default config with example query dim
- adjust tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc822aa188321a07e647d834d4261