### PR TITLE
Add disable_tqdm and wandb API key

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -16,19 +16,21 @@ log_filename: "train.log"
 # 로그 상세도 ― "INFO" | "DEBUG"
 log_level: "DEBUG"
 
-######################
-# WandB 사용 여부
-######################
-use_wandb: true
-wandb_project: "kd_monitor"
-wandb_entity: "kakamy0820-yonsei-university"   # ← 필요 없으면 빈칸
-# run name 미지정 시 exp_id 가 그대로 사용됨
-wandb_run_name: ""
-
-# 모든 하이퍼파라미터 표 형태로 로그 파일에 출력
-log_all_hparams: true
 save_checkpoint: true
 ckpt_dir: "./checkpoints"
+
+# ────────────── Logging & Dashboard ──────────────
+log_all_hparams: true        # 모든 하이퍼파라미터 표 형태 출력
+disable_tqdm: true           # progress-bar 숨기기(=PROGRESS=0)
+
+# ────────────── Weights & Biases ────────────────
+use_wandb: true
+wandb_entity: "kakamy0820-yonsei-university"
+wandb_project: "kd_monitor"
+# run name 미지정 시 exp_id 가 그대로 사용됨
+wandb_run_name: ""
+# (선택) 키를 여기서 직접 지정하면 `wandb login` 생략 가능
+wandb_api_key: ""            # ""이면 env/W&B login 사용
 
 finetune_ckpt1: "./checkpoints/teacher1_finetuned.pth"
 finetune_ckpt2: "./checkpoints/teacher2_finetuned.pth"

--- a/main.py
+++ b/main.py
@@ -322,6 +322,14 @@ def main():
     cli_cfg = {k: v for k, v in vars(args).items() if v is not None}
     cfg = {**base_cfg, **cli_cfg}
 
+    # ── tqdm 전체 OFF ─────────────────────────────
+    if cfg.get("disable_tqdm", False):
+        os.environ["PROGRESS"] = "0"    # utils.progress 에서 사용
+
+    # ── W&B API-key (config 우선) ────────────────
+    if cfg.get("use_wandb", False) and cfg.get("wandb_api_key", ""):
+        os.environ.setdefault("WANDB_API_KEY", str(cfg["wandb_api_key"]))
+
     # ────────────────── LOGGING & W&B ──────────────────
     log_file = setup_logging(cfg)
     log_hparams(cfg)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -71,6 +71,12 @@ class ExperimentLogger:
         # For timing
         self.start_time = time.time()
 
+        # ── (옵션) 모든 하이퍼파라미터 즉시 출력 ───────────────
+        if self.config.get("log_all_hparams", False):
+            import pprint, logging
+            logging.getLogger().setLevel(self.config.get("log_level", "DEBUG"))
+            pprint.pprint(self.config, width=120)
+
     def _generate_exp_id(self, exp_name="exp"):
         """
         Creates an experiment ID like 'eval_experiment_synergy_20240805_153210'

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -1,6 +1,6 @@
 # utils/progress.py
 
-# tqdm 표시 기본 OFF ➜ PROGRESS=1 로 켜기
+# tqdm 표시 기본 ON (tty에서만) ➜ PROGRESS=0 으로 끄기
 from tqdm import tqdm
 import sys, os
 
@@ -26,7 +26,8 @@ def smart_tqdm(iterable, desc=None, **kwargs):
     """
     kwargs.setdefault("file", sys.stdout)
     kwargs.setdefault("leave", False)
-    # PROGRESS=1 을 주면 강제 활성화, 기본은 OFF
-    env_flag = os.environ.get("PROGRESS", "0").lower() in ("1", "true", "yes", "on")
-    kwargs["disable"] = not env_flag
+    if "disable" not in kwargs:
+        # 1) 환경변수 PROGRESS=0 → 무조건 OFF
+        env_off = os.getenv("PROGRESS", "1") == "0"
+        kwargs["disable"] = env_off or not sys.stdout.isatty()
     return tqdm(iterable, desc=desc, **kwargs)


### PR DESCRIPTION
## Summary
- add new dashboard options to default configuration
- expose disable_tqdm and wandb api key in main
- update progress bar handling
- optionally dump hyperparams in logger

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcff9d644832189b8bd25d66db63f