### PR TITLE
Fix dtype mismatch during KD

### DIFF
--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -190,7 +190,9 @@ def student_distillation_update(
             feat_kd_val = torch.tensor(0.0, device=cfg["device"])
             if cfg.get("feat_kd_alpha", 0) > 0:
                 if la_mode and not isinstance(mbm, IB_MBM):
-                    feat_kd_val = F.mse_loss(student_q_proj, teacher_attn_out.detach())
+                    # AMP 환경에서 dtype 불일치를 피한다
+                    tgt = teacher_attn_out.detach().to(student_q_proj.dtype)
+                    feat_kd_val = F.mse_loss(student_q_proj, tgt)
                 else:
                     key = cfg.get("feat_kd_key", "feat_2d")
 

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -186,7 +186,7 @@ def teacher_adaptive_update(
                 feat_kd_loss = torch.tensor(0.0, device=cfg["device"])
                 if la_mode and cfg.get("feat_kd_alpha", 0) > 0 and not isinstance(mbm, IB_MBM):
                     s_flat = s_feat.view(s_feat.size(0), -1)
-                    f_flat = fsyn.detach().view(fsyn.size(0), -1)
+                    f_flat = fsyn.detach().view(fsyn.size(0), -1).to(s_flat.dtype)
                     if s_flat.size(1) == f_flat.size(1):
                         feat_kd_loss = torch.nn.functional.mse_loss(s_flat, f_flat)
                     else:


### PR DESCRIPTION
## Summary
- ensure tensors match dtype in mixed precision training
- cast teacher attention to student's dtype before MSE loss
- cast feature tensor in teacher adapter path to match student dtype

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bde2595d883219cb78a436fa440cf