### PR TITLE
Fix duplicate log handlers

### DIFF
--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -17,6 +17,10 @@ def _ensure_dir(path):
 
 
 def setup_logging(cfg: dict):
+    # ── 중복 로그 핸들러 방지 ─────────────────────────────
+    for h in logging.root.handlers[:]:
+        logging.root.removeHandler(h)
+
     level = getattr(logging, cfg.get("log_level", "INFO").upper(), logging.INFO)
     log_file = os.path.join(cfg.get("results_dir", "."), cfg.get("log_filename", "train.log"))
     _ensure_dir(log_file)


### PR DESCRIPTION
## Summary
- prevent duplicate log handlers by clearing existing handlers in `setup_logging`

## Testing
- `pytest tests/test_experiment_logger_finalize.py -q`
- `pytest tests/test_argparse_adam_beta.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687c5d940ef08321905526bade47f30e