### PR TITLE
Fix KL sign in teacher adaptive update

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -293,8 +293,9 @@ class ASMBDistiller(nn.Module):
                     w1, w2 = None, None
                 zsyn = self.synergy_head(syn_feat)
 
-                # (i) -KL(s_logit, zsyn)
-                kl_val = kd_loss_fn(zsyn, s_logit, T=cur_tau)  # 여기선 sign 주의
+                # (i) KL(s_logit, zsyn)
+                # Synergy 가 Student 와 가까워지도록 **그대로 최소화**합니다.
+                kl_val = kd_loss_fn(zsyn, s_logit, T=cur_tau)
                 # (ii) synergy CE
                 ce_val = ce_loss_fn(
                     zsyn,
@@ -317,7 +318,7 @@ class ASMBDistiller(nn.Module):
                     reg_loss += (p**2).sum()
 
                 loss = (
-                    (-1.0) * kl_val
+                    kl_val
                     + synergy_ce
                     + self.feat_kd_alpha * feat_loss
                     + self.reg_lambda * reg_loss


### PR DESCRIPTION
## Summary
- adjust KD loss sign in `_teacher_adaptive_update` so synergy gets closer to student

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c6381f23c83219ef69da2a585aba0