### PR TITLE
Add teacher types to sweep config

### DIFF
--- a/sweeps/asmb_grid.yaml
+++ b/sweeps/asmb_grid.yaml
@@ -10,6 +10,8 @@ parameters:
   use_ib:        {values: [false, true]}      # ablation
   ib_beta:       {values: [0.0, 0.001, 0.01]}
   seed:          {values: [42, 777]}
+  teacher1_type: {value: resnet152}
+  teacher2_type: {value: efficientnet_b2}
 
 command:
   - ${env}


### PR DESCRIPTION
## Summary
- specify teacher model types for sweeps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf0d2d74c8321a72772b6ffd996c4