### PR TITLE
Fix synergy_ce_alpha formatting

### DIFF
--- a/sweeps/asmb_grid.yaml
+++ b/sweeps/asmb_grid.yaml
@@ -9,7 +9,7 @@ parameters:
   student_epochs_per_stage: {value: 12}
   use_ib:        {values: [false, true]}      # ablation
   ib_beta:       {values: [0.0, 0.001, 0.01]}
-  synergy_ce_alpha:{value: 0.6}
+  synergy_ce_alpha: {value: 0.6}
   seed:          {values: [42, 777]}
   teacher1_type: {value: resnet152}
   teacher2_type: {value: efficientnet_b2}


### PR DESCRIPTION
## Summary
- fix YAML formatting for synergy_ce_alpha in sweep config

## Testing
- `pip install wandb` *(fails: Cannot connect to proxy)*
- `wandb sweep sweeps/asmb_grid.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfe644dd483218cdc390ebe73dd0f