### PR TITLE
Fix missing results_dir config

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -67,6 +67,8 @@ class ExperimentLogger:
 
         # Where to save results
         self.results_dir = self.config.get("results_dir", "results")
+        # ensure results_dir is recorded in config for downstream users
+        self.config.setdefault("results_dir", self.results_dir)
 
         # For timing
         self.start_time = time.time()


### PR DESCRIPTION
## Summary
- ensure `ExperimentLogger` injects default `results_dir` into config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0be2d1708321be1dd3f6c983f85f