### PR TITLE
Fix ExperimentLogger serialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -367,7 +367,6 @@ def main():
         level=cfg.get("log_level", "INFO"),
         stream_level="INFO" if cfg.get("log_level", "INFO").upper() == "DEBUG" else cfg.get("log_level", "INFO")
     )
-    cfg["logger"] = logger
 
     global _HP_LOGGED
     if not _HP_LOGGED:

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -6,12 +6,15 @@ import json
 import time
 from datetime import datetime
 
+
+def _json_default(obj):
+    """Fallback serialization for unsupported objects."""
+    return str(obj)
+
 def save_json(exp_dict, save_path):
-    """
-    Save exp_dict (configs + results) as a JSON file.
-    """
-    with open(save_path, 'w') as f:
-        json.dump(exp_dict, f, indent=4)
+    """Save ``exp_dict`` (configs + results) as a JSON file."""
+    with open(save_path, "w") as f:
+        json.dump(exp_dict, f, indent=4, default=_json_default)
 
 def save_csv_row(exp_dict, csv_path, fieldnames, write_header_if_new=True):
     """
@@ -113,6 +116,8 @@ class ExperimentLogger:
         # 1) total time
         total_time = time.time() - self.start_time
         self.config["total_time_sec"] = total_time
+        # drop unserializable objects before saving
+        self.config.pop("logger", None)
 
 
         # Ensure results directory exists


### PR DESCRIPTION
## Summary
- remove logger object from config to avoid JSON serialization issues
- allow `save_json` to fallback to string conversion for unsupported objects
- drop logger before saving results

## Testing
- `bash scripts/setup_tests.sh` *(fails: Could not install torch)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7d3d7d288321a108a07df160b2c0