### PR TITLE
Fix eval single ckpt message indentation

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -187,12 +187,16 @@ def main():
 
         # load single model ckpt
         if cfg["ckpt_path"]:
-            ckpt = torch.load(cfg["ckpt_path"], map_location=device, weights_only=True)
+            ckpt = torch.load(
+                cfg["ckpt_path"],
+                map_location=device,
+                weights_only=True,
+            )
             if "model_state" in ckpt:
                 model.load_state_dict(ckpt["model_state"], strict=False)
             else:
                 model.load_state_dict(ckpt, strict=False)
-        print(f"[Eval single] loaded from {cfg['ckpt_path']}")
+            print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
 


### PR DESCRIPTION
## Summary
- fix indentation of `[Eval single] loaded from` message
- keep `else` aligned with the `if` to ensure correct branching
- run ruff to confirm no syntax error

## Testing
- `ruff check eval.py`

------
https://chatgpt.com/codex/tasks/task_e_687dc45c460c83219757a8ee12dbc403