### PR TITLE
Clean up imports and fix ruff warnings

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -13,7 +13,7 @@ import os
 
 from data.cifar100 import get_cifar100_loaders
 from data.imagenet100 import get_imagenet100_loaders
-from models.mbm import ManifoldBridgingModule, SynergyHead, build_from_teachers
+from models.mbm import build_from_teachers
 from models.la_mbm import LightweightAttnMBM
 from utils.logger import ExperimentLogger
 from utils.misc import set_random_seed, get_amp_components
@@ -187,12 +187,16 @@ def main():
 
         # load single model ckpt
         if cfg["ckpt_path"]:
-            ckpt = torch.load(cfg["ckpt_path"], map_location=device, weights_only=True)
+            ckpt = torch.load(
+                cfg["ckpt_path"],
+                map_location=device,
+                weights_only=True,
+            )
             if "model_state" in ckpt:
                 model.load_state_dict(ckpt["model_state"], strict=False)
             else:
                 model.load_state_dict(ckpt, strict=False)
-        print(f"[Eval single] loaded from {cfg['ckpt_path']}")
+            print(f"[Eval single] loaded from {cfg['ckpt_path']}")
         else:
             print("[Eval single] no ckpt => random init")
 

--- a/main.py
+++ b/main.py
@@ -8,12 +8,14 @@ Implements a multi-stage distillation flow using:
 Repeated for 'num_stages' times, as in ASMB multi-stage self-training.
 """
 
-import argparse, logging, os, json
-import copy
+import argparse
+import logging
+import os
+import json
 import torch
 import yaml
-from utils.cl_utils import ReplayBuffer, EWC          # NEW
 from typing import Optional
+
 import torch.optim as optim
 from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR
 
@@ -44,7 +46,7 @@ from modules.partial_freeze import (
 )
 
 # Teacher creation (factory):
-from models.teachers.teacher_resnet import create_resnet101, create_resnet152
+from models.teachers.teacher_resnet import create_resnet101
 from models.teachers.teacher_efficientnet import create_efficientnet_b2
 from models.teachers.teacher_swin import create_swin_t
 
@@ -109,7 +111,7 @@ def create_student_by_name(
             f"[create_student_by_name] unknown student_name={student_name}"
         )
 
-from models.mbm import ManifoldBridgingModule, SynergyHead, build_from_teachers
+from models.mbm import build_from_teachers
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -87,10 +87,9 @@ class ASMBDistiller(nn.Module):
 
         # 2) mbm => synergy with query if available
         if self.la_mode:
-            syn_feat, attn, _, _ = self.mbm(s_feat, feats_2d)
+            syn_feat, _, _, _ = self.mbm(s_feat, feats_2d)
         else:
             syn_feat = self.mbm(feats_2d, feats_4d)
-            attn = None
         zsyn = self.synergy_head(syn_feat)
 
         # CE
@@ -289,11 +288,10 @@ class ASMBDistiller(nn.Module):
                 if self.la_mode:
                     syn_feat, attn, _, _ = self.mbm(s_feat, f1)
                     attn_flat = attn.squeeze(1)
-                    w1, w2 = attn_flat[:, 0], attn_flat[:, 1]
+                    _, _ = attn_flat[:, 0], attn_flat[:, 1]
                 else:
                     syn_feat = self.mbm(f1, f2)
                     attn = None
-                    w1, w2 = None, None
                 zsyn = self.synergy_head(syn_feat)
 
                 # (i)  KL(zsyn \u2016 s_logit) \u2190 최소화 방향 그대로 사용

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
 from typing import Optional
-from modules.losses import kd_loss_fn, ce_loss_fn
+from modules.losses import ce_loss_fn
 
 class CRDLoss(nn.Module):
     """

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -3,7 +3,6 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from typing import Optional
 from modules.losses import ce_loss_fn, dkd_loss
 
@@ -57,7 +56,6 @@ class DKDDistiller(nn.Module):
         # teacher
         with torch.no_grad():
             t_out = self.teacher(x)
-            t_dict = t_out
             t_logit = t_out["logit"]
         # student
         s_dict, s_logit, _ = self.student(x)

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -3,7 +3,6 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from typing import Optional
 
 from modules.losses import kd_loss_fn, ce_loss_fn

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from typing import List, Optional, Tuple
 
 # 기존 MBM
@@ -110,8 +109,6 @@ def build_from_teachers(
             feat_dims.append(getattr(t, "distill_dim"))
         else:
             feat_dims.append(t.get_feat_dim())
-    in_dim = sum(feat_dims)
-
     use_4d = bool(cfg.get("mbm_use_4d", False))
     if use_4d:
         channels = [t.get_feat_channels() for t in teachers]

--- a/models/students/student_efficientnet_adapter.py
+++ b/models/students/student_efficientnet_adapter.py
@@ -1,6 +1,5 @@
 # models/students/student_efficientnet_adapter.py
 
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.models import efficientnet_b2, EfficientNet_B2_Weights

--- a/models/students/student_resnet152_adapter.py
+++ b/models/students/student_resnet152_adapter.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torchvision.models import resnet152, ResNet152_Weights
 
 class ExtendedAdapterResNet152(nn.Module):

--- a/models/students/student_swin_adapter.py
+++ b/models/students/student_swin_adapter.py
@@ -1,9 +1,7 @@
 # models/students/student_swin_adapter.py
 
-import torch
 import torch.nn as nn
 import timm
-import torch.nn.functional as F
 from typing import Optional
 
 class StudentSwinAdapter(nn.Module):

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -1,6 +1,5 @@
 # models/teachers/teacher_efficientnet.py
 
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Optional

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -2,7 +2,6 @@
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from typing import Optional
 from .adapters import DistillationAdapter
 from torchvision.models import (

--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -1,6 +1,5 @@
 # models/teachers/teacher_swin.py
 
-import torch
 import torch.nn as nn
 from typing import Optional
 from .adapters import DistillationAdapter

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,2 +1,4 @@
 from models.la_mbm import LightweightAttnMBM
 from .ib_mbm import IB_MBM
+
+__all__ = ["LightweightAttnMBM", "IB_MBM"]

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -1,6 +1,5 @@
 # modules/partial_freeze.py
 
-import torch
 import torch.nn as nn
 
 from utils.freeze import apply_bn_ln_policy, freeze_all, unfreeze_by_regex

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -151,12 +151,14 @@ def student_distillation_update(
                 zsyn = synergy_head(fsyn)
 
                 if mix_mode != "none":
-                    ce_obj = lambda pred, target: ce_loss_fn(
-                        pred,
-                        target,
-                        label_smoothing=cfg.get("label_smoothing", 0.0),
-                        reduction="none",
-                    )
+                    def ce_obj(pred, target):
+                        return ce_loss_fn(
+                            pred,
+                            target,
+                            label_smoothing=cfg.get("label_smoothing", 0.0),
+                            reduction="none",
+                        )
+
                     ce_vec = mixup_criterion(ce_obj, s_logit, y_a, y_b, lam)
                 else:
                     ce_vec = ce_loss_fn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff.lint]
+extend-ignore = ["E402"]
+exclude = ["analysis/plot_results.ipynb"]

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -14,7 +14,6 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import argparse
-import copy
 import torch
 import yaml
 from typing import Optional
@@ -36,7 +35,6 @@ from modules.partial_freeze import (
     partial_freeze_teacher_efficientnet,
     partial_freeze_teacher_swin,
 )
-from utils.freeze import freeze_all
 
 # cutmix finetune
 from modules.cutmix_finetune_teacher import finetune_teacher_cutmix, eval_teacher

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setup(
     name="asib_kd",
     version="0.2.0",
     packages=find_packages(),
-    install_requires=[l.strip() for l in open("requirements.txt")],
+    install_requires=[line.strip() for line in open("requirements.txt")],
     python_requires=">=3.8",
 )

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -78,7 +78,9 @@ class ExperimentLogger:
 
         # ── (옵션) 모든 하이퍼파라미터 즉시 출력 ───────────────
         if self.config.get("log_all_hparams", False):
-            import pprint, logging
+            import logging
+            import pprint
+
             logging.getLogger().setLevel(self.config.get("log_level", "DEBUG"))
             pprint.pprint(self.config, width=120)
 

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -1,8 +1,12 @@
 """공통 로깅/모니터링 초기화."""
-import logging, os, sys, json, pprint
+import json
+import logging
+import os
+import pprint
+import sys
 from pathlib import Path
+
 import wandb
-from datetime import datetime
 
 try:
     from rich.console import Console

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -6,7 +6,6 @@ import random
 import numpy as np
 import inspect
 import logging
-import copy
 
 # ----------------------------------------------------------------------------
 def sanitize_cfg(cfg: dict) -> dict:

--- a/utils/progress.py
+++ b/utils/progress.py
@@ -2,7 +2,8 @@
 
 # tqdm 표시 기본 ON (tty에서만) ➜ PROGRESS=0 으로 끄기
 from tqdm import tqdm
-import sys, os
+import sys
+import os
 
 __all__ = ["smart_tqdm"]
 


### PR DESCRIPTION
## Summary
- set `ruff` config and exclude notebook
- fix incorrect indentation in `eval.py`
- clean unused imports and split multi-import lines
- define `__all__` in modules
- remove unused variables and fix lambda assignment
- rename ambiguous variable in `setup.py`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dc45e9240832189100ff19a044abe