### PR TITLE
Fix duplicate hyperparams

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -85,13 +85,10 @@ head_dropout: 0.0     # dropout prob for synergy head
 # e.g. "2 3 4 5" to run multiple values in a batch script.
 num_stages: 4
 n_stage_list: 4
-sc_alpha_list: "0.6" # 0.3 0.6
+synergy_ce_alpha: 0.6  # formerly sc_alpha_list
 hybrid_beta: 0.2
-# Additional sweep lists
-hybrid_beta_list: "0.1"       # e.g. "0.1 0.5 0.9"
-# Epoch sweep lists
-teacher_adapt_epochs_list: "3"
-student_epochs_per_stage_list: "12"   # full fine-tune 는 수렴 빠르므로 12 ep 로 균형
+teacher_adapt_epochs: 3
+student_epochs_per_stage: 12   # full fine-tune 는 수렴 빠르므로 12 ep 로 균형
 # Teacher adaptation
 teacher_adapt_alpha_kd: 1.0
 mbm_lr_factor: 2.0

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -85,8 +85,8 @@ run_loop() {
   mkdir -p "${OUTPUT_DIR}"
   mkdir -p checkpoints
 
-  for TEACH_EP in ${teacher_adapt_epochs_list}; do
-    for STUD_EP in ${student_epochs_per_stage_list}; do
+  for TEACH_EP in ${teacher_adapt_epochs}; do
+    for STUD_EP in ${student_epochs_per_stage}; do
       teacher_adapt_epochs=${TEACH_EP}
       student_epochs_per_stage=${STUD_EP}
       for T1 in $T1_LIST; do
@@ -116,8 +116,8 @@ run_loop() {
         done
 
         # 2) ASMB multi-stage distillation
-        for SC_ALPHA in ${sc_alpha_list}; do
-          for H_BETA in ${hybrid_beta_list}; do
+        for SC_ALPHA in ${synergy_ce_alpha}; do
+          for H_BETA in ${hybrid_beta}; do
             synergy_ce_alpha=${SC_ALPHA}
             hybrid_beta=${H_BETA}
             # N_STAGE_LIST may contain space-separated values like "2 3 4 5"


### PR DESCRIPTION
## Summary
- remove redundant list-based hyperparameters
- use scalar values for synergy_ce_alpha, hybrid_beta, teacher_adapt_epochs, and student_epochs_per_stage
- update experiment script to use new scalar parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de0ed941c8321a2111e6e1d22db38