### PR TITLE
Add W&B bayesian sweep config

### DIFF
--- a/sweeps/asmb_mixed.yaml
+++ b/sweeps/asmb_mixed.yaml
@@ -1,0 +1,31 @@
+name: "asmb_mixed"
+method: bayes
+metric:
+  name: stage4_student_acc
+  goal: maximize
+parameters:
+  # 고정값 ------------------------------------------------------
+  use_partial_freeze: {value: true}
+  student_freeze_level: {value: 1}
+  student_epochs_per_stage: {value: 15}
+
+  # 탐색축 ------------------------------------------------------
+  ib_beta:        {distribution: log_uniform, min: 0.002, max: 0.008}
+  hybrid_beta:    {values: [0.20, 0.25, 0.30]}
+  kd_alpha:       {values: [0.70, 0.75, 0.80]}
+  ce_alpha:       {values: [0.30, 0.25, 0.20]}   # kd_alpha 와 합이 1 되도록 주의
+  tau_start:      {values: [7, 8, 9]}
+  tau_end:        {value: 3}
+  tau_decay_epochs:{values: [5, 6, 7]}
+  student_lr:     {distribution: log_uniform, min: 0.0008, max: 0.002}
+
+command:
+  - ${env}
+  - python
+  - main.py
+  - --config
+  - configs/default.yaml
+  - --hparams
+  - configs/hparams.yaml
+  - ${args}
+


### PR DESCRIPTION
## Summary
- add sweep config for combined bayesian and grid search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e11a399ec83218aa0022c6e39b511