### PR TITLE
Add certainty weighting for IB MBM

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -80,6 +80,23 @@ def ib_loss(mu, logvar, beta: float = 1e-3):
     return beta * kl_elem.mean()
 
 
+def certainty_weights(logvar: torch.Tensor) -> torch.Tensor:
+    """Return per-element certainty weights ``1 / exp(logvar)``.
+
+    Parameters
+    ----------
+    logvar : Tensor
+        Log variance tensor from the Information Bottleneck module.
+
+    Returns
+    -------
+    Tensor
+        ``1 / exp(logvar)`` with the same shape as ``logvar``.
+    """
+
+    return 1.0 / logvar.exp()
+
+
 def dkd_loss(student_logits, teacher_logits, labels, alpha=1.0, beta=1.0, temperature=4.0):
     """Decoupled Knowledge Distillation loss."""
     if student_logits.dim() > 2:

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -6,7 +6,7 @@ from utils.progress import smart_tqdm
 from models.la_mbm import LightweightAttnMBM
 from modules.ib_mbm import IB_MBM
 
-from modules.losses import kd_loss_fn, ce_loss_fn, ib_loss
+from modules.losses import kd_loss_fn, ce_loss_fn, ib_loss, certainty_weights
 from utils.schedule import get_tau
 from utils.misc import get_amp_components
 
@@ -172,12 +172,27 @@ def teacher_adaptive_update(
                 zsyn = synergy_head(fsyn)
 
                 # (D) compute loss (KL + synergyCE)
-                loss_kd         = kd_loss_fn(zsyn, s_logit, T=cur_tau)
-                loss_ce         = ce_loss_fn(
-                    zsyn,
-                    y,
-                    label_smoothing=cfg.get("label_smoothing", 0.0),
-                )
+                if cfg.get("use_ib", False) and isinstance(mbm, IB_MBM):
+                    ce_vec = ce_loss_fn(
+                        zsyn,
+                        y,
+                        label_smoothing=cfg.get("label_smoothing", 0.0),
+                        reduction="none",
+                    )
+                    kd_vec = kd_loss_fn(
+                        zsyn, s_logit, T=cur_tau, reduction="none"
+                    ).sum(dim=1)
+                    cw = certainty_weights(logvar).mean(dim=1).to(zsyn.dtype)
+                    loss_ce = (cw * ce_vec).mean()
+                    loss_kd = (cw * kd_vec).mean()
+                else:
+                    loss_kd = kd_loss_fn(zsyn, s_logit, T=cur_tau)
+                    loss_ce = ce_loss_fn(
+                        zsyn,
+                        y,
+                        label_smoothing=cfg.get("label_smoothing", 0.0),
+                    )
+
                 # ① 누락 시 기본값 0.6
                 synergy_weight = cfg.get("synergy_ce_alpha", 0.6)
                 synergy_ce_loss = synergy_weight * loss_ce

--- a/tests/test_certainty_weighting.py
+++ b/tests/test_certainty_weighting.py
@@ -1,0 +1,125 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from modules.trainer_student import student_distillation_update
+from modules.trainer_teacher import teacher_adaptive_update
+from modules.losses import certainty_weights
+
+
+class ConstTeacher(torch.nn.Module):
+    def __init__(self, logit):
+        super().__init__()
+        self.register_buffer("logit", torch.tensor(logit, dtype=torch.float32))
+
+    def forward(self, x):
+        b = x.size(0)
+        return {"feat_2d": torch.zeros(b, 1), "logit": self.logit.expand(b, -1), "feat_4d": None}
+
+    def get_feat_dim(self):
+        return 1
+
+    def get_feat_channels(self):
+        return 1
+
+
+class ConstStudent(torch.nn.Module):
+    def __init__(self, logit):
+        super().__init__()
+        self.register_buffer("logit", torch.tensor(logit, dtype=torch.float32))
+
+    def forward(self, x):
+        b = x.size(0)
+        return {"feat_2d": torch.zeros(b, 1)}, self.logit.expand(b, -1), None
+
+    def get_feat_dim(self):
+        return 1
+
+
+class DummyIBMBM(torch.nn.Module):
+    def __init__(self, logvar):
+        super().__init__()
+        self.register_buffer("logvar", torch.tensor(logvar, dtype=torch.float32))
+
+    def forward(self, q, feats):
+        b = q.size(0)
+        logvar = self.logvar.expand(b, -1)
+        mu = torch.zeros_like(logvar)
+        z = torch.zeros(b, self.logvar.size(0))
+        return z, mu, logvar
+
+
+class ConstHead(torch.nn.Module):
+    def __init__(self, logit):
+        super().__init__()
+        self.register_buffer("logit", torch.tensor(logit, dtype=torch.float32))
+
+    def forward(self, x):
+        return self.logit.expand(x.size(0), -1)
+
+
+class DummyLogger:
+    def __init__(self):
+        self.metrics = {}
+
+    def info(self, msg: str):
+        pass
+
+    def update_metric(self, key, value):
+        self.metrics[key] = value
+
+
+def run_student(use_ib):
+    t1 = ConstTeacher([[0.0, 1.0]])
+    t2 = ConstTeacher([[0.0, 1.0]])
+    student = ConstStudent([[0.0, 0.0]])
+    mbm = DummyIBMBM([[2.0]])
+    head = ConstHead([[1.0, 0.0]])
+    loader = [(torch.zeros(1, 3), torch.tensor([0]))]
+    cfg = {
+        "device": "cpu",
+        "ce_alpha": 1.0,
+        "kd_alpha": 1.0,
+        "student_iters": 1,
+        "use_ib": use_ib,
+        "ib_beta": 0.0,
+    }
+    logger = DummyLogger()
+    opt = torch.optim.Adam(student.parameters(), lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+    student_distillation_update([t1, t2], mbm, head, student, loader, loader, cfg, logger, optimizer=opt, scheduler=sched)
+    return logger.metrics["student_ep1_loss"]
+
+
+def run_teacher(use_ib):
+    t1 = ConstTeacher([[0.0, 1.0]])
+    t2 = ConstTeacher([[0.0, 1.0]])
+    student = ConstStudent([[0.0, 0.0]])
+    mbm = DummyIBMBM([[2.0]])
+    head = ConstHead([[1.0, 0.0]])
+    loader = [(torch.zeros(1, 3), torch.tensor([0]))]
+    cfg = {
+        "device": "cpu",
+        "synergy_ce_alpha": 1.0,
+        "teacher_iters": 1,
+        "teacher_adapt_alpha_kd": 1.0,
+        "use_ib": use_ib,
+        "ib_beta": 0.0,
+    }
+    logger = DummyLogger()
+    params = []
+    opt = torch.optim.Adam(params, lr=0.1)
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=1)
+    teacher_adaptive_update([t1, t2], mbm, head, student, loader, None, cfg, logger, optimizer=opt, scheduler=sched, global_ep=0)
+    return logger.metrics["teacher_ep1_loss"]
+
+
+def test_certainty_weighting_changes_losses():
+    w = certainty_weights(torch.tensor([[2.0]])).mean().item()
+    loss_base = run_student(False)
+    loss_weighted = run_student(True)
+    assert loss_weighted == pytest.approx(loss_base * w)
+
+    loss_base_t = run_teacher(False)
+    loss_weighted_t = run_teacher(True)
+    assert loss_weighted_t == pytest.approx(loss_base_t * w)


### PR DESCRIPTION
## Summary
- add `certainty_weights` helper
- weight CE/KD losses by certainty when using IB-MBM
- test certainty weighting for student and teacher trainers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4eb24ea8832186dfdaba9604a457