### PR TITLE
Add mbm_type default

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -101,6 +101,7 @@ distill_hidden_dim: 1024  # same for 모든 교사
 distill_out_dim: 512      # 모든 교사 512-D
 
 # MBM options (타입은 default.yaml에서 상속/고정)
+mbm_type: ib_mbm
 mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: true


### PR DESCRIPTION
## Summary
- set `mbm_type: ib_mbm` in `configs/hparams.yaml`

## Testing
- `pytest -q`
- `python scripts/generate_config.py --base configs/default.yaml --hparams configs/hparams.yaml --out /tmp/test.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687e4eb2c9288321b707bb5133742131