### PR TITLE
Reset freeze levels when partial freeze off

### DIFF
--- a/main.py
+++ b/main.py
@@ -383,6 +383,8 @@ def main():
     # ------------------------------------------------------------------
     if not cfg.get("use_partial_freeze", False):
         cfg["student_freeze_level"] = 0
+        cfg["teacher1_freeze_level"] = 0
+        cfg["teacher2_freeze_level"] = 0
     # ------------------------------------------- #
 
     # ── tqdm 전체 OFF ─────────────────────────────


### PR DESCRIPTION
## Summary
- reset `teacher1_freeze_level` and `teacher2_freeze_level` when partial freeze is disabled
- keep all freeze level values consistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e539272988321b9ae7a2741cad4f7