### PR TITLE
Support per-teacher attention averaging

### DIFF
--- a/models/mbm.py
+++ b/models/mbm.py
@@ -144,6 +144,7 @@ def build_from_teachers(
             n_head=cfg.get("mbm_n_head", 1),
             learnable_q=cfg.get("mbm_learnable_q", False),
             query_dim=qdim,
+            per_teacher_attn_threshold=cfg.get("mbm_loop_threshold", 8),
         )
     else:
         mbm = ManifoldBridgingModule(


### PR DESCRIPTION
## Summary
- add optional `per_teacher_attn_threshold` to `LightweightAttnMBM`
- average attention per teacher when the number of teachers is large
- expose threshold in `build_from_teachers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e554dfa208321b2aab66820685e7d