### PR TITLE
Per-teacher attention support in LightweightAttnMBM

### DIFF
--- a/models/la_mbm.py
+++ b/models/la_mbm.py
@@ -26,6 +26,7 @@ class LightweightAttnMBM(nn.Module):
         n_head: int = 1,
         learnable_q: bool = True,
         query_dim: Optional[int] = None,
+        loop_threshold: int = 8,
     ) -> None:
         super().__init__()
         if query_dim is not None and query_dim <= 0:
@@ -48,6 +49,7 @@ class LightweightAttnMBM(nn.Module):
 
         self.attn = nn.MultiheadAttention(self.embed_dim, n_head, batch_first=True)
         self.out_proj = nn.Linear(self.embed_dim, out_dim)
+        self.loop_threshold = max(1, loop_threshold)
 
     def forward(
         self,
@@ -101,10 +103,20 @@ class LightweightAttnMBM(nn.Module):
 
         keys = [proj(f).unsqueeze(1) for f, proj in zip(feats, self.k_proj)]
         values = [proj(f).unsqueeze(1) for f, proj in zip(feats, self.v_proj)]
-        k = torch.cat(keys, dim=1)
-        v = torch.cat(values, dim=1)
 
-        attn_out, attn = self.attn(q, k, v)
+        if len(keys) > self.loop_threshold:
+            out_list = []
+            attn_list = []
+            for k_i, v_i in zip(keys, values):
+                attn_tmp, attn_map = self.attn(q, k_i, v_i)
+                out_list.append(attn_tmp)
+                attn_list.append(attn_map)
+            attn_out = torch.stack(out_list, dim=0).mean(dim=0)
+            attn = torch.stack(attn_list, dim=0).mean(dim=0)
+        else:
+            k = torch.cat(keys, dim=1)
+            v = torch.cat(values, dim=1)
+            attn_out, attn = self.attn(q, k, v)
         out = self.out_proj(attn_out.squeeze(1))
         if isinstance(query_or_feats, list):
             return out

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -144,6 +144,7 @@ def build_from_teachers(
             n_head=cfg.get("mbm_n_head", 1),
             learnable_q=cfg.get("mbm_learnable_q", False),
             query_dim=qdim,
+            loop_threshold=cfg.get("mbm_loop_threshold", 8),
         )
     else:
         mbm = ManifoldBridgingModule(


### PR DESCRIPTION
## Summary
- add `loop_threshold` to `LightweightAttnMBM` to handle many teachers
- compute attention per-teacher and average when the threshold is exceeded
- expose the threshold through `build_from_teachers`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e55837d1c832194e77eccd2198e97