### PR TITLE
Add force_refinetune flag and AMP handling

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -35,6 +35,7 @@ wandb_api_key: ""            # ""이면 env/W&B login 사용
 
 finetune_ckpt1: "./checkpoints/teacher1_finetuned.pth"
 finetune_ckpt2: "./checkpoints/teacher2_finetuned.pth"
+force_refinetune: false
 
 # === Information Bottleneck MBM ===
 mbm_type: ib_mbm

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -48,6 +48,7 @@ finetune_weight_decay: 0.0005
 finetune_use_cutmix: true
 finetune_cutmix_alpha: 1.0
 finetune_alpha: 1.0
+force_refinetune: false
 
 # ===============================================================
 # 4. Distillation Hyperparameters


### PR DESCRIPTION
## Summary
- support `force_refinetune` in configs and fine-tuning script
- use AMP utilities in `standard_ce_finetune`
- skip fine‑tuning only when the flag is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5c2569108321a22566e7859fc7ce