### PR TITLE
Fix ExperimentLogger symlink handling

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -142,7 +142,11 @@ class ExperimentLogger:
         try:
             if os.path.islink(latest_path) or os.path.exists(latest_path):
                 os.remove(latest_path)
-            os.symlink(os.path.basename(json_path), latest_path)
+            if os.name != "nt":
+                os.symlink(os.path.basename(json_path), latest_path)
+            else:
+                import shutil
+                shutil.copy2(json_path, latest_path)
         except OSError:
             # 심링크가 안 되는 파일시스템이면 그만 복사
             import shutil


### PR DESCRIPTION
## Summary
- ensure `utils.logger.ExperimentLogger` handles Windows by copying instead of symlinking when creating `latest.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6162a7488321b62cb1ef35d38d01