### PR TITLE
Expose KD hyperparameters in config

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -52,13 +52,14 @@ class ASMBDistiller(nn.Module):
         self.la_mode = isinstance(mbm, LightweightAttnMBM)
 
         # 하이퍼파라미터
-        self.alpha = alpha
-        self.synergy_ce_alpha = synergy_ce_alpha
-        self.T = temperature
-        self.reg_lambda = reg_lambda
-        self.mbm_reg_lambda = mbm_reg_lambda
-        self.feat_kd_alpha = feat_kd_alpha
-        self.num_stages = num_stages
+        cfg = config or {}
+        self.alpha = cfg.get("ce_alpha", alpha)
+        self.synergy_ce_alpha = cfg.get("synergy_ce_alpha", synergy_ce_alpha)
+        self.T = cfg.get("tau_start", temperature)
+        self.reg_lambda = cfg.get("reg_lambda", reg_lambda)
+        self.mbm_reg_lambda = cfg.get("mbm_reg_lambda", mbm_reg_lambda)
+        self.feat_kd_alpha = cfg.get("feat_kd_alpha", feat_kd_alpha)
+        self.num_stages = cfg.get("num_stages", num_stages)
         self.device = device
         self.config = config if config is not None else {}
         self.log_int = int(self.config.get("log_step_interval", 100))

--- a/methods/at.py
+++ b/methods/at.py
@@ -59,12 +59,13 @@ class ATDistiller(nn.Module):
         super().__init__()
         self.teacher = teacher_model
         self.student = student_model
-        self.alpha = alpha
-        self.p = p
-        self.layer_key = layer_key
-        self.label_smoothing = label_smoothing
+        cfg = config or {}
+        self.alpha = cfg.get("at_alpha", alpha)
+        self.p = cfg.get("at_p", p)
+        self.layer_key = cfg.get("layer_key", layer_key)
+        self.label_smoothing = cfg.get("label_smoothing", label_smoothing)
         # optional runtime configuration for training loops
-        self.cfg = config if config is not None else {}
+        self.cfg = cfg
 
     def forward(self, x, y):
         # 1) teacher

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -37,14 +37,15 @@ class DKDDistiller(nn.Module):
         super().__init__()
         self.teacher = teacher_model
         self.student = student_model
-        self.ce_weight = ce_weight
-        self.alpha = alpha
-        self.beta = beta
-        self.temperature = temperature
-        self.warmup = warmup
-        self.label_smoothing = label_smoothing
+        cfg = config or {}
+        self.ce_weight = cfg.get("dkd_ce_weight", ce_weight)
+        self.alpha = cfg.get("dkd_alpha", alpha)
+        self.beta = cfg.get("dkd_beta", beta)
+        self.temperature = cfg.get("tau_start", temperature)
+        self.warmup = cfg.get("dkd_warmup", warmup)
+        self.label_smoothing = cfg.get("label_smoothing", label_smoothing)
         # optional runtime configuration for training loops
-        self.cfg = config if config is not None else {}
+        self.cfg = cfg
 
     def forward(self, x, y, epoch=1):
         """

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -33,15 +33,17 @@ class FitNetDistiller(nn.Module):
         self.teacher = teacher_model
         self.student = student_model
 
-        # 어느 레이어(키)를 hint/guided로 쓸지
-        self.hint_key = hint_key
-        self.guided_key = guided_key
+        cfg = config or {}
 
-        self.alpha_hint = alpha_hint
-        self.alpha_ce = alpha_ce
-        self.label_smoothing = label_smoothing
+        # 어느 레이어(키)를 hint/guided로 쓸지
+        self.hint_key = cfg.get("hint_key", hint_key)
+        self.guided_key = cfg.get("guided_key", guided_key)
+
+        self.alpha_hint = cfg.get("fit_alpha_hint", alpha_hint)
+        self.alpha_ce = cfg.get("fit_alpha_ce", alpha_ce)
+        self.label_smoothing = cfg.get("label_smoothing", label_smoothing)
         # optional runtime configuration for training loops
-        self.cfg = config if config is not None else {}
+        self.cfg = cfg
 
         # 학생 특징맵을 스승 특징맵 채널로 변환하는 1x1 convolution
         self.regressor = nn.Conv2d(s_channels, t_channels, kernel_size=1)

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -27,9 +27,10 @@ class VanillaKDDistiller(nn.Module):
         super().__init__()
         self.teacher = teacher_model
         self.student = student_model
-        self.alpha = alpha
-        self.temperature = temperature
-        self.cfg = config if config is not None else {}
+        cfg = config or {}
+        self.alpha = cfg.get("ce_alpha", alpha)
+        self.temperature = cfg.get("tau_start", temperature)
+        self.cfg = cfg
 
     def forward(self, x, y, tau=None):
         """


### PR DESCRIPTION
## Summary
- let ASMBDistiller, VanillaKDDistiller, DKDDistiller, FitNetDistiller and ATDistiller read configurable hyperparameters from YAML config when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1f7b8fbc8321bbb8aa878d4ce170