### PR TITLE
Add ResNet-152 adapter configuration

### DIFF
--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -9,7 +9,7 @@ seed: 42
 deterministic: true
 dataset_name: "cifar100"
 data_root: "./data"
-batch_size: 128
+batch_size: 96
 num_workers: 2
 data_aug: 1
 small_input: true
@@ -22,7 +22,8 @@ small_input: true
 # Lists used by run_experiments.sh when looping
 teacher1_list: ["resnet152"]
 teacher2_list: ["efficientnet_b2", "swin_tiny"]
-student_list: ["resnet_adapter"]      # 첫 실험은 하나로 충분
+student_list: ["resnet152_adapter"]      # 첫 실험은 하나로 충분
+student_type: "resnet152_adapter"
 method_list: ["asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"] # "asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"
 
 # Partial-freeze / adapter options
@@ -106,7 +107,7 @@ mbm_type: ib_mbm
 mbm_r: 4
 mbm_n_head: 1
 mbm_learnable_q: true
-mbm_query_dim: 0
+mbm_query_dim: 2048
 
 # Misc
 grad_clip_norm: 2.0

--- a/sweeps/asmb_grid.yaml
+++ b/sweeps/asmb_grid.yaml
@@ -9,11 +9,12 @@ metric:
 # (클라우드-컨트롤러 사용: 별도 설정 없이 기본값)
 
 parameters:             # ---- Hyper-search 공간 ----
+  student_type: {values: ["resnet152_adapter"]}
   # 🔧 1) learning-rate (log10 균등)
   student_lr:
-    distribution: log_uniform_values   # 6e-4  ~  1.4e-3
-    min: 0.0005
-    max: 0.0018
+    distribution: log_uniform_values
+    min: 0.0004
+    max: 0.0012
 
   # 👀 sweep 영역 확장
   ib_beta:                             # β (IB loss) → 좀 더 넓게


### PR DESCRIPTION
## Summary
- support ResNet-152 adapter in default config and sweep grid
- adjust batch size and MBM query dim for larger student
- update sweep grid to explore the new student

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f243deef48321a46003f63076bbd7