### PR TITLE
Refactor CLI overrides and freezing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,11 @@ teacher2_bn_head_only: 0
 sweeps or batch runs without editing every config file.
 
 ### Freeze Levels
+* **-1 \u2192 no freeze** (new)  
+* 0 \u2192 head only  
+* 1 \u2192 last block train  
+* 2 \u2192 last two blocks train  
+  (architecture\u2011specific mapping\ub294 `modules/partial_freeze.py` \ucc38\uace0)
 
 The amount of each model that remains trainable is controlled by three keys in `configs/partial_freeze.yaml`:
 

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -13,9 +13,8 @@ def apply_partial_freeze(model, level: int, freeze_bn: bool = False):
     model : nn.Module
         Target network whose ``requires_grad`` flags will be updated.
     level : int
-        Numeric freeze level. ``level < 0`` disables freezing,
-        ``0`` keeps only the classifier/head trainable, ``1`` unfreezes the
-        last block as well and ``2`` unfreezes the last two blocks.
+        level<0 → no‑freeze, level=0 → head만 학습,
+        ``1`` unfreezes the last block and ``2`` the last two blocks.
     freeze_bn : bool, optional
         When ``True`` the BatchNorm parameters remain frozen.
     """

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -15,7 +15,7 @@ from main import (
     create_teacher_by_name,
     create_student_by_name,
     partial_freeze_teacher_auto,
-    partial_freeze_student_auto,
+    apply_partial_freeze,
 )
 
 from methods.vanilla_kd import VanillaKDDistiller
@@ -198,15 +198,11 @@ def main():
             torch.load(cfg["student_ckpt"], map_location=device, weights_only=True),
             strict=False,
         )
-    if cfg.get("use_partial_freeze", True):
-        partial_freeze_student_auto(
-            student,
-            student_name=cfg.get("student_type", "resnet_adapter"),
-            freeze_bn=cfg.get("student_freeze_bn", True),
-            freeze_ln=cfg.get("student_freeze_ln", True),
-            use_adapter=cfg.get("student_use_adapter", False),
-            freeze_level=cfg.get("student_freeze_level", 1),
-        )
+    apply_partial_freeze(
+        student,
+        cfg.get("student_freeze_level", -1 if not cfg.get("use_partial_freeze") else 0),
+        cfg.get("student_freeze_bn", False),
+    )
 
     distiller = build_distiller(method, teacher, student, cfg)
     acc = distiller.train_distillation(

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -14,7 +14,7 @@ import torch.optim as optim
 from utils.misc import set_random_seed, check_label_range
 from data.cifar100 import get_cifar100_loaders
 from data.imagenet100 import get_imagenet100_loaders
-from main import create_student_by_name, partial_freeze_student_auto
+from main import create_student_by_name, apply_partial_freeze
 from modules.cutmix_finetune_teacher import eval_teacher
 from utils.progress import smart_tqdm
 from utils.misc import get_amp_components
@@ -168,13 +168,10 @@ def main():
             strict=False,
         )
 
-    partial_freeze_student_auto(
+    apply_partial_freeze(
         student,
-        student_name=cfg.get("student_type", "resnet_adapter"),
-        freeze_bn=cfg.get("student_freeze_bn", True),
-        freeze_ln=cfg.get("student_freeze_ln", True),
-        use_adapter=cfg.get("student_use_adapter", False),
-        freeze_level=cfg.get("student_freeze_level", 1),
+        cfg.get("student_freeze_level", -1 if not cfg.get("use_partial_freeze") else 0),
+        cfg.get("student_freeze_bn", False),
     )
 
     os.makedirs(cfg.get("results_dir", "results"), exist_ok=True)

--- a/tests/test_partial_freeze.py
+++ b/tests/test_partial_freeze.py
@@ -1,0 +1,26 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn as nn
+from modules.partial_freeze import apply_partial_freeze
+
+
+class _Toy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 3, 1)
+        self.fc = nn.Linear(3, 3)
+
+
+def test_no_freeze_when_level_negative():
+    m = _Toy()
+    apply_partial_freeze(m, level=-1)
+    assert all(p.requires_grad for p in m.parameters())
+
+
+def test_head_only_freeze():
+    m = _Toy()
+    apply_partial_freeze(m, level=0)
+    conv_grad = m.conv.weight.requires_grad
+    fc_grad = m.fc.weight.requires_grad
+    assert conv_grad is False and fc_grad is True


### PR DESCRIPTION
## Summary
- refine CLI overrides to ignore `None` values and keep protected keys
- normalize `ce_alpha` and `kd_alpha` once via helper
- adjust freeze-level safety switch to use `-1` for disabled partial freeze
- update student freeze application in helper scripts
- clarify freeze level docstrings and README section
- add tests for `apply_partial_freeze`

## Testing
- `pytest -k partial_freeze -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3bf7ee34832188b1b0bcc9c2ce20