### PR TITLE
Fix trainable parameter count

### DIFF
--- a/main.py
+++ b/main.py
@@ -689,7 +689,8 @@ def main():
 
     # ───────────────────────── debug: trainable 파라미터 개수 로그 ──────────────
     def _count_trainable(m):
-        return sum(p.requires_grad for p in m.parameters())
+        """Return the number of trainable elements in ``m``."""
+        return sum(p.numel() for p in m.parameters() if p.requires_grad)
 
     n_trainable = _count_trainable(student_model)
     print(f"[Debug] Student trainable params → {n_trainable:,}")


### PR DESCRIPTION
## Summary
- count total elements instead of parameter objects when printing student trainable parameter count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3fead10c8321b91f08793213771d