### PR TITLE
Fix overlapping class handling and loaders

### DIFF
--- a/data/cifar100_overlap.py
+++ b/data/cifar100_overlap.py
@@ -16,9 +16,10 @@ def _split_classes(pct_overlap, seed=42):
     shared = classes[:n_overlap]
     rem = classes[n_overlap:]
 
-    half = (100 - n_overlap) // 2
-    classes_A = shared + rem[:half]
-    classes_B = shared + rem[half: half * 2]
+    half, extra = divmod(100 - n_overlap, 2)
+    # extra(0 or 1)를 A 쪽에 먼저 배분해 100개 보존
+    classes_A = shared + rem[: half + extra]
+    classes_B = shared + rem[half + extra :]
     return classes_A, classes_B
 
 

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -289,7 +289,13 @@ def main():
             augment=cfg.get("data_aug", True),
         )
 
-    num_classes = len(train_loader.dataset.classes)
+    # Subset ⇒ 원본 Dataset 객체의 .classes 사용
+    origin_ds = (
+        train_loader.dataset.dataset
+        if isinstance(train_loader.dataset, torch.utils.data.Subset)
+        else train_loader.dataset
+    )
+    num_classes = len(origin_ds.classes)
     check_label_range(train_loader.dataset, num_classes)
     check_label_range(test_loader.dataset, num_classes)
 

--- a/scripts/run_overlap_experiments.sh
+++ b/scripts/run_overlap_experiments.sh
@@ -4,7 +4,7 @@ export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 OVERLAPS="0 10 20 30 40 50 60 70 80 90 100"
 KD_LIST="asmb vanilla_kd dkd at crd fitnet"
-STUDENT="resnet_adapter"
+STUDENT="resnet152_adapter"
 
 for P in $OVERLAPS; do
   ## 1) 두 교사 학습 (ResNet-152 ×2)


### PR DESCRIPTION
## Summary
- handle odd overlap percentage correctly when splitting classes
- load overlapping CIFAR-100 subsets when `overlap_pct` is set
- ensure fine tuning detects num_classes with Subset datasets
- correct student name in overlap experiment script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa96cd92c8321ab0f8b39cb8e8502