### PR TITLE
Add pretrained toggle configs

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -37,6 +37,14 @@ finetune_ckpt1: "./checkpoints/teacher1_finetuned.pth"
 finetune_ckpt2: "./checkpoints/teacher2_finetuned.pth"
 force_refinetune: false
 
+# --- pretrained toggles ---------------------------------------
+# True  → ImageNet weights 로드
+# False → 완전 scratch
+teacher1_pretrained: true
+teacher2_pretrained: true
+student_pretrained:  true   # <‑‑ 기본값은 켜 두고,
+                             #     hparams.yaml 에서만 꺼서 실험
+
 # === Information Bottleneck MBM ===
 mbm_type: ib_mbm
 use_ib: true

--- a/configs/hparams.yaml
+++ b/configs/hparams.yaml
@@ -26,6 +26,11 @@ student_list: ["resnet152_adapter"]      # 첫 실험은 하나로 충분
 student_type: "resnet152_adapter"
 method_list: ["asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"] # "asmb", "vanilla_kd", "dkd", "crd", "at", "fitnet"
 
+# --- pretrained toggles (실험용 override) ----------------------
+teacher1_pretrained: true        # 두 교사 모두 ImageNet 가중치
+teacher2_pretrained: true
+student_pretrained:  false       # ★ scratch 학습
+
 # Partial-freeze / adapter options
 use_partial_freeze: false      # 첫 실험은 full fine-tune 로 성능 ceiling 파악
 student_freeze_level: 0        # head 만 고정 (실제로는 전체 학습)


### PR DESCRIPTION
## Summary
- add teacher/student pretrained toggles to default and hparams configs
- expose ImageNet weight flags for experiments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68803f8c69088321b70d692e2f3150ab