### PR TITLE
Switch scripts to Hydra config-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Baseline runs (e.g., `vanilla_kd`) produce their own logs such as `VanillaKD => 
 
 1) Multi-Stage Distillation (main.py)
 
-python main.py --config configs/partial_freeze.yaml --device cuda \
+python main.py --config-name base --device cuda \
   --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 1
   # Freeze levels (`teacher1_freeze_level`, `teacher2_freeze_level`,
   # `student_freeze_level`) are loaded from `configs/partial_freeze.yaml`
@@ -261,7 +261,7 @@ python main.py --config configs/partial_freeze.yaml --device cuda \
 2) Single-Teacher Distillation (run_single_teacher.py)
 
 ```bash
-python scripts/run_single_teacher.py --config configs/default.yaml \
+python scripts/run_single_teacher.py --config-name base \
   --method vanilla_kd --teacher_type resnet152 --teacher_ckpt teacher.pth \
   --student_type resnet_adapter --epochs 40 \
   --dataset imagenet100
@@ -280,7 +280,7 @@ sets `use_partial_freeze: false` when the selected `method` is not `asmb`.
 Run the student alone using the same partial-freeze settings to gauge its standalone performance:
 
 ```bash
-python scripts/train_student_baseline.py --config configs/partial_freeze.yaml \
+python scripts/train_student_baseline.py --config-name base \
   --student_type resnet_adapter --epochs 40 --dataset cifar100
 # Freeze levels come from `configs/partial_freeze.yaml`
 ```
@@ -313,7 +313,7 @@ python eval.py --eval_mode synergy \
 Use the `--data_aug` flag to control dataset transforms. When set to `1` (default), the loaders apply `RandomCrop`, `RandomHorizontalFlip` and `RandAugment` for stronger augmentation. Passing `--data_aug 0` disables these operations and only performs normalization/resizing.
 
 ```bash
-python main.py --config configs/default.yaml --data_aug 0
+python main.py --config-name base --data_aug 0
 ```
 
 Set `num_workers` in your YAML file to control how many processes each

--- a/eval.py
+++ b/eval.py
@@ -46,8 +46,12 @@ def create_teacher_by_name(teacher_name, num_classes=100, pretrained=False, smal
 def parse_args():
     parser = argparse.ArgumentParser(description="Evaluation script (Train/Test Acc) with ExperimentLogger")
 
-    parser.add_argument("--config", type=str, default="configs/default.yaml",
-                        help="Path to config YAML")
+    parser.add_argument(
+        "--config-name",
+        type=str,
+        default="base",
+        help="Hydra config name (from configs/)",
+    )
     parser.add_argument("--eval_mode", type=str, default="single", choices=["single","synergy"],
                         help="Evaluate single model or synergy model")
 
@@ -81,7 +85,7 @@ def parse_args():
     return parser.parse_args()
 
 def load_config(path):
-    if os.path.exists(path):
+    if path and os.path.exists(path):
         with open(path, 'r') as f:
             return yaml.safe_load(f)
     return {}
@@ -144,8 +148,9 @@ class SynergyEnsemble(nn.Module):
 def main():
     # 1) parse + load config
     args = parse_args()
-    base_cfg = load_config(args.config)
-    cfg = {**base_cfg, **vars(args)}
+    cfg_path = f"configs/{args.config_name}.yaml" if args.config_name else None
+    base_cfg = load_config(cfg_path)
+    cfg = {**base_cfg, **{k: v for k, v in vars(args).items() if k != "config_name"}}
 
     # 2) set seed
     deterministic = cfg.get("deterministic", True)

--- a/examples/run_cifar100_cl.sh
+++ b/examples/run_cifar100_cl.sh
@@ -2,7 +2,7 @@
 # Simple Split-CIFAR run (5 tasks, quick debug)
 
 python main.py \
-  --config configs/default.yaml \
+  --config-name base \
   --cl_mode 1 \
   --num_tasks 5 \
   --epochs 3 \

--- a/main.py
+++ b/main.py
@@ -138,10 +138,13 @@ def parse_args():
     parser.add_argument('--use_ib', type=lambda x: str(x).lower()=='true')
     # ---------------------------------------------- #
 
-    # (1) YAML 파일
-    parser.add_argument("--config", type=str,
-                        default="configs/default.yaml",
-                        help="Path to yaml config for distillation")
+    # (1) Hydra config name (default: base)
+    parser.add_argument(
+        "--config-name",
+        type=str,
+        default="base",
+        help="Hydra config name to load (from configs/)",
+    )
     parser.add_argument("--hparams", type=str, default=None)
 
     # (2) sweep 할 때 바꿀 필드들 ▶ YAML 값을 CLI-인자가 **덮어쓰도록** 할 목적

--- a/scripts/run_overlap_experiments.sh
+++ b/scripts/run_overlap_experiments.sh
@@ -34,7 +34,7 @@ PY
   ## 2) Distillation – 모든 KD 방법 루프
   for KD in $KD_LIST; do
     python main.py \
-      --config configs/default.yaml \
+      --config-name base \
       --overlap_pct $P \
       --method $KD \
       --teacher1_type resnet152 \

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -35,7 +35,12 @@ METHOD_MAP = {
 
 def parse_args():
     p = argparse.ArgumentParser(description="Single teacher KD")
-    p.add_argument("--config", type=str, default="configs/default.yaml")
+    p.add_argument(
+        "--config-name",
+        type=str,
+        default="base",
+        help="Hydra config name (from configs/)",
+    )
     p.add_argument("--method", type=str, default="vanilla_kd")
     p.add_argument("--teacher_type", type=str)
     p.add_argument("--teacher_ckpt", type=str)
@@ -61,7 +66,7 @@ def parse_args():
 
 
 def load_config(path):
-    if os.path.exists(path):
+    if path and os.path.exists(path):
         with open(path, "r") as f:
             return yaml.safe_load(f) or {}
     return {}
@@ -94,8 +99,13 @@ def build_distiller(method, teacher, student, cfg):
 
 def main():
     args = parse_args()
-    base_cfg = load_config(args.config)
-    cli_cfg = {k: v for k, v in vars(args).items() if v is not None}
+    cfg_path = f"configs/{args.config_name}.yaml" if args.config_name else None
+    base_cfg = load_config(cfg_path)
+    cli_cfg = {
+        k: v
+        for k, v in vars(args).items()
+        if v is not None and k != "config_name"
+    }
     cfg = {**base_cfg, **cli_cfg}
 
     # ──────────────────────────────────────────────────────────────

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -22,7 +22,12 @@ from utils.misc import get_amp_components
 
 def parse_args():
     p = argparse.ArgumentParser(description="Student baseline training")
-    p.add_argument("--config", type=str, default="configs/default.yaml")
+    p.add_argument(
+        "--config-name",
+        type=str,
+        default="base",
+        help="Hydra config name (from configs/)",
+    )
     p.add_argument("--student_type", type=str)
     p.add_argument("--student_ckpt", type=str)
     p.add_argument("--batch_size", type=int)
@@ -43,7 +48,7 @@ def parse_args():
 
 
 def load_config(path):
-    if os.path.exists(path):
+    if path and os.path.exists(path):
         with open(path, "r") as f:
             import yaml
             return yaml.safe_load(f) or {}
@@ -120,8 +125,13 @@ def train_student_ce(
 
 def main():
     args = parse_args()
-    base_cfg = load_config(args.config)
-    cli_cfg = {k: v for k, v in vars(args).items() if v is not None}
+    cfg_path = f"configs/{args.config_name}.yaml" if args.config_name else None
+    base_cfg = load_config(cfg_path)
+    cli_cfg = {
+        k: v
+        for k, v in vars(args).items()
+        if v is not None and k != "config_name"
+    }
     cfg = {**base_cfg, **cli_cfg}
 
     device = cfg.get("device", "cuda")


### PR DESCRIPTION
## Summary
- replace deprecated `--config` defaults with `--config-name base`
- update single-teacher, student baseline and eval utilities for optional config files
- drop YAML loading in run_experiments and pass Hydra overrides
- adjust overlap and example scripts
- update README examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804be3c2bc832192004aae574ea364