### PR TITLE
Switch scripts to Hydra

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -13,9 +13,9 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-import argparse
+import hydra
+from omegaconf import DictConfig, OmegaConf
 import torch
-import yaml
 from typing import Optional
 
 from utils.misc import (
@@ -43,52 +43,6 @@ from modules.partial_freeze import (
 
 # cutmix finetune
 from modules.cutmix_finetune_teacher import finetune_teacher_cutmix, eval_teacher
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Teacher Fine-tuning Script")
-
-    # ① YAML 기본값
-    parser.add_argument(
-        "--config",
-        type=str,
-        default="configs/hparams.yaml",
-        help="Path to YAML config for fine-tuning",
-    )
-
-    # ② run_experiments.sh 가 전달하는 옵션들(없으면 None)
-    parser.add_argument("--teacher_type", type=str)
-    parser.add_argument("--device", type=str)
-    parser.add_argument("--finetune_ckpt_path", type=str)
-
-    # (필요 시 추가) lr·epoch 등 sweep 파라미터
-    parser.add_argument("--finetune_lr", type=float)
-    parser.add_argument("--finetune_epochs", type=int)
-    parser.add_argument("--batch_size", type=int)
-    parser.add_argument("--finetune_weight_decay", type=float)
-    # ↓ run_experiments.sh 에서 CutMix 알파도 변경할 수 있도록
-    parser.add_argument("--finetune_cutmix_alpha", type=float)
-    parser.add_argument("--data_aug", type=int)
-    parser.add_argument("--small_input", type=int)
-    parser.add_argument("--dropout_p", type=float)
-    parser.add_argument("--use_amp", type=int)
-    parser.add_argument("--amp_dtype", type=str)
-    parser.add_argument("--adam_beta1", type=float)
-    parser.add_argument("--adam_beta2", type=float)
-    parser.add_argument("--grad_scaler_init_scale", type=int)
-    parser.add_argument("--force_refinetune", type=int)
-    parser.add_argument(
-        "--class_subset",
-        type=str,
-        help="comma-sep class ids(0-99) for subset training",
-    )
-
-    return parser.parse_args()
-
-def load_config(cfg_path):
-    if os.path.exists(cfg_path):
-        with open(cfg_path, 'r') as f:
-            return yaml.safe_load(f)
-    return {}
 
 def get_data_loaders(dataset_name, batch_size=128, num_workers=2, augment=True):
     """
@@ -245,13 +199,9 @@ def standard_ce_finetune(
             torch.save(model.state_dict(), ckpt_path)
     return model, best_acc
 
-def main():
-    args = parse_args()
-    base_cfg = load_config(args.config)
-
-    # argparse 값이 None 이면 YAML 값을 유지, 아니면 덮어쓰기
-    cli_cfg  = {k: v for k, v in vars(args).items() if v is not None}
-    cfg      = {**base_cfg, **cli_cfg}
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
+def main(cfg: DictConfig):
+    cfg = OmegaConf.to_container(cfg, resolve=True)
     device = cfg.get("device", "cuda")
     if device == "cuda" and not torch.cuda.is_available():
         print("[Warning] No CUDA => Using CPU")
@@ -264,9 +214,9 @@ def main():
     # 1) dataset
     dataset_name = cfg.get("dataset_name", "cifar100")
     batch_size   = cfg.get("batch_size", 128)
-    if args.class_subset:
+    if cfg.get("class_subset"):
         from data.cifar100_overlap import _make_loader
-        subset = [int(x) for x in args.class_subset.split(",")]
+        subset = [int(x) for x in str(cfg.get("class_subset")).split(",")]
         train_loader = _make_loader(
             subset,
             True,

--- a/scripts/load_hparams.py
+++ b/scripts/load_hparams.py
@@ -4,9 +4,14 @@
 import sys
 import yaml
 import shlex
+import warnings
 
 
 def main(path: str):
+    warnings.warn(
+        "load_hparams.py is deprecated; pass config fragments directly to Hydra",
+        DeprecationWarning,
+    )
     with open(path, 'r') as f:
         data = yaml.safe_load(f) or {}
     for key, value in data.items():

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -5,8 +5,8 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-import argparse
-import yaml
+import hydra
+from omegaconf import DictConfig, OmegaConf
 import torch
 from utils.misc import set_random_seed, check_label_range, get_model_num_classes
 from data.cifar100 import get_cifar100_loaders
@@ -33,38 +33,7 @@ METHOD_MAP = {
     "crd": CRDDistiller,
 }
 
-def parse_args():
-    p = argparse.ArgumentParser(description="Single teacher KD")
-    p.add_argument("--config", type=str, default="configs/default.yaml")
-    p.add_argument("--method", type=str, default="vanilla_kd")
-    p.add_argument("--teacher_type", type=str)
-    p.add_argument("--teacher_ckpt", type=str)
-    p.add_argument("--student_type", type=str)
-    p.add_argument("--student_ckpt", type=str)
-    p.add_argument("--batch_size", type=int)
-    p.add_argument("--student_lr", type=float)
-    p.add_argument("--weight_decay", type=float)
-    p.add_argument("--epochs", type=int)
-    p.add_argument("--results_dir", type=str, default="results")
-    p.add_argument("--ckpt_dir", type=str, default=None)
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--device", type=str)
-    p.add_argument("--dataset", "--dataset_name", dest="dataset_name", type=str,
-                   help="Dataset to use (cifar100 or imagenet100). Defaults to the config value")
-    p.add_argument("--data_aug", type=int)
-    p.add_argument("--mixup_alpha", type=float)
-    p.add_argument("--cutmix_alpha_distill", type=float)
-    p.add_argument("--label_smoothing", type=float)
-    p.add_argument("--small_input", type=int)
-    p.add_argument("--student_freeze_level", type=int)
-    return p.parse_args()
 
-
-def load_config(path):
-    if os.path.exists(path):
-        with open(path, "r") as f:
-            return yaml.safe_load(f) or {}
-    return {}
 
 
 def build_distiller(method, teacher, student, cfg):
@@ -92,11 +61,9 @@ def build_distiller(method, teacher, student, cfg):
     raise ValueError(method)
 
 
-def main():
-    args = parse_args()
-    base_cfg = load_config(args.config)
-    cli_cfg = {k: v for k, v in vars(args).items() if v is not None}
-    cfg = {**base_cfg, **cli_cfg}
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
+def main(cfg: DictConfig):
+    cfg = OmegaConf.to_container(cfg, resolve=True)
 
     # ──────────────────────────────────────────────────────────────
     # YAML/CLI override 로 인해 숫자가 문자열로 들어올 수 있다.
@@ -115,11 +82,11 @@ def main():
                 pass
     # ──────────────────────────────────────────────────────────────
 
-    method = cfg.get("method", args.method)
+    method = cfg.get("method", "vanilla_kd")
     if method != "asmb":
         cfg["use_partial_freeze"] = False
     teacher_type = cfg.get("teacher_type", cfg.get("default_teacher_type"))
-    student_type = cfg.get("student_type", args.student_type)
+    student_type = cfg.get("student_type")
     print(
         f">>> [run_single_teacher.py] method={method} teacher={teacher_type} student={student_type}"
     )


### PR DESCRIPTION
## Summary
- switch evaluation and training scripts to hydra configs
- drop custom load_config implementations
- deprecate `load_hparams.py`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804be4ca688321b915ae38ea6bb260