### PR TITLE
Fix Hydra config path for script entrypoints

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -199,7 +199,7 @@ def standard_ce_finetune(
             torch.save(model.state_dict(), ckpt_path)
     return model, best_acc
 
-@hydra.main(config_path="configs", config_name="base", version_base="1.3")
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)
     device = cfg.get("device", "cuda")

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -60,7 +60,7 @@ def build_distiller(method, teacher, student, cfg):
     raise ValueError(method)
 
 
-@hydra.main(config_path="configs", config_name="base", version_base="1.3")
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)
 

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -92,7 +92,7 @@ def train_student_ce(
     return best_acc
 
 
-@hydra.main(config_path="configs", config_name="base", version_base="1.3")
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)
 


### PR DESCRIPTION
## Summary
- load config files from repository root when running helper scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880662cc73c83219854164079a877a0