### PR TITLE
Fix Hydra config paths and CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ Baseline runs (e.g., `vanilla_kd`) produce their own logs such as `VanillaKD => 
 
 1) Multi-Stage Distillation (main.py)
 
-python main.py --config-name base --device cuda \
-  --mbm_type LA --mbm_r 4 --mbm_n_head 1 --mbm_learnable_q 1
+python main.py --config-name base \
+  device=cuda mbm.type=LA mbm.r=4 mbm.n_head=1 mbm.learnable_q=1
   # Freeze levels are defined in the model YAMLs under configs/model/
   # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
         •       Adjust model settings in `configs/model/*` or pass Hydra overrides.
@@ -187,14 +187,14 @@ python main.py --config-name base --device cuda \
 
 ```bash
 python scripts/run_single_teacher.py --config-name base \
-  --method vanilla_kd --teacher_type resnet152 --teacher_ckpt teacher.pth \
-  --student_type resnet_adapter --epochs 40 \
-  --dataset imagenet100
+  +method=vanilla_kd +teacher_type=resnet152 +teacher_ckpt=teacher.pth \
+  +student_type=resnet_adapter +epochs=40 \
+  dataset=imagenet100
 ```
 
-The `--method` flag selects one of `vanilla_kd`, `fitnet`, `dkd`, `at` or `crd`.
-Pass `--dataset` to override the dataset specified in the YAML config (either
-`cifar100` or `imagenet100`).
+The `method` option selects one of `vanilla_kd`, `fitnet`, `dkd`, `at` or `crd`.
+Override the dataset by passing `dataset=imagenet100` or `dataset=cifar100` on
+the command line.
 Partial freezing is automatically turned off for these methods—`run_single_teacher.py`
 sets `use_partial_freeze: false` when the selected `method` is not `asmb`.
 
@@ -206,7 +206,7 @@ Run the student alone using the same partial-freeze settings to gauge its standa
 
 ```bash
 python scripts/train_student_baseline.py --config-name base \
-  --student_type resnet_adapter --epochs 40 --dataset cifar100
+  +student_type=resnet_adapter +epochs=40 dataset=cifar100
 # Freeze levels come from the student YAML under configs/model/
 ```
 
@@ -337,8 +337,8 @@ Run the fine-tuning script directly to update a single teacher:
 
 ```bash
 python scripts/fine_tuning.py --config-name base \
-  --teacher_type resnet152 --finetune_epochs 100 --finetune_lr 0.0005 \
-  --dropout_p 0.5
+  +teacher_type=resnet152 +finetune_epochs=100 +finetune_lr=0.0005 \
+  +dropout_p=0.5
 ```
 
 The script uses **CIFAR-100** by default. Change `dataset.name` via a Hydra override

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -37,7 +37,7 @@ ckpt_dir: "./checkpoints"
 
 # ---------- W&B ----------
 wandb:
-  use: true
+  use: false
   entity: "kakamy0820-yonsei-university"
   project: "kd_monitor"
   run_name: ""              # 비우면 exp_id 사용

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -199,7 +199,7 @@ def standard_ce_finetune(
             torch.save(model.state_dict(), ckpt_path)
     return model, best_acc
 
-@hydra.main(config_path="configs", config_name="base", version_base="1.3")
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)
     device = cfg.get("device", "cuda")

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -56,14 +56,14 @@ run_loop() {
         echo ">>> [run_experiments.sh] fine-tuning teacher=${T}  (epochs=${finetune_epochs}, lr=${finetune_lr})"
           python scripts/fine_tuning.py \
           --config-name base \
-          +teacher_type="${T}" \
-          +device=cuda \
-          +batch_size=${batch_size} \
+          +teacher_type=${T} \
+          device=cuda \
+          batch_size=${batch_size} \
           +finetune_epochs=${finetune_epochs} \
           +finetune_lr=${finetune_lr} \
           +finetune_weight_decay=${finetune_weight_decay} \
           +finetune_cutmix_alpha=${finetune_cutmix_alpha} \
-          +finetune_ckpt_path="${CKPT}" \
+          +finetune_ckpt_path=${CKPT} \
           +data_aug=${data_aug}
         fi
         done
@@ -86,49 +86,49 @@ run_loop() {
           if [ "$METHOD" = "asmb" ]; then
           python main.py \
             --config-name base \
-            +teacher1_type="${T1}" \
-            +teacher2_type="${T2}" \
+            +teacher1_type=${T1} \
+            +teacher2_type=${T2} \
             +finetune_epochs=0 \
-            +student_type="${STUDENT}" \
+            +student_type=${STUDENT} \
             +num_stages=${STAGE} \
             +synergy_ce_alpha=${SC_ALPHA} \
             +hybrid_beta=${H_BETA} \
             +ib_beta=${ib_beta} \
             +teacher_lr=${teacher_lr} \
             +student_lr=${student_lr} \
-            +batch_size=${batch_size} \
+            batch_size=${batch_size} \
             +teacher1_use_adapter=${teacher1_use_adapter} \
             +teacher1_bn_head_only=${teacher1_bn_head_only} \
             +teacher2_use_adapter=${teacher2_use_adapter} \
             +teacher2_bn_head_only=${teacher2_bn_head_only} \
             +student_freeze_level=${student_freeze_level} \
-            +results_dir="${OUTDIR}" \
-            +ckpt_dir="${CKPT_DIR}" \
-            +exp_id="${EXP_ID}" \
-            +seed=42 \
+            +results_dir=${OUTDIR} \
+            +ckpt_dir=${CKPT_DIR} \
+            +exp_id=${EXP_ID} \
+            seed=42 \
             +data_aug=${data_aug} \
             +mixup_alpha=${mixup_alpha} \
             +cutmix_alpha_distill=${cutmix_alpha_distill} \
             +label_smoothing=${label_smoothing} \
-            +method=${METHOD} \
+            method=${METHOD} \
             "${EXTRA_ARGS[@]}"
           else
           python scripts/run_single_teacher.py \
             --config-name base \
-            +teacher_type="${T2}" \
-            +student_type="${STUDENT}" \
+            +teacher_type=${T2} \
+            +student_type=${STUDENT} \
             +student_lr=${student_lr} \
-            +batch_size=${batch_size} \
+            batch_size=${batch_size} \
             +epochs=${student_epochs_per_stage} \
             +student_freeze_level=${student_freeze_level} \
-            +results_dir="${OUTDIR}" \
-            +ckpt_dir="${CKPT_DIR}" \
-            +seed=42 \
+            +results_dir=${OUTDIR} \
+            +ckpt_dir=${CKPT_DIR} \
+            seed=42 \
             +data_aug=${data_aug} \
             +mixup_alpha=${mixup_alpha} \
             +cutmix_alpha_distill=${cutmix_alpha_distill} \
             +label_smoothing=${label_smoothing} \
-            +method=${METHOD} \
+            method=${METHOD} \
             "${EXTRA_ARGS[@]}"
           fi 2>&1 | tee -a "${OUTDIR}/train.log"
                 done            # closes STAGE loop
@@ -160,12 +160,12 @@ run_sweep() {
       hybrid_beta=${h_beta}
       python main.py \
         --config-name base \
-        +teacher1_type="${T1}" \
-        +teacher2_type="${T2}" \
+        +teacher1_type=${T1} \
+        +teacher2_type=${T2} \
         +synergy_ce_alpha=${sc_alpha} \
         +hybrid_beta=${h_beta} \
         +ib_beta=${ib_beta} \
-        +device=${device} \
+        device=${device} \
         +finetune_epochs=0 \
         +data_aug=${data_aug} \
         +mixup_alpha=${mixup_alpha} \
@@ -176,7 +176,7 @@ run_sweep() {
         +teacher2_bn_head_only=${teacher2_bn_head_only} \
         +student_freeze_level=${student_freeze_level} \
         +label_smoothing=${label_smoothing} \
-        +method=${METHOD} 2>&1 | tee -a "${OUTPUT_DIR}/train.log"
+        method=${METHOD} 2>&1 | tee -a "${OUTPUT_DIR}/train.log"
       done
     done
   done

--- a/scripts/run_overlap_experiments.sh
+++ b/scripts/run_overlap_experiments.sh
@@ -29,8 +29,8 @@ PY
         +teacher_type=resnet152 \
         +finetune_epochs=10 \
         +finetune_lr=3e-4 \
-        +class_subset="${!CLS_VAR}" \
-        +finetune_ckpt_path="$CKPT"
+        +class_subset=${!CLS_VAR} \
+        +finetune_ckpt_path=${CKPT}
     fi
   done
 

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -60,7 +60,7 @@ def build_distiller(method, teacher, student, cfg):
     raise ValueError(method)
 
 
-@hydra.main(config_path="configs", config_name="base", version_base="1.3")
+@hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)
 


### PR DESCRIPTION
## Summary
- point Hydra at the correct config directory for scripts
- set `wandb.use` to false by default
- clean up quoting and plus overrides in run scripts
- update README examples for Hydra syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880669f7edc83218391e2d63c253a1f