### PR TITLE
Add log config propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ python main.py model.teacher.freeze_level=1 model.student.lr=0.0008
 
 Batch scripts like `run_experiments.sh` simply forward arguments to `main.py`.
 
+Logging options live under the `log:` section in each YAML.  The helper
+function `flatten_hydra_config` copies `log.level` and `log.filename` to the
+top‑level keys `log_level` and `log_filename` so older scripts continue to work.
+
 
 ## Testing
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,19 @@
+import utils.config_utils as cu
+
+
+def test_log_options_propagated():
+    cfg = {"log": {"level": "WARNING", "filename": "out.log"}}
+    out = cu.flatten_hydra_config(dict(cfg))
+    assert out["log_level"] == "WARNING"
+    assert out["log_filename"] == "out.log"
+
+
+def test_existing_top_level_not_overridden():
+    cfg = {
+        "log": {"level": "DEBUG", "filename": "nested.log"},
+        "log_level": "INFO",
+    }
+    out = cu.flatten_hydra_config(dict(cfg))
+    assert out["log_level"] == "INFO"
+    assert out["log_filename"] == "nested.log"
+

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -60,4 +60,8 @@ def flatten_hydra_config(cfg: dict) -> dict:
     cfg.setdefault("wandb_run_name", wandb_cfg.get("run_name"))
     cfg.setdefault("wandb_api_key", wandb_cfg.get("api_key"))
 
+    log_cfg = cfg.get("log", {})
+    cfg.setdefault("log_level", log_cfg.get("level"))
+    cfg.setdefault("log_filename", log_cfg.get("filename"))
+
     return cfg


### PR DESCRIPTION
## Summary
- propagate `log.level` and `log.filename` from Hydra config to top-level
- cover new behaviour with tests
- mention new log section in the README

## Testing
- `bash scripts/setup_tests.sh` *(fails: Cannot connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807465e14c832189c2a5bb62582f47