### PR TITLE
Add strict error handling to shell scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # run.sh
+set -euo pipefail
 #SBATCH --job-name=run_asmb_experiment
 #SBATCH --partition=base_suma_rtx3090
 #SBATCH --gres=gpu:1

--- a/run_finetune.sh
+++ b/run_finetune.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # run_finetune.sh ── 교사 2종을 ‘한 번에’ 돌리고 싶으면 SLURM 배열 유지,
+set -euo pipefail
 #                ‘하나씩’ 돌리고 싶으면 아래처럼 파라미터화.
 
 #SBATCH --job-name=ft_teacher


### PR DESCRIPTION
## Summary
- ensure failure on any command in `run.sh` and `run_finetune.sh`

## Testing
- `bash scripts/setup_tests.sh` *(fails: Cannot connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809cee39248321ae001afce658e64d