### PR TITLE
Add dataset defaults and data_root support

### DIFF
--- a/configs/finetune/resnet152_cifar32.yaml
+++ b/configs/finetune/resnet152_cifar32.yaml
@@ -26,3 +26,7 @@ log_level: INFO
 deterministic: true
 
 finetune_ckpt_path: checkpoints/resnet152_cifar32.pth
+
+# ─── NEW ─────────────────────────────────────────────
+dataset_name: cifar100        # ← loader 에서 요구
+data_root: ./data             # (경로 바꿀 거면 같이 수정)

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -45,18 +45,22 @@ from modules.partial_freeze import (
 # cutmix finetune
 from modules.cutmix_finetune_teacher import finetune_teacher_cutmix, eval_teacher
 
-def get_data_loaders(dataset_name, batch_size=128, num_workers=2, augment=True):
+def get_data_loaders(
+    dataset_name, batch_size=128, num_workers=2, augment=True, root=None
+):
     """
     Returns train_loader, test_loader based on dataset_name.
     """
     if dataset_name == "cifar100":
         return get_cifar100_loaders(
+            root=root or "./data",
             batch_size=batch_size,
             num_workers=num_workers,
             augment=augment,
         )
     elif dataset_name == "imagenet32":
         return get_imagenet32_loaders(
+            root or "./data/imagenet32",
             batch_size=batch_size,
             num_workers=num_workers,
         )
@@ -239,6 +243,7 @@ def main(cfg: DictConfig):
             batch_size=batch_size,
             num_workers=cfg.get("num_workers", 2),
             augment=cfg.get("data_aug", True),
+            root=cfg.get("data_root"),
         )
 
     if isinstance(train_loader.dataset, torch.utils.data.ConcatDataset):

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -18,7 +18,9 @@ def flatten_hydra_config(cfg: dict) -> dict:
     """
 
     dataset = cfg.get("dataset", {})
-    cfg.setdefault("dataset_name", dataset.get("name"))
+    dataset_name = dataset.get("name")
+    if dataset_name:
+        cfg.setdefault("dataset_name", dataset_name)
     cfg.setdefault("data_root", dataset.get("root"))
     cfg.setdefault("small_input", dataset.get("small_input"))
     cfg.setdefault("data_aug", dataset.get("data_aug"))


### PR DESCRIPTION
## Summary
- add `dataset_name` and `data_root` defaults to `resnet152` finetune config
- avoid overwriting existing `dataset_name` with `None`
- allow `get_data_loaders` to pass dataset root from config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f234bbe88321ae68f6e8e6b11051