### PR TITLE
Fix Hydra override paths in experiment config

### DIFF
--- a/configs/experiment/res152_effi_b2.yaml
+++ b/configs/experiment/res152_effi_b2.yaml
@@ -3,11 +3,11 @@
 # inherit common defaults from ../base
 defaults:
   - ../base
-  - override dataset: cifar100
-  - override model/teacher: resnet152
-  - override model/student: resnet152_pretrain
-  - override method: asmb
-  - override schedule: cosine
+  - override /dataset: cifar100
+  - override /model/teacher: resnet152
+  - override /model/student: resnet152_pretrain
+  - override /method: asmb
+  - override /schedule: cosine
   - _self_
 
 # Experiment-specific overrides


### PR DESCRIPTION
## Summary
- correct dataset/method/model overrides for experiments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fc08cc74832198ab729e92707b4d