### PR TITLE
Fix log level defaults

### DIFF
--- a/main.py
+++ b/main.py
@@ -297,10 +297,11 @@ def main(cfg: DictConfig):
 
     # ────────────────── LOGGING & W&B ──────────────────
     exp_dir = cfg.get("results_dir", ".")
+    lvl = cfg.get("log_level") or "INFO"
     logger = get_logger(
         exp_dir,
-        level=cfg.get("log_level", "INFO"),
-        stream_level="INFO" if cfg.get("log_level", "INFO").upper() == "DEBUG" else cfg.get("log_level", "INFO")
+        level=lvl,
+        stream_level="INFO" if lvl.upper() == "DEBUG" else lvl,
     )
 
     global _HP_LOGGED

--- a/modules/disagreement.py
+++ b/modules/disagreement.py
@@ -87,7 +87,8 @@ def compute_disagreement_rate(
     dis_rate = 100.0 * disagree_count / total_samples if total_samples > 0 else 0.0
 
     # ---- DEBUG 로그 --------------------------------------------------
-    if cfg is not None and cfg.get("log_level", "INFO").upper() == "DEBUG":
+    lvl = (cfg.get("log_level") if cfg is not None else None) or "INFO"
+    if cfg is not None and lvl.upper() == "DEBUG":
         logging.debug(
             "[DisagreeDBG] mode=%s | selected=%d / %d (%.1f %%)",
             mode,

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -31,7 +31,8 @@ def setup_logging(cfg: dict):
     for h in logging.root.handlers[:]:
         logging.root.removeHandler(h)
 
-    level = getattr(logging, cfg.get("log_level", "INFO").upper(), logging.INFO)
+    level_str = (cfg.get("log_level") or "INFO").upper()
+    level = getattr(logging, level_str, logging.INFO)
     log_file = os.path.join(cfg.get("results_dir", "."), cfg.get("log_filename", "train.log"))
     _ensure_dir(log_file)
 
@@ -112,13 +113,15 @@ def get_logger(
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     f_hdl.setFormatter(f_fmt)
-    f_hdl.setLevel(getattr(logging, level.upper()))
+    f_level = getattr(logging, (level or "INFO").upper())
+    f_hdl.setLevel(f_level)
     logger.addHandler(f_hdl)
 
     s_hdl = logging.StreamHandler(sys.stdout)
     s_fmt = logging.Formatter("%(levelname)s | %(message)s")
     s_hdl.setFormatter(s_fmt)
-    s_hdl.setLevel(getattr(logging, stream_level.upper()))
+    s_level = getattr(logging, (stream_level or "WARNING").upper())
+    s_hdl.setLevel(s_level)
     logger.addHandler(s_hdl)
 
     class _WBHandler(logging.Handler):
@@ -128,7 +131,7 @@ def get_logger(
     if wandb.run is not None:
         wb_hdl = _WBHandler()
         wb_hdl.setFormatter(f_fmt)
-        wb_hdl.setLevel(getattr(logging, level.upper()))
+        wb_hdl.setLevel(f_level)
         logger.addHandler(wb_hdl)
 
     _LOGGERS[gkey] = logger


### PR DESCRIPTION
## Summary
- handle missing `log_level` in main
- avoid `None.upper()` in disagreement rate module
- ensure logger setup handles absent log levels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881015d00088321b68f00fce2bf4e85