### PR TITLE
Fix float casting conditional

### DIFF
--- a/main.py
+++ b/main.py
@@ -333,7 +333,7 @@ def main(cfg: DictConfig):
         "student_lr",
         "finetune_lr",
     ):
-        if key in cfg:
+        if key in cfg and cfg[key] is not None:
             cfg[key] = float(cfg[key])
 
     exp_logger = ExperimentLogger(cfg, exp_name="asmb_experiment")


### PR DESCRIPTION
## Summary
- avoid casting learning rate and weight decay when value is `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810386345883218375fe1142cd5e0f