### PR TITLE
Fix nested teacher/student config handling

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -29,3 +29,9 @@ def test_experiment_nested_dataset():
     out = cu.flatten_hydra_config(dict(cfg))
     assert out["dataset_name"] == "cifar100"
     assert out["data_root"] == "./data"
+
+
+def test_nested_teacher_model():
+    cfg = {"model": {"teacher": {"model": {"teacher": {"lr": 0.001}}}}}
+    out = cu.flatten_hydra_config(dict(cfg))
+    assert out["teacher_lr"] == 0.001

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -41,6 +41,10 @@ def flatten_hydra_config(cfg: dict) -> dict:
 
     model = cfg.get("model", {})
     teacher = model.get("teacher", {})
+    if isinstance(teacher, dict) and "model" in teacher:
+        teacher = teacher["model"]
+    if isinstance(teacher, dict) and "teacher" in teacher:
+        teacher = teacher["teacher"]
     cfg.setdefault("teacher_type", teacher.get("name"))
     cfg.setdefault("teacher_pretrained", teacher.get("pretrained"))
     cfg.setdefault("teacher_lr", teacher.get("lr"))
@@ -53,6 +57,10 @@ def flatten_hydra_config(cfg: dict) -> dict:
     cfg.setdefault("teacher_bn_head_only", teacher.get("bn_head_only"))
 
     student = model.get("student", {})
+    if isinstance(student, dict) and "model" in student:
+        student = student["model"]
+    if isinstance(student, dict) and "student" in student:
+        student = student["student"]
     cfg.setdefault("student_type", student.get("name"))
     cfg.setdefault("student_pretrained", student.get("pretrained"))
     cfg.setdefault("student_lr", student.get("lr"))


### PR DESCRIPTION
## Summary
- support nested `model` entries when flattening hydra config
- test teacher LR extraction from nested experiment config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810703642083218abcc10f502f7029