### PR TITLE
Fix nested model flattening

### DIFF
--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -29,3 +29,17 @@ def test_experiment_nested_dataset():
     out = cu.flatten_hydra_config(dict(cfg))
     assert out["dataset_name"] == "cifar100"
     assert out["data_root"] == "./data"
+
+
+def test_experiment_nested_model_teacher_lr():
+    cfg = {
+        "experiment": {
+            "model": {
+                "teacher": {
+                    "model": {"lr": 0.001}
+                }
+            }
+        }
+    }
+    out = cu.flatten_hydra_config(dict(cfg))
+    assert out["teacher_lr"] == 0.001

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -41,6 +41,8 @@ def flatten_hydra_config(cfg: dict) -> dict:
 
     model = cfg.get("model", {})
     teacher = model.get("teacher", {})
+    if isinstance(teacher, dict) and "model" in teacher:
+        teacher = teacher["model"]
     cfg.setdefault("teacher_type", teacher.get("name"))
     cfg.setdefault("teacher_pretrained", teacher.get("pretrained"))
     cfg.setdefault("teacher_lr", teacher.get("lr"))
@@ -53,6 +55,8 @@ def flatten_hydra_config(cfg: dict) -> dict:
     cfg.setdefault("teacher_bn_head_only", teacher.get("bn_head_only"))
 
     student = model.get("student", {})
+    if isinstance(student, dict) and "model" in student:
+        student = student["model"]
     cfg.setdefault("student_type", student.get("name"))
     cfg.setdefault("student_pretrained", student.get("pretrained"))
     cfg.setdefault("student_lr", student.get("lr"))


### PR DESCRIPTION
## Summary
- support nested `model` keys when flattening config dictionaries
- test flattening of experiment model section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688106fd299483218911db579f8d5df0