### PR TITLE
Fix missing teacher adaptive KD weight default

### DIFF
--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -218,8 +218,12 @@ def teacher_adaptive_update(
                             feat_kd_warned = True
 
             # Standard KD + CE
+            kd_weight = cfg.get(
+                "teacher_adapt_alpha_kd",
+                cfg.get("kd_alpha", 1.0),
+            )
             total_loss = (
-                cfg["teacher_adapt_alpha_kd"] * loss_kd
+                kd_weight * loss_kd
                 + synergy_ce_loss
                 + cfg.get("feat_kd_alpha", 0) * feat_kd_loss
                 + ib_loss_val


### PR DESCRIPTION
## Summary
- avoid KeyError by defaulting `teacher_adapt_alpha_kd` to `kd_alpha`

## Testing
- `bash scripts/setup_tests.sh` *(fails: "externally managed environment" and cannot install packages)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688109aaf73c83218724908b420d83bb