### PR TITLE
Fix PYTHONPATH setup in run scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@
 cd "${SLURM_SUBMIT_DIR:-$(dirname "$0")}"
 source ~/.bashrc
 conda activate tlqkf
+export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 : "${SLURM_JOB_ID:=manual}"
 mkdir -p "outputs/asmb_${SLURM_JOB_ID}"

--- a/scripts/run_sweep.sh
+++ b/scripts/run_sweep.sh
@@ -20,6 +20,7 @@ mkdir -p "${OUTPUT_DIR}"
 
 source ~/.bashrc
 conda activate tlqkf
+export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 # ---------- W&B 설정 ----------
 export WANDB_ENTITY="kakamy0820-yonsei-university"


### PR DESCRIPTION
## Summary
- export PYTHONPATH in `run.sh`
- ensure sweep script does the same

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688112c5d43c8321a0363572ad69c4ff