### PR TITLE
Fix finetune config path

### DIFF
--- a/run_finetune_clean.sh
+++ b/run_finetune_clean.sh
@@ -28,4 +28,6 @@ fi
 
 echo "▶ Fine-tuning config: $CFG_NAME"
 mkdir -p logs
-python scripts/fine_tuning.py --config-name "$CFG_NAME"
+python scripts/fine_tuning.py \
+  --config-path ./configs/finetune \
+  --config-name "$CFG_NAME"


### PR DESCRIPTION
## Summary
- point Hydra to the local `configs/finetune` directory in `run_finetune_clean.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688113e712a883219561b5869d9c6af3