### PR TITLE
Remove unused efficientnet adapter setting

### DIFF
--- a/configs/experiment/res152_effi_b2.yaml
+++ b/configs/experiment/res152_effi_b2.yaml
@@ -17,7 +17,6 @@ teacher1_ckpt: checkpoints/resnet152_ft.pth
 teacher2_type: efficientnet_b2
 teacher2_ckpt: checkpoints/efficientnet_b2_ft.pth
 teacher2_use_adapter: true
-efficientnet_adapter_dim: 1024
 
 student_type: resnet152_adapter
 student_pretrained: true


### PR DESCRIPTION
## Summary
- remove `efficientnet_adapter_dim` from `res152_effi_b2.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688113e7828c83218d2fffebc3a04f9f