### PR TITLE
Implement teacher & student adapter updates

### DIFF
--- a/models/common/__init__.py
+++ b/models/common/__init__.py
@@ -1,0 +1,5 @@
+"""Common utility modules for model components."""
+
+from .adapter import BottleneckAdapter
+
+__all__ = ["BottleneckAdapter"]

--- a/models/common/adapter.py
+++ b/models/common/adapter.py
@@ -1,0 +1,21 @@
+import torch.nn as nn
+
+class BottleneckAdapter(nn.Module):
+    """
+    [Student-side] Partial-Freeze 단계에서 얼린 블록 바로 뒤에 삽입되는 어댑터.
+
+    단순한 2-layer bottleneck 구조로 입력과 동일한 차원을 출력하며
+    잔차 연결(residual)을 사용한다.
+    """
+
+    def __init__(self, dim: int, r: int = 4):
+        super().__init__()
+        mid = max(1, dim // r)
+        self.adapter = nn.Sequential(
+            nn.Linear(dim, mid, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Linear(mid, dim, bias=False),
+        )
+
+    def forward(self, x):
+        return x + self.adapter(x)

--- a/models/teachers/adapters.py
+++ b/models/teachers/adapters.py
@@ -5,7 +5,13 @@ import torch.nn as nn
 from typing import Optional
 
 class DistillationAdapter(nn.Module):
-    """Simple MLP used to refine teacher features for distillation."""
+    """
+    [Teacher-side] 채널 / 공간 해상도 보정을 위한 작은 어댑터.
+
+    학생의 feature dimension에 맞추기 위한 용도로만 사용하며,
+    학습 루프에서는 ``train_distill_adapter_only`` 옵션이 활성화될 때에만
+    파라미터를 업데이트한다.
+    """
 
     def __init__(
         self,
@@ -24,7 +30,7 @@ class DistillationAdapter(nn.Module):
             hidden_dim = max(1, in_dim // 2)
         if out_dim is None or out_dim <= 0:
             out_dim = max(1, in_dim // 4)
-        self.mlp = nn.Sequential(
+        self.proj = nn.Sequential(
             nn.Linear(in_dim, hidden_dim),
             nn.ReLU(inplace=True),
             nn.Linear(hidden_dim, out_dim),
@@ -32,4 +38,4 @@ class DistillationAdapter(nn.Module):
         self.out_dim = out_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.mlp(x)
+        return self.proj(x)


### PR DESCRIPTION
## Summary
- clarify teacher-side `DistillationAdapter` and rename internal projection
- add `BottleneckAdapter` for student-side usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d6b446708321884b5db2391fffa9