### PR TITLE
Integrate feature KD helpers

### DIFF
--- a/modules/losses.py
+++ b/modules/losses.py
@@ -70,9 +70,9 @@ def hybrid_kd_loss_fn(student_logits, teacher_logits, labels, alpha=0.5, T=4.0):
 def feat_mse_loss(s_feat, t_feat, norm: str = "none", reduction="mean"):
     """Return the MSE between two features after optional normalization."""
     if s_feat.dim() > 2:
-        s_feat = s_feat.view(s_feat.size(0), -1)
+        s_feat = s_feat.flatten(1)
     if t_feat.dim() > 2:
-        t_feat = t_feat.view(t_feat.size(0), -1)
+        t_feat = t_feat.flatten(1)
 
     if norm == "l2":
         s_feat = F.normalize(s_feat, dim=1)

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -200,9 +200,12 @@ def student_distillation_update(
             feat_kd_val = torch.tensor(0.0, device=cfg["device"])
             if cfg.get("feat_kd_alpha", 0) > 0:
                 if la_mode and not isinstance(mbm, IB_MBM):
-                    # AMP 환경에서 dtype 불일치를 피한다
                     tgt = teacher_attn_out.detach().to(student_q_proj.dtype)
-                    feat_kd_val = F.mse_loss(student_q_proj, tgt)
+                    feat_kd_val = feat_mse_loss(
+                        student_q_proj,
+                        tgt,
+                        norm=cfg.get("feat_kd_norm", "none"),
+                    )
                 else:
                     key = cfg.get("feat_kd_key", "feat_2d")
                     s_feat = feat_dict[key]


### PR DESCRIPTION
## Summary
- update `feat_mse_loss` to handle non‑contiguous tensors via `flatten`
- use `feat_mse_loss` for LA MBM feature KD in student trainer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881db591e5c8321ad70243f3f34a65b