### PR TITLE
Update MBM config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Baseline runs (e.g., `vanilla_kd`) produce their own logs such as `VanillaKD => 
 1) Multi-Stage Distillation (main.py)
 
 python main.py --config-name base \
-  device=cuda mbm.type=LA mbm.r=4 mbm.n_head=1 mbm.learnable_q=1
+  device=cuda mbm_type=LA mbm_r=4 mbm_n_head=1 mbm_learnable_q=1
   # Freeze levels are defined in the model YAMLs under configs/model/
   # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
         •       Adjust model settings in `configs/model/*` or pass Hydra overrides.

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -47,12 +47,22 @@ wandb:
   run_name: ""              # 비우면 exp_id 사용
   api_key: ""               # "" → wandb login 로드
 
-# ---------- MBM / Information Bottleneck ----------
-mbm:
-  type: ib_mbm
-  use_ib: true
-  beta: 0.01
-  query_dim: 2048
+# ---------- MBM / Information‑Bottleneck ---------------------------------
+#  ※ 코드( main.py, trainer_*.py ) 는 중첩 dict 대신 **flat key** 를 조회합니다.
+#    그래서 기존 `mbm:` 블록을 없애고 flat alias 로 교체합니다.
+
+# 모듈 종류  ('la', 'ib_mbm', 'mlp')
+mbm_type: ib_mbm
+
+# IB 옵션
+use_ib: true
+ib_beta: 0.01                     # 최종 β
+beta_schedule: [0.0, 0.01, 5]     # 0→0.01 로 5 epoch linear warm‑up
+
+# 차원 설정
+mbm_query_dim: 2048               # student feat dim (ResNet‑152)
+mbm_d_emb: 512                    # ★ 내부 embedding 크기 변경 (256→512)
+mbm_out_dim: 512                  # synergy‑head 입력 dim (= d_emb)
 
 # ---------- Distillation stage 기본 ----------
 num_stages: 3

--- a/configs/experiment/res152_effi_b2.yaml
+++ b/configs/experiment/res152_effi_b2.yaml
@@ -29,5 +29,8 @@ student_freeze_level: 1
 num_stages: 3
 batch_size: 128
 
+# ---- MBM override (명시) ----
+mbm_d_emb: 512
+
 results_dir: outputs/res152_effi_b2
 exp_id: res152_effi_b2


### PR DESCRIPTION
## Summary
- refactor MBM config keys to be flat
- bump MBM embedding dim to 512
- show MBM override example in experiment config
- update README CLI example to use flat keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688231427de883219cf248e5bd723aa9