### PR TITLE
Remove redundant mbm_d_emb override

### DIFF
--- a/configs/experiment/res152_effi_b2.yaml
+++ b/configs/experiment/res152_effi_b2.yaml
@@ -29,8 +29,6 @@ student_freeze_level: 1
 num_stages: 3
 batch_size: 128
 
-# ---- MBM override (명시) ----
-mbm_d_emb: 512
 
 results_dir: outputs/res152_effi_b2
 exp_id: res152_effi_b2


### PR DESCRIPTION
## Summary
- remove duplicate `mbm_d_emb` override from `res152_effi_b2.yaml`
- rely on the value in `base.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882354944d0832191bc0c79b6277cbd