### PR TITLE
Fix import for IB_MBM in modules package

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,4 @@
 from models.la_mbm import LightweightAttnMBM
-from .ib_mbm import IB_MBM
+from models.mbm import IB_MBM
 
 __all__ = ["LightweightAttnMBM", "IB_MBM"]


### PR DESCRIPTION
## Summary
- import `IB_MBM` from `models.mbm` instead of the local file in `modules/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68823942a7588321ba35c4d0fa2c1b1f