### PR TITLE
Add verbose flag to DistillationAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 - **Disagreement Metrics**: `compute_disagreement_rate` now accepts
   `mode="pred"` to measure prediction mismatch or `mode="both_wrong"` for
   cross-error
+- **Adapter Debug Print**: set `debug_verbose: true` under a teacher's config to
+  print adapter input/output shapes during training
 
 ---
 

--- a/models/teachers/adapters.py
+++ b/models/teachers/adapters.py
@@ -19,11 +19,14 @@ class DistillationAdapter(nn.Module):
         hidden_dim: Optional[int] = None,
         out_dim: Optional[int] = None,
         cfg: Optional[dict] = None,
+        verbose: bool = False,
     ) -> None:
         super().__init__()
         if cfg is not None:
             hidden_dim = cfg.get("distill_hidden_dim", hidden_dim)
             out_dim = cfg.get("distill_out_dim", out_dim)
+            verbose = cfg.get("debug_verbose", verbose)
+        self.verbose = verbose
 
         # allow 0, negative, or None to trigger automatic dimension selection
         if hidden_dim is None or hidden_dim <= 0:
@@ -38,12 +41,13 @@ class DistillationAdapter(nn.Module):
         self.out_dim = out_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # DEBUG
-        print(f"[DistillAdapter] in  shape={tuple(x.shape)}")
+        if self.verbose:
+            print(f"[DistillAdapter] in  shape={tuple(x.shape)}")
         if x.dim() > 2:
             x = x.flatten(1)
-            print(f"[DistillAdapter] GAP/flatten -> {tuple(x.shape)}")
+            if self.verbose:
+                print(f"[DistillAdapter] GAP/flatten -> {tuple(x.shape)}")
         out = self.proj(x)
-        print(f"[DistillAdapter] out shape={tuple(out.shape)}")
-        #
+        if self.verbose:
+            print(f"[DistillAdapter] out shape={tuple(out.shape)}")
         return out

--- a/models/teachers/teacher_efficientnet.py
+++ b/models/teachers/teacher_efficientnet.py
@@ -30,7 +30,10 @@ class TeacherEfficientNetWrapper(nn.Module):
         hidden_dim = cfg.get("distill_hidden_dim")
         out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
+            self.feat_dim,
+            hidden_dim=hidden_dim,
+            out_dim=out_dim,
+            cfg=cfg,
         )
         self.distill_dim = self.distillation_adapter.out_dim
     

--- a/models/teachers/teacher_resnet.py
+++ b/models/teachers/teacher_resnet.py
@@ -35,7 +35,10 @@ class TeacherResNetWrapper(nn.Module):
         hidden_dim = cfg.get("distill_hidden_dim")
         out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
+            self.feat_dim,
+            hidden_dim=hidden_dim,
+            out_dim=out_dim,
+            cfg=cfg,
         )
         self.distill_dim = self.distillation_adapter.out_dim
     

--- a/models/teachers/teacher_swin.py
+++ b/models/teachers/teacher_swin.py
@@ -31,7 +31,10 @@ class TeacherSwinWrapper(nn.Module):
         hidden_dim = cfg.get("distill_hidden_dim")
         out_dim = cfg.get("distill_out_dim")
         self.distillation_adapter = DistillationAdapter(
-            self.feat_dim, hidden_dim=hidden_dim, out_dim=out_dim
+            self.feat_dim,
+            hidden_dim=hidden_dim,
+            out_dim=out_dim,
+            cfg=cfg,
         )
         self.distill_dim = self.distillation_adapter.out_dim
 


### PR DESCRIPTION
## Summary
- add a `verbose` argument to `DistillationAdapter` and store it
- only print adapter shapes when `verbose` is enabled
- pass config dict to all teacher adapters
- mention `debug_verbose` option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824744e3f08321aea0362b77bfde9a