### PR TITLE
Fix mbm_out_dim to match ResNet-152

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -62,7 +62,7 @@ beta_schedule: [0.0, 0.01, 5]     # 0→0.01 로 5 epoch linear warm‑up
 # 차원 설정
 mbm_query_dim: 2048               # student feat dim (ResNet‑152)
 mbm_d_emb: 512                    # ★ 내부 embedding 크기 변경 (256→512)
-mbm_out_dim: 512                  # synergy‑head 입력 dim (= d_emb)
+mbm_out_dim: 2048                  # synergy‑head 입력 dim (= d_emb)
 
 # ---------- Distillation Adapter 기본 ----------
 use_distillation_adapter: false


### PR DESCRIPTION
## Summary
- set `mbm_out_dim` to 2048 in base config

## Testing
- `pytest -q`
- `bash scripts/setup_tests.sh` *(fails: cannot access the internet)*

------
https://chatgpt.com/codex/tasks/task_e_688260e9df908321a8583b46f8037ddd