### PR TITLE
Remove unused feat_mse_loss import

### DIFF
--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -7,7 +7,7 @@ from utils.progress import smart_tqdm
 from models.mbm import IB_MBM
 
 from modules.losses import (
-    kd_loss_fn, ce_loss_fn, ib_loss, certainty_weights, feat_mse_loss
+    kd_loss_fn, ce_loss_fn, ib_loss, certainty_weights
 )
 from modules.disagreement import sample_weights_from_disagreement
 from utils.misc import mixup_data, cutmix_data, mixup_criterion, get_amp_components

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -6,7 +6,7 @@ from utils.progress import smart_tqdm
 from models.mbm import IB_MBM
 
 from modules.losses import (
-    kd_loss_fn, ce_loss_fn, ib_loss, certainty_weights, feat_mse_loss
+    kd_loss_fn, ce_loss_fn, ib_loss, certainty_weights
 )
 from utils.schedule import get_tau, get_beta
 from utils.misc import get_amp_components


### PR DESCRIPTION
## Summary
- clean up imports for trainer modules by removing `feat_mse_loss`

## Testing
- `ruff check modules/trainer_student.py modules/trainer_teacher.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68826d7b042483218909b63d8de08b9f