### PR TITLE
Remove LA-MBM remnants; simplify IB-MBM path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,18 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
   token instead of the student feature as attention query
 - **IB β Warmup**: `ib_beta_warmup_epochs` linearly scales the KL weight from
   0 to `ib_beta` over the specified epochs
-- **Feature-Level KD**: align student features with the synergy representation.
-  A nonzero `feat_kd_alpha` enables feature alignment during teacher and student
-  updates. Example model config snippet:
+- **Feature-Level KD (disabled)**: set `feat_kd_alpha` > 0 to align student
+  features with the synergy representation during teacher and student updates.
+  Example model config snippet:
 
   ```yaml
-  feat_kd_alpha: 1.0
+  feat_kd_alpha: 0.0  # disabled by default
   feat_kd_key: "feat_2d"
   feat_kd_norm: "none"
   ```
 
-  The same values can be overridden via CLI using
+  The same values can be overridden via CLI. Set `feat_kd_alpha` to a
+  positive value to enable this loss:
   `--feat_kd_alpha 1.0 --feat_kd_key feat_2d --feat_kd_norm none`.
 - **Hybrid Guidance**: set `hybrid_beta` (>0) to blend vanilla KD from the
   average teacher logits with the default ASMB loss.

--- a/eval.py
+++ b/eval.py
@@ -108,7 +108,7 @@ class SynergyEnsemble(nn.Module):
         f2_4d = f2_dict.get("feat_4d")
 
         if self.la_mode:
-            assert self.student is not None, "student required for LA MBM"
+            assert self.student is not None, "student required for query-based MBM"
             feat_dict, _, _ = self.student(x)
             key = self.cfg.get("feat_kd_key", "feat_2d")
             s_feat = feat_dict[key]
@@ -240,7 +240,7 @@ def main(cfg: DictConfig):
             )
             synergy_head.load_state_dict(head_ck, strict=False)
 
-        # 5) student for LA MBM or optional synergy
+        # 5) student for query-based MBM or optional synergy
         student_name = cfg.get("student_type", "resnet_adapter")
         student = create_student_by_name(
             student_name,

--- a/tests/test_ib_mbm.py
+++ b/tests/test_ib_mbm.py
@@ -30,6 +30,19 @@ def test_ib_loss_nonneg():
     assert loss.item() >= 0
 
 
+def test_loss_backward():
+    mbm = IB_MBM(q_dim=16, kv_dim=16, d_emb=8)
+    decoder = torch.nn.Linear(8, 4)
+    q = torch.randn(2, 16, requires_grad=True)
+    kv = torch.randn(2, 1, 16)
+    y = torch.randint(0, 4, (2,))
+    z, mu, logvar = mbm(q, kv)
+    loss = mbm.loss(z, mu, logvar, y, decoder)
+    loss.backward()
+    assert q.grad is not None
+    assert q.grad.abs().sum() > 0
+
+
 @pytest.mark.parametrize("d_emb", [8, 32])
 def test_output_dim_matches_d_emb(d_emb):
     mbm = IB_MBM(q_dim=16, kv_dim=16, d_emb=d_emb)


### PR DESCRIPTION
## Summary
- clean up old LA-MBM comments and variables
- rename `query_mode` to `use_ib_mbm`
- delete unused attention and feature KD logic
- document feature KD as disabled
- add gradient test for `IB_MBM.loss`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68826fe572708321900f26c225008a78