### PR TITLE
Patch for MBM removal and training fixes

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -47,8 +47,9 @@ class ASMBDistiller(nn.Module):
         self.student  = student
         self.mbm = mbm
         self.synergy_head = synergy_head
-        # LightweightAttnMBM 은 더 이상 쓰지 않는다 → 항상 False
+        # LightweightAttnMBM 기능은 제거되었습니다.
         self.la_mode = False
+        assert not self.la_mode, "LA\u2011MBM support has been completely removed."
 
         # 하이퍼파라미터
         cfg = config or {}
@@ -97,9 +98,11 @@ class ASMBDistiller(nn.Module):
         zsyn = self.synergy_head(syn_feat)
 
         # CE
-        ce_val = 0.0
-        if y is not None:
-            ce_val = self.ce_loss_fn(s_logit, y)
+        ce_val = (
+            self.ce_loss_fn(s_logit, y)
+            if y is not None
+            else torch.tensor(0.0, device=s_logit.device)
+        )
 
         # KL
         kd_val = kd_loss_fn(s_logit, zsyn, T=self.T, reduction="batchmean")
@@ -283,6 +286,8 @@ class ASMBDistiller(nn.Module):
                 print(f"\n[DBG][Teacher] ====== Stage-Teacher ep {ep}/{epochs} ======")
             cur_tau = get_tau(self.config, ep-1)
             total_loss, total_num = 0.0, 0
+            # -- L2 reg 항은 epoch 단위로 한 번만 계산하여 속도 향상
+            reg_loss_epoch = torch.stack([(p ** 2).mean() for p in params]).mean()
             for it, (x, y) in enumerate(train_loader):
                 x, y = x.to(self.device), y.to(self.device)
 
@@ -322,12 +327,11 @@ class ASMBDistiller(nn.Module):
                     synergy_ce = self.synergy_ce_alpha * ce_val
 
                     # 파라미터 개수로 나눠 스케일 다운
-                    reg_loss = torch.stack([(p ** 2).mean() for p in params]).mean()
 
                     loss = (
                         kl_val
                         + synergy_ce
-                        + self.reg_lambda * reg_loss
+                        + self.reg_lambda * reg_loss_epoch
                     )
 
                 if logger is not None and attn is not None:


### PR DESCRIPTION
## Summary
- remove stale LA-MBM flag and ensure feature synergy computations
- compute student CE only when labels exist
- reduce teacher update L2 reg overhead
- import feat_mse_loss and fix query-based MBM logic
- update MBM forward and drop unused loss API
- adjust tests for new MBM API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ea47fbe4832182ddcc7457ca41d8