### PR TITLE
Update tau schedule API

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -289,7 +289,12 @@ class ASMBDistiller(nn.Module):
         for ep in range(1, epochs+1):
             if self.debug:
                 print(f"\n[DBG][Teacher] ====== Stage-Teacher ep {ep}/{epochs} ======")
-            cur_tau = get_tau(self.config, ep-1)
+            # 전 스테이지 누적 epoch = (stage-1)·epochs + (ep-1)
+            cur_tau = get_tau(
+                self.config,
+                epoch=(stage - 1) * epochs + (ep - 1),
+                total_epochs=self.num_stages * epochs,
+            )
             total_loss, total_num = 0.0, 0
             # L2 정규화는 매 batch 재계산해 그래프 중복 backward 오류를 방지
             for it, (x, y) in enumerate(train_loader):
@@ -446,7 +451,11 @@ class ASMBDistiller(nn.Module):
         for ep in range(1, epochs+1):
             if self.debug:
                 print(f"\n[DBG][Student] ====== Distill ep {ep}/{epochs} ======")
-            cur_tau = get_tau(self.config, ep-1)
+            cur_tau = get_tau(
+                self.config,
+                epoch=(stage - 1) * epochs + (ep - 1),
+                total_epochs=self.num_stages * epochs,
+            )
             self.student.train()
             total_loss, total_num = 0.0, 0
             for it, (x, y) in enumerate(train_loader):

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -80,9 +80,13 @@ def student_distillation_update(
     for ep in range(student_epochs):
         if scheduler is not None and hasattr(scheduler, "T_max"):
             total_epochs = scheduler.T_max
-            cur_tau = get_tau(cfg, min(global_ep + ep, total_epochs - 1))
         else:
-            cur_tau = get_tau(cfg, global_ep + ep)
+            total_epochs = cfg.get("total_epochs", 1)
+        cur_tau = get_tau(
+            cfg,
+            epoch=global_ep + ep,
+            total_epochs=total_epochs,
+        )
         distill_loss_sum = 0.0
         cnt = 0
         student_model.train()

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -125,9 +125,13 @@ def teacher_adaptive_update(
             student_model.eval()
         if scheduler is not None and hasattr(scheduler, "T_max"):
             total_epochs = scheduler.T_max
-            cur_tau = get_tau(cfg, min(global_ep + ep, total_epochs - 1))
         else:
-            cur_tau = get_tau(cfg, global_ep + ep)
+            total_epochs = cfg.get("total_epochs", 1)
+        cur_tau = get_tau(
+            cfg,
+            epoch=global_ep + ep,
+            total_epochs=total_epochs,
+        )
         teacher_loss_sum = 0.0
         count = 0
 

--- a/utils/schedule.py
+++ b/utils/schedule.py
@@ -1,22 +1,38 @@
 # utils/schedule.py
 
-def get_tau(cfg: dict, epoch: int) -> float:
-    """
-    Polynomial temperature decay.
+from typing import Optional
 
-    The schedule follows:
-      τ(e) = τ_end + (τ_start - τ_end) · (1 - e/E)^p
 
-    where ``E`` is the total number of epochs (``T_max`` or ``total_epochs``)
-    and ``p`` controls the curvature.
+def get_tau(cfg: dict, epoch: int, total_epochs: Optional[int] = None) -> float:
+    """Polynomial temperature decay.
+
+    The schedule is defined as::
+
+        τ(e) = τ_end + (τ_start - τ_end) · (1 - e/E)^p
+
+    Parameters
+    ----------
+    cfg : dict
+        Must provide ``tau_start``. If ``tau_end`` or ``tau_decay_power`` are
+        missing the temperature remains fixed.
+    epoch : int
+        Current epoch index (0-based).
+    total_epochs : int, optional
+        Length ``E`` of the schedule. If omitted, ``cfg['T_max']`` then
+        ``cfg['total_epochs']`` are consulted. If none are present ``E = 1`` and
+        decay is disabled.
     """
 
     tau_start = float(cfg.get("tau_start", 4.0))
-    tau_end = float(cfg.get("tau_end", tau_start))  # decay off if missing
+    tau_end = float(cfg.get("tau_end", tau_start))
     power = float(cfg.get("tau_decay_power", 1.0))
-    total_ep = max(1, cfg.get("T_max", cfg.get("total_epochs", 1)))
-    prog = min(epoch / total_ep, 1.0)
-    return tau_end + (tau_start - tau_end) * (1.0 - prog) ** power
+
+    if total_epochs is None:
+        total_epochs = int(cfg.get("T_max", cfg.get("total_epochs", 1)))
+    total_epochs = max(total_epochs, 1)
+
+    progress = min(epoch / total_epochs, 1.0)
+    return tau_end + (tau_start - tau_end) * (1.0 - progress) ** power
 
 
 def get_beta(cfg: dict, epoch: int = 0) -> float:


### PR DESCRIPTION
## Summary
- add `total_epochs` arg to `get_tau` for polynomial temperature decay
- adjust trainer modules and ASMB methods to pass total training epochs to `get_tau`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883586f66448321b301b7d8afd300f3