### PR TITLE
Refactor student registry and clean up adapters

### DIFF
--- a/configs/model/student/resnet152_pretrain.yaml
+++ b/configs/model/student/resnet152_pretrain.yaml
@@ -2,7 +2,7 @@
 
 model:
   student:
-    name: resnet152_adapter
+    name: resnet152
     pretrained: true
     lr: 8e-4
     weight_decay: 8e-4

--- a/configs/model/student/resnet152_scratch.yaml
+++ b/configs/model/student/resnet152_scratch.yaml
@@ -2,7 +2,7 @@
 
 model:
   student:
-    name: resnet152_adapter
+    name: resnet152
     pretrained: false
     lr: 5e-4
     weight_decay: 8e-4

--- a/models/common/adapter.py
+++ b/models/common/adapter.py
@@ -2,6 +2,7 @@
 
 import torch.nn as nn
 
+
 class BottleneckAdapter(nn.Module):
     """
     [Student-side] Partial-Freeze 단계에서 얼린 블록 바로 뒤에 삽입되는 어댑터.
@@ -22,13 +23,13 @@ class BottleneckAdapter(nn.Module):
     def forward(self, x):
         # DEBUG
         # print(f"[BottleneckAdapter] in  shape={tuple(x.shape)}")
-        if x.dim() > 2:                # (N,C,H,W) -> (N,C)
+        if x.dim() > 2:  # (N,C,H,W) -> (N,C)
             x = x.flatten(1)
             # print(f"[BottleneckAdapter] GAP/flatten -> {tuple(x.shape)}")
         out = self.adapter(x)
         # print(f"[BottleneckAdapter] out shape={tuple(out.shape)}")
         #
-        return x + out                 # residual
+        return x + out  # residual
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +41,7 @@ class ChannelAdapter2D(nn.Module):
     def __init__(self, in_ch: int, out_ch: int | None = None, groups: int = 32):
         super().__init__()
         out_ch = in_ch if out_ch is None else out_ch
-        gn = min(groups, out_ch)   # groups ≤ channels
+        gn = min(groups, out_ch)  # groups ≤ channels
         self.net = nn.Sequential(
             nn.Conv2d(in_ch, out_ch, 1, bias=False),
             nn.GroupNorm(gn, out_ch),
@@ -52,11 +53,9 @@ class ChannelAdapter2D(nn.Module):
     def forward(self, x):
         return x + self.net(x)
 
-
-# ---------------------------------------------------------------------------
-# Bottleneck MLP Adapter (2D tokens)
-# ---------------------------------------------------------------------------
-class BottleneckMLP(nn.Module):
+    # ---------------------------------------------------------------------------
+    # Bottleneck MLP Adapter (2D tokens)
+    # ---------------------------------------------------------------------------
     """Linear-ReLU-Linear bottleneck with residual."""
 
     def __init__(self, dim: int, r: int = 4):
@@ -89,32 +88,3 @@ class TokenAdapter1D(nn.Module):
 
     def forward(self, x):
         return x + self.proj(x)
-
-# ────────────────────────────────────────────────────────────────
-#  Teacher-side   DistillationAdapter  (기존 teachers/adapters.py)
-# ────────────────────────────────────────────────────────────────
-class DistillationAdapter(nn.Module):
-    """[Teacher]  학생 feature dim에 맞추는 작은 MLP.
-    `cfg['train_distill_adapter_only']` 때만 업데이트 됩니다."""
-
-    def __init__(self, in_dim: int,
-                 hidden_dim: int | None = None,
-                 out_dim: int | None = None,
-                 cfg: dict | None = None):
-        super().__init__()
-        cfg = cfg or {}
-        hidden_dim = cfg.get("distill_hidden_dim", hidden_dim or in_dim // 2)
-        out_dim    = cfg.get("distill_out_dim",    out_dim  or in_dim // 4)
-
-        self.proj = nn.Sequential(
-            nn.Linear(in_dim, hidden_dim),
-            nn.ReLU(inplace=True),
-            nn.Linear(hidden_dim, out_dim),
-        )
-        self.out_dim = out_dim
-
-    def forward(self, x):
-        if x.dim() > 2:                       # (N,C,H,W) → (N,C)
-            x = x.flatten(1)
-        return self.proj(x)
-

--- a/models/students/resnet152_student.py
+++ b/models/students/resnet152_student.py
@@ -1,128 +1,63 @@
-# models/students/resnet152_student.py
+"""
+ResNet-152 student with Channel-Adapter after layer3 (registry v2).
+"""
 
 import torch
 import torch.nn as nn
 from torchvision.models import resnet152, ResNet152_Weights
 
-class ExtendedAdapterResNet152(nn.Module):
-    """
-    ResNet152 + Adapter (layer3 뒤 etc.)
-    => forward(x,y=None)->(feature_dict, logit, ce_loss)
-    feature_dict:
-      {
-        "feat_4d": [N, 1024(or 2048?), H, W]  # adapter 이후 최종 feature
-        "feat_2d": [N, ???],                # global pool
-        "feat_4d_layer1": [N, C1, H1, W1],  # layer1 출력
-        "feat_4d_layer2": [N, C2, H2, W2],  # layer2 출력
-        "feat_4d_layer3": [N, C3, H3, W3],  # layer3 출력
-      }
-    """
-    def __init__(self, base_model):
-        super().__init__()
-        self.backbone = base_model
-        self.criterion_ce = nn.CrossEntropyLoss()
-        self.feat_dim = 2048
-
-        # 기존 resnet structure references
-        self.conv1   = self.backbone.conv1
-        self.bn1     = self.backbone.bn1
-        self.relu    = self.backbone.relu
-        self.maxpool = self.backbone.maxpool
-        self.layer1  = self.backbone.layer1
-        self.layer2  = self.backbone.layer2
-        self.layer3  = self.backbone.layer3
-        self.layer4  = self.backbone.layer4
-        self.avgpool = self.backbone.avgpool
-        self.fc      = self.backbone.fc
-
-        # adapter
-        self.adapter_conv1 = nn.Conv2d(1024, 512, kernel_size=1, bias=False)
-        self.adapter_gn1   = nn.GroupNorm(32, 512)
-        self.adapter_conv2 = nn.Conv2d(512, 512, kernel_size=1, bias=False)
-        self.adapter_gn2   = nn.GroupNorm(32, 512)
-        self.adapter_conv3 = nn.Conv2d(512, 1024, kernel_size=1, bias=False)
-        self.adapter_gn3   = nn.GroupNorm(32, 1024)
-        self.adapter_relu  = nn.ReLU(inplace=True)
-
-    def get_feat_dim(self) -> int:
-        """Return the dimension of the 2D feature (feat_2d)."""
-        return self.feat_dim
-
-    def forward(self, x, y=None):
-        # 1) stem
-        x = self.conv1(x)
-        x = self.bn1(x)
-        x = self.relu(x)
-        x = self.maxpool(x)
-
-        # 2) layer1,2,3
-        x = self.layer1(x)
-        feat_layer1 = x
-        x = self.layer2(x)
-        feat_layer2 = x
-        x = self.layer3(x)
-        feat_layer3 = x
-
-        # 3) adapter
-        xa = self.adapter_conv1(x)
-        xa = self.adapter_gn1(xa)
-        xa = self.adapter_relu(xa)
-        xa = self.adapter_conv2(xa)
-        xa = self.adapter_gn2(xa)
-        xa = self.adapter_relu(xa)
-        xa = self.adapter_conv3(xa)
-        xa = self.adapter_gn3(xa)
-
-        x = x + xa
-        x = self.adapter_relu(x)  # => shape: [N, 1024, H, W]
-
-        # 4) layer4
-        f4 = self.layer4(x)  # [N,2048,H',W']
-
-        # 5) global pool => flatten => fc => logit
-        gp   = self.avgpool(f4)     # [N,2048,1,1]
-        feat_2d = torch.flatten(gp, 1)  # [N,2048]
-        logit   = self.fc(feat_2d)      # [N,100]
-
-        # optional CE
-        ce_loss = None
-        if y is not None:
-            ce_loss = self.criterion_ce(logit, y)
-
-        # dict
-        # adapter output x => 4D(1024) or final f4 => 4D(2048), 취사선택
-        # 여기서는 "feat_4d"=adapter 마지막 => f4
-        feature_dict = {
-            "feat_4d": f4,         # [N,2048,H',W']
-            "feat_2d": feat_2d,    # [N,2048]
-            # intermediate features for KD baselines
-            "feat_4d_layer1": feat_layer1,
-            "feat_4d_layer2": feat_layer2,
-            "feat_4d_layer3": feat_layer3,
-        }
-        return feature_dict, logit, ce_loss
+from models.common.base_wrapper import BaseKDModel, register
+from models.common.adapter import ChannelAdapter2D
 
 
-def create_resnet152_with_extended_adapter(
-    pretrained: bool = True,
-    num_classes: int = 100,
-    small_input: bool = False,
-):
-    """
-    ResNet152 load => last FC => 100
-    => ExtendedAdapterResNet152 => (dict, logit, ce_loss)
-    """
-    if pretrained:
-        base = resnet152(weights=ResNet152_Weights.IMAGENET1K_V2)
-    else:
-        base = resnet152(weights=None)
+@register("resnet152_student")
+class ResNet152Student(BaseKDModel):
+    def __init__(
+        self,
+        *,
+        pretrained: bool = True,
+        num_classes: int = 100,
+        small_input: bool = False,
+        cfg: dict | None = None,
+    ):
+        backbone = resnet152(
+            weights=ResNet152_Weights.IMAGENET1K_V2 if pretrained else None
+        )
+        if small_input:
+            backbone.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+            backbone.maxpool = nn.Identity()
 
-    if small_input:
-        base.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
-        base.maxpool = nn.Identity()
+        super().__init__(backbone, num_classes, role="student", cfg=cfg or {})
 
-    num_ftrs = base.fc.in_features
-    base.fc = nn.Linear(num_ftrs, num_classes)
+        ch = backbone.layer3[-1].conv3.out_channels  # 1024
+        self.adapter = ChannelAdapter2D(ch)
 
-    model = ExtendedAdapterResNet152(base)
-    return model
+    # ------------------------------------------------------------
+    def extract_feats(self, x):
+        b = self.backbone
+        x = b.relu(b.bn1(b.conv1(x)))
+        x = b.maxpool(x)
+        x = b.layer1(x)
+        x = b.layer2(x)
+        x = self.adapter(b.layer3(x))
+        f4d = b.layer4(x)
+        f2d = torch.flatten(b.avgpool(f4d), 1)
+        return f4d, f2d
+
+
+# legacy registry key for backward compatibility
+from models.common.base_wrapper import MODEL_REGISTRY
+
+MODEL_REGISTRY["resnet152_adapter_student"] = ResNet152Student
+
+
+def create_resnet152_with_extended_adapter(*a, **kw):
+    """Backward compatibility wrapper."""
+    import warnings
+
+    warnings.warn(
+        "renamed → models.students.resnet152_student.ResNet152Student",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return ResNet152Student(*a, **kw)

--- a/models/students/swin_student.py
+++ b/models/students/swin_student.py
@@ -4,6 +4,10 @@ import torch.nn as nn
 import timm
 from typing import Optional
 
+from models.common.base_wrapper import register
+
+
+@register("swin_student")
 class SwinStudent(nn.Module):
     """
     Example Student model:
@@ -12,8 +16,15 @@ class SwinStudent(nn.Module):
       3) final fc => logit
       => returns (feature_dict, logit, ce_loss)
     """
-    def __init__(self, pretrained=True, adapter_dim=64, num_classes=100,
-                 small_input: bool = False, cfg: Optional[dict] = None):
+
+    def __init__(
+        self,
+        pretrained=True,
+        adapter_dim=64,
+        num_classes=100,
+        small_input: bool = False,
+        cfg: Optional[dict] = None,
+    ):
         if cfg is not None:
             adapter_dim = cfg.get("swin_adapter_dim", adapter_dim)
         super().__init__()
@@ -26,7 +37,7 @@ class SwinStudent(nn.Module):
             pretrained=pretrained,
             img_size=img_sz,
         )
-        
+
         # 2) remove default classifier => (N, in_features)
         in_features = self.swin.head.in_features
         self.swin.head = nn.Identity()
@@ -57,7 +68,7 @@ class SwinStudent(nn.Module):
         # 1) base Swin => 2D embedding
         feat_2d = self.swin(x)  # shape: [N, in_features]
 
-        # (만약 swin forward_features(...) => 4D를 보고 싶다면, 
+        # (만약 swin forward_features(...) => 4D를 보고 싶다면,
         #  teacher_swin 처럼 f4d = self.swin.forward_features(x)을 활용)
 
         # 2) adapter residual
@@ -83,14 +94,22 @@ class SwinStudent(nn.Module):
 
 def create_swin_adapter_student(*a, **kw):
     import warnings
+
     warnings.warn(
         "renamed → models.students.swin_student.SwinStudent",
-        DeprecationWarning, stacklevel=2,
+        DeprecationWarning,
+        stacklevel=2,
     )
     return SwinStudent(*a, **kw)
 
-def create_swin_student(pretrained=True, adapter_dim=64, num_classes=100,
-                        small_input: bool = False, cfg: Optional[dict] = None):
+
+def create_swin_student(
+    pretrained=True,
+    adapter_dim=64,
+    num_classes=100,
+    small_input: bool = False,
+    cfg: Optional[dict] = None,
+):
     if cfg is not None:
         adapter_dim = cfg.get("swin_adapter_dim", adapter_dim)
     """Creates the Student Swin model w/ adapter."""

--- a/models/teachers/resnet_teacher.py
+++ b/models/teachers/resnet_teacher.py
@@ -3,16 +3,22 @@
 import torch
 import torch.nn as nn
 from models.common.base_wrapper import BaseKDModel, register
-from models.common.adapter import ChannelAdapter2D
 
 import torchvision.models as tv
+
 
 @register("resnet101_teacher")
 class ResNet101Teacher(BaseKDModel):
     """ResNet-101 Teacher with optional distillation adapter."""
 
-    def __init__(self, *, pretrained: bool = True, num_classes: int = 100,
-                 small_input: bool = False, cfg: dict | None = None):
+    def __init__(
+        self,
+        *,
+        pretrained: bool = True,
+        num_classes: int = 100,
+        small_input: bool = False,
+        cfg: dict | None = None,
+    ):
         backbone = tv.resnet101(
             weights=tv.ResNet101_Weights.IMAGENET1K_V2 if pretrained else None
         )
@@ -37,8 +43,14 @@ class ResNet101Teacher(BaseKDModel):
 class ResNet152Teacher(BaseKDModel):
     """ResNet-152 Teacher with optional distillation adapter."""
 
-    def __init__(self, *, pretrained: bool = True, num_classes: int = 100,
-                 small_input: bool = False, cfg: dict | None = None):
+    def __init__(
+        self,
+        *,
+        pretrained: bool = True,
+        num_classes: int = 100,
+        small_input: bool = False,
+        cfg: dict | None = None,
+    ):
         backbone = tv.resnet152(
             weights=tv.ResNet152_Weights.IMAGENET1K_V2 if pretrained else None
         )
@@ -59,12 +71,23 @@ class ResNet152Teacher(BaseKDModel):
         return f4d, f2d
 
 
-def create_resnet101(num_classes: int = 100, pretrained: bool = True,
-                     small_input: bool = False, cfg: dict | None = None):
-    return ResNet101Teacher(pretrained=pretrained, num_classes=num_classes,
-                            small_input=small_input, cfg=cfg)
+def create_resnet101(
+    num_classes: int = 100,
+    pretrained: bool = True,
+    small_input: bool = False,
+    cfg: dict | None = None,
+):
+    return ResNet101Teacher(
+        pretrained=pretrained, num_classes=num_classes, small_input=small_input, cfg=cfg
+    )
 
-def create_resnet152(num_classes: int = 100, pretrained: bool = True,
-                     small_input: bool = False, cfg: dict | None = None):
-    return ResNet152Teacher(pretrained=pretrained, num_classes=num_classes,
-                            small_input=small_input, cfg=cfg)
+
+def create_resnet152(
+    num_classes: int = 100,
+    pretrained: bool = True,
+    small_input: bool = False,
+    cfg: dict | None = None,
+):
+    return ResNet152Teacher(
+        pretrained=pretrained, num_classes=num_classes, small_input=small_input, cfg=cfg
+    )

--- a/quick_check.py
+++ b/quick_check.py
@@ -1,0 +1,12 @@
+import torch, importlib
+from models.common.base_wrapper import MODEL_REGISTRY
+
+x = torch.rand(2, 3, 32, 32)
+for name, cls in MODEL_REGISTRY.items():
+    try:
+        m = cls(pretrained=False, num_classes=10, small_input=True, cfg={})
+        m.eval()
+        m(x)
+        print(f"[OK] {name}")
+    except Exception as e:
+        print(f"[FAIL] {name}: {e}")


### PR DESCRIPTION
## Summary
- modernize `resnet152_student` to use `BaseKDModel` and add registry key
- register `swin_student`
- build students via registry in `main.py`
- drop unused `DistillationAdapter` class
- remove unused imports from teachers
- update configs to use new student key
- add `quick_check.py` utility

## Testing
- `ruff format models/students/resnet152_student.py models/students/swin_student.py main.py models/common/adapter.py models/teachers/resnet_teacher.py quick_check.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bac694548321a847907696d862a7