### PR TITLE
Rename resnet teacher module

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Folder Structure
 │   ├── students/
 │   │   └── resnet101_student.py
 │   └── teachers/
-│       ├── resnet_teacher.py
+│       ├── resnet152_teacher.py
 │       └── efficientnet_l2_teacher.py
 
 ├── modules/

--- a/eval.py
+++ b/eval.py
@@ -19,7 +19,7 @@ from main import create_student_by_name
 
 # Teacher Factory
 # Import the three teacher creation functions:
-from models.teachers.resnet_teacher import create_resnet152
+from models.teachers.resnet152_teacher import create_resnet152
 
 def create_teacher_by_name(
     teacher_name,

--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -1,4 +1,4 @@
-# models/teachers/resnet_teacher.py
+# models/teachers/resnet152_teacher.py
 
 import torch
 import torch.nn as nn
@@ -7,7 +7,7 @@ from models.common.base_wrapper import BaseKDModel, register
 import torchvision.models as tv
 
 
-@register("resnet_teacher")  # single entry
+@register("resnet152_teacher")  # single entry
 class ResNet152Teacher(BaseKDModel):
     """ResNet-152 Teacher with optional distillation adapter."""
 
@@ -49,6 +49,7 @@ def create_resnet152(
         pretrained=pretrained, num_classes=num_classes, small_input=small_input, cfg=cfg
     )
 
-# previous key kept for backward compatibility
-from models.common.base_wrapper import MODEL_REGISTRY
-MODEL_REGISTRY["resnet152_teacher"] = ResNet152Teacher
+# (For backward compatibility, you may keep the alias below. Remove the
+# commented lines if you don't need it.)
+# from models.common.base_wrapper import MODEL_REGISTRY
+# MODEL_REGISTRY["resnet_teacher"] = ResNet152Teacher

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -31,7 +31,7 @@ from data.cifar100 import get_cifar100_loaders
 from data.imagenet32 import get_imagenet32_loaders
 
 # teacher factories
-from models.teachers.resnet_teacher import create_resnet152
+from models.teachers.resnet152_teacher import create_resnet152
 
 # partial freeze
 from modules.partial_freeze import (


### PR DESCRIPTION
## Summary
- rename `resnet_teacher.py` to `resnet152_teacher.py`
- update registry key to `resnet152_teacher`
- adjust imports in eval and fine tuning scripts
- update README path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846376b0348321be4888ce7a4aa0bf