### PR TITLE
Simplify MBM implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python main.py cl=split_cifar
 `--cl_mode 1` 활성화 후 `--num_tasks` 값을 지정하면 별도의 CL 전용 YAML 없이 연속 학습을 수행할 수 있습니다.
 
 ## 주요 config 플래그
-* `mbm_type` : **mlp | ib_mbm**
+* `mbm_type` (ignored) : always uses **ib_mbm**
 * `use_ib`   : true / false  (IB ablation)
 * `ib_beta_warmup_epochs` : ramp-up epochs for the IB KL weight
 * `cl_mode`  : true → CL 활성화
@@ -197,7 +197,7 @@ Baseline runs (e.g., `vanilla_kd`) produce their own logs such as `VanillaKD => 
 1) Multi-Stage Distillation (main.py)
 
 python main.py --config-name base \
-  device=cuda mbm_type=ib_mbm mbm_r=4 mbm_n_head=1 mbm_learnable_q=1
+  device=cuda mbm_r=4 mbm_n_head=1 mbm_learnable_q=1
   # Freeze levels are defined in the model YAMLs under configs/model/
   # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
         •       Adjust model settings in `configs/model/*` or pass Hydra overrides.
@@ -250,7 +250,7 @@ python eval.py +eval_mode=synergy \
   +head_ckpt=synergy_head.pth \
   +student_type=resnet \
   +student_ckpt=student.pth \
-  +mbm_type=ib_mbm +mbm_r=4 +mbm_n_head=1 +mbm_learnable_q=1
+  +mbm_r=4 +mbm_n_head=1 +mbm_learnable_q=1
   # mbm_query_dim and mbm_out_dim are automatically set to the student feature dimension
 
 	•	Prints Train/Test accuracy, optionally logs to CSV if configured.

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -51,7 +51,7 @@ wandb:
 #  ※ 코드( main.py, trainer_*.py ) 는 중첩 dict 대신 **flat key** 를 조회합니다.
 #    그래서 기존 `mbm:` 블록을 없애고 flat alias 로 교체합니다.
 
-# 모듈 종류  ('la', 'ib_mbm', 'mlp')
+# 모듈 종류 (고정: ib_mbm)
 mbm_type: ib_mbm
 
 # IB 옵션

--- a/eval.py
+++ b/eval.py
@@ -119,7 +119,7 @@ def main(cfg: DictConfig):
     logger = ExperimentLogger(cfg, exp_name="eval_experiment")
     logger.update_metric("use_amp", cfg.get("use_amp", False))
     logger.update_metric("amp_dtype", cfg.get("amp_dtype", "float16"))
-    logger.update_metric("mbm_type", cfg.get("mbm_type", "MLP"))
+    logger.update_metric("mbm_type", "ib_mbm")
     logger.update_metric("mbm_r", cfg.get("mbm_r"))
     logger.update_metric("mbm_n_head", cfg.get("mbm_n_head"))
     logger.update_metric("mbm_learnable_q", cfg.get("mbm_learnable_q"))

--- a/main.py
+++ b/main.py
@@ -315,7 +315,7 @@ def main(cfg: DictConfig):
     exp_logger = ExperimentLogger(cfg, exp_name="asmb_experiment")
     exp_logger.update_metric("use_amp", cfg.get("use_amp", False))
     exp_logger.update_metric("amp_dtype", cfg.get("amp_dtype", "float16"))
-    exp_logger.update_metric("mbm_type", cfg.get("mbm_type", "MLP"))
+    exp_logger.update_metric("mbm_type", "ib_mbm")
     exp_logger.update_metric("mbm_r", cfg.get("mbm_r"))
     exp_logger.update_metric("mbm_n_head", cfg.get("mbm_n_head"))
     exp_logger.update_metric("mbm_learnable_q", cfg.get("mbm_learnable_q"))
@@ -628,25 +628,6 @@ def main(cfg: DictConfig):
                 f"[Auto-cfg] mbm_out_dim 조정: {cfg['mbm_out_dim']} → {cfg['mbm_query_dim']}"
             )
             cfg["mbm_out_dim"] = cfg["mbm_query_dim"]
-
-    # Validate or infer MBM query dimension
-    mbm_query_dim = cfg.get("mbm_query_dim", 0)
-    if cfg.get("mbm_type", "MLP") == "LA":
-        if mbm_query_dim <= 0:
-            if feat_dim is not None:
-                mbm_query_dim = feat_dim
-                cfg["mbm_query_dim"] = mbm_query_dim
-                print(
-                    f"[Info] mbm_query_dim not specified; using student feature dimension {mbm_query_dim}"
-                )
-            else:
-                print(
-                    "[Warning] Student model does not expose get_feat_dim(); please set mbm_query_dim manually"
-                )
-        elif feat_dim is not None and mbm_query_dim != feat_dim:
-            raise ValueError(
-                f"mbm_query_dim ({mbm_query_dim}) does not match the student feature dimension ({feat_dim})."
-            )
 
     # 6) MBM and synergy head
     mbm_query_dim = cfg.get("mbm_query_dim")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,12 +1,10 @@
 from .mbm import (
-    ManifoldBridgingModule,
     SynergyHead,
     IB_MBM,
     build_from_teachers,
 )
 
 __all__ = [
-    "ManifoldBridgingModule",
     "SynergyHead",
     "IB_MBM",
     "build_from_teachers",

--- a/tests/test_ib_mbm.py
+++ b/tests/test_ib_mbm.py
@@ -114,7 +114,6 @@ class DummyTeacher(torch.nn.Module):
 def test_build_from_teachers_distill_dim(use_da):
     teacher = DummyTeacher()
     cfg = {
-        "mbm_type": "ib_mbm",
         "mbm_query_dim": 16,
         "mbm_out_dim": 8,
         "use_distillation_adapter": use_da,

--- a/tests/test_synergy_head_num_classes.py
+++ b/tests/test_synergy_head_num_classes.py
@@ -28,7 +28,7 @@ def get_loader(num_classes):
 @pytest.mark.parametrize("n_cls", [3, 7])
 def test_synergy_head_output_matches_dataset_class_count(n_cls):
     loader = get_loader(n_cls)
-    cfg = {"mbm_out_dim": 8}
+    cfg = {"mbm_out_dim": 8, "mbm_query_dim": 4}
     # mimic logic in main.py/eval.py
     num_classes = len(loader.dataset.classes)
     cfg["num_classes"] = num_classes


### PR DESCRIPTION
## Summary
- remove legacy ManifoldBridgingModule and unused imports
- make `build_from_teachers` always return `IB_MBM`
- adjust training utilities for IB-MBM only
- update tests and documentation

## Testing
- `ruff check models/mbm.py models/__init__.py modules/trainer_student.py modules/trainer_teacher.py tests/test_distillation_adapter_usage.py tests/test_ib_mbm.py tests/test_synergy_head_num_classes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884672beadc832186334bbe498b0915