### PR TITLE
Update teacher registry and feature KD loss

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -61,8 +61,8 @@ beta_schedule: [0.0, 0.01, 5]     # 0→0.01 로 5 epoch linear warm‑up
 
 # 차원 설정
 mbm_query_dim: 2048               # student feat dim (ResNet‑152)
-mbm_d_emb: 512                    # ★ 내부 embedding 크기 변경 (256→512)
 mbm_out_dim: 2048                  # synergy‑head 입력 dim (= d_emb)
+## IB-MBM options: keep mbm_query_dim, mbm_out_dim, ib_beta
 
 # ---------- Distillation Adapter 기본 ----------
 use_distillation_adapter: false

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,3 +9,6 @@ __all__ = [
     "IB_MBM",
     "build_from_teachers",
 ]
+
+from models.common.base_wrapper import MODEL_REGISTRY
+MODEL_REGISTRY.pop("resnet152_student", None)

--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch.nn as nn
-from models.common.base_wrapper import BaseKDModel, register
+from models.common.base_wrapper import BaseKDModel, register, MODEL_REGISTRY
 
 import torchvision.models as tv
 
@@ -49,7 +49,5 @@ def create_resnet152(
         pretrained=pretrained, num_classes=num_classes, small_input=small_input, cfg=cfg
     )
 
-# (For backward compatibility, you may keep the alias below. Remove the
-# commented lines if you don't need it.)
-# from models.common.base_wrapper import MODEL_REGISTRY
-# MODEL_REGISTRY["resnet_teacher"] = ResNet152Teacher
+# backward compatibility
+MODEL_REGISTRY["resnet_teacher"] = ResNet152Teacher

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -193,21 +193,11 @@ def student_distillation_update(
             ce_loss_val = (weights * ce_vec).mean()
             kd_loss_val = (weights * kd_vec).mean()
 
-            # ——— Feature-KD (MSE) ———
+            # --- μ‑MSE with certainty weight ---------------------------------
             feat_kd_val = torch.tensor(0.0, device=cfg["device"])
             if cfg.get("feat_kd_alpha", 0) > 0:
-                key = cfg.get("feat_kd_key", "feat_2d")
-                s_feat = feat_dict[key]
-                fsyn_use = fsyn
-                if fsyn_use.dim() == 4 and s_feat.dim() == 2:
-                    fsyn_use = torch.nn.functional.adaptive_avg_pool2d(
-                        fsyn_use, (1, 1)
-                    ).flatten(1)
-                feat_kd_val = feat_mse_loss(
-                    s_feat,
-                    fsyn_use,
-                    norm=cfg.get("feat_kd_norm", "none"),
-                )
+                diff = (s_feat - mu).pow(2).sum(dim=1)   # ‖zs - μφ‖²
+                feat_kd_val = (cw * diff).mean()
 
             loss = (
                 cfg["ce_alpha"] * ce_loss_val

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -197,10 +197,9 @@ def teacher_adaptive_update(
 
                 feat_kd_loss = torch.tensor(0.0, device=cfg["device"])
                 if cfg.get("feat_kd_alpha", 0) > 0:
-                    feat_kd_loss = feat_mse_loss(
-                        s_feat, fsyn,
-                        norm=cfg.get("feat_kd_norm", "none")
-                    )
+                    diff = (s_feat - mu).pow(2).sum(dim=1)
+                    cw   = certainty_weights(logvar).mean(dim=1).to(s_feat.dtype)
+                    feat_kd_loss = (cw * diff).mean()
 
                 # ---- (1) 전체 손실 구성 ----
                 kd_weight = cfg.get("teacher_adapt_alpha_kd",


### PR DESCRIPTION
## Summary
- import MODEL_REGISTRY in teacher wrapper and register legacy key
- drop unused mbm_d_emb option and document remaining MBM config keys
- add safety pop of removed student model
- weight feature distillation by certainty for both trainer loops

## Testing
- `pytest -q`
- `python -m models.mbm` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68846c2c70148321bc5290bacf4f71ce