### PR TITLE
Apply debug gating and improve dataset handling

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -35,6 +35,9 @@ log:
 disable_tqdm: false
 log_all_hparams: true
 
+# ---- Debugging -----------------------------------------------
+debug_verbose: false        # set true to enable verbose debug prints
+
 # ---------- Checkpoint ----------
 save_checkpoint: true
 ckpt_dir: "./checkpoints"

--- a/data/imagenet32.py
+++ b/data/imagenet32.py
@@ -29,17 +29,23 @@ class ImageNet32(Dataset):
                 entry = pickle.load(f, encoding="latin1")
             self.data.append(entry["data"])
             self.labels += entry["labels"]
-        self.data = np.vstack(self.data).reshape(-1, 3, 32, 32)
+        # ------------------------------- #
+        #  • data  : [N, 3, 32, 32] uint8
+        #  • labels: 0-based int64
+        #  • classes: List[int] (for len(...))
+        # ------------------------------- #
+        self.data   = np.vstack(self.data).reshape(-1, 3, 32, 32)
+        self.labels = (np.array(self.labels, dtype=np.int64) - 1)
+        self.classes = list(range(self.labels.max() + 1))
 
     def __len__(self):
         return self.data.shape[0]
 
     def __getitem__(self, idx):
-        img = torch.tensor(self.data[idx], dtype=torch.uint8)
-        img = img.float() / 255.0
-        if self.transform:
-            img = self.transform(img)
-        target = self.labels[idx] - 1
+        img = torch.tensor(self.data[idx], dtype=torch.uint8).float().div_(255.0)
+        if self.transform is not None:
+            img = self.transform(img)          # e.g. RandomFlip + ToTensor etc.
+        target = int(self.labels[idx])         # already 0-based
         return img, target
 
 

--- a/eval.py
+++ b/eval.py
@@ -140,7 +140,12 @@ def main(cfg: DictConfig):
     small_input = cfg.get("small_input")
     if small_input is None:
         small_input = dataset_name == "cifar100"
-    n_classes = len(train_loader.dataset.classes)
+    n_classes = getattr(train_loader.dataset, "classes", None)
+    if n_classes is None:
+        n_classes = getattr(train_loader.dataset, "num_classes", None)
+    if n_classes is None:
+        raise AttributeError("Dataset must expose `classes` or `num_classes`")
+    n_classes = len(n_classes) if not isinstance(n_classes, int) else n_classes
     cfg["num_classes"] = n_classes
     logger.update_metric("num_classes", n_classes)
 

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -159,7 +159,7 @@ def student_distillation_update(
                 ).sum(dim=1)
 
                 # ---- DEBUG: 첫 batch 모양 확인 ----
-                if ep == 0 and step == 0:
+                if ep == 0 and step == 0 and cfg.get("debug_verbose", False):
                     print(
                         "[DBG/student] x",
                         tuple(x.shape),
@@ -218,7 +218,8 @@ def student_distillation_update(
                 scaler.update()
             else:
                 loss.backward()
-                print(f"[StudentDistill] batch loss={loss.item():.4f}")
+                if cfg.get("debug_verbose", False):
+                    print(f"[StudentDistill] batch loss={loss.item():.4f}")
                 if cfg.get("grad_clip_norm", 0) > 0:
                     torch.nn.utils.clip_grad_norm_(
                         student_model.parameters(), cfg["grad_clip_norm"]

--- a/modules/trainer_teacher.py
+++ b/modules/trainer_teacher.py
@@ -171,7 +171,7 @@ def teacher_adaptive_update(
                     ).sum(dim=1)
 
                     # ---- DEBUG: 첫 batch 모양 확인 ----
-                    if ep == 0 and step == 0:
+                    if ep == 0 and step == 0 and cfg.get("debug_verbose", False):
                         print(
                             "[DBG/teacher] t1_logit",
                             tuple(t1_dict["logit"].shape),


### PR DESCRIPTION
## Summary
- document debug flag in `configs/base.yaml`
- fix ImageNet32 loader labels and expose `classes`
- gate debug prints in training utilities and main entry
- support dataset class inference fallback in `main.py` and `eval.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847013c4748321b85b5a3307df4b3f