### PR TITLE
Apply CL config fix and cleanup debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ mkdir checkpoints
 wget -O checkpoints/resnet152_ft.pth <링크>
 wget -O checkpoints/efficientnet_l2_ft.pth <링크>  # optional EfficientNet-L2
 ```
-5. **Run a single experiment**:
+5. **Set dataset and W&B paths (optional)**:
+```bash
+export DATA_ROOT=/path/to/datasets
+export WANDB_ENTITY=my_entity
+export WANDB_PROJECT=my_project
+```
+6. **Run a single experiment**:
 ```bash
 python main.py --config-name experiment/res152_effi_l2  # EfficientNet-L2 teacher
 ```

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -45,8 +45,8 @@ ckpt_dir: "./checkpoints"
 # ---------- W&B ----------
 wandb:
   use: false
-  entity: "kakamy0820-yonsei-university"
-  project: "kd_monitor"
+  entity: ${env:WANDB_ENTITY}
+  project: ${env:WANDB_PROJECT}
   run_name: ""              # 비우면 exp_id 사용
   api_key: ""               # "" → wandb login 로드
 

--- a/data/cifar100.py
+++ b/data/cifar100.py
@@ -1,6 +1,7 @@
 # data/cifar100.py
 
 import torch
+import os
 import torchvision
 import torchvision.transforms as T
 
@@ -31,6 +32,7 @@ def get_cifar100_loaders(root="./data", batch_size=128, num_workers=2, augment=T
                     (0.2673,0.2564,0.2762))
     ])
 
+    root = root or os.getenv("DATA_ROOT", "./data")
     train_dataset = torchvision.datasets.CIFAR100(
         root=root,
         train=True,

--- a/data/cifar100_overlap.py
+++ b/data/cifar100_overlap.py
@@ -4,6 +4,7 @@ import random
 import torch
 import torchvision.transforms as T
 from torchvision.datasets import CIFAR100
+import os
 
 __all__ = ["get_overlap_loaders"]
 
@@ -25,7 +26,7 @@ def _split_classes(pct_overlap, seed=42):
     return classes_A, classes_B
 
 
-def _make_loader(class_ids, train, batch_size, num_workers, augment):
+def _make_loader(class_ids, train, batch_size, num_workers, augment, root):
     tr = [
         T.RandomCrop(32, 4),
         T.RandomHorizontalFlip(),
@@ -35,7 +36,7 @@ def _make_loader(class_ids, train, batch_size, num_workers, augment):
         T.ToTensor(),
         T.Normalize((0.5071, 0.4865, 0.4409), (0.2673, 0.2564, 0.2762)),
     ]
-    ds = CIFAR100(root="./data", train=train, download=True, transform=T.Compose(tr))
+    ds = CIFAR100(root=root, train=train, download=True, transform=T.Compose(tr))
     idx = [i for i, (_, y) in enumerate(ds) if y in class_ids]
     sub = torch.utils.data.Subset(ds, idx)
     return torch.utils.data.DataLoader(
@@ -47,11 +48,12 @@ def _make_loader(class_ids, train, batch_size, num_workers, augment):
     )
 
 
-def get_overlap_loaders(pct_overlap=0, batch_size=128, num_workers=2, augment=True, seed=42):
+def get_overlap_loaders(pct_overlap=0, batch_size=128, num_workers=2, augment=True, seed=42, root=None):
     """Return loaders for two class subsets with given overlap."""
+    root = root or os.getenv("DATA_ROOT", "./data")
     cls_A, cls_B = _split_classes(pct_overlap, seed)
-    A_tr = _make_loader(cls_A, True, batch_size, num_workers, augment)
-    A_te = _make_loader(cls_A, False, batch_size, num_workers, False)
-    B_tr = _make_loader(cls_B, True, batch_size, num_workers, augment)
-    B_te = _make_loader(cls_B, False, batch_size, num_workers, False)
+    A_tr = _make_loader(cls_A, True, batch_size, num_workers, augment, root)
+    A_te = _make_loader(cls_A, False, batch_size, num_workers, False, root)
+    B_tr = _make_loader(cls_B, True, batch_size, num_workers, augment, root)
+    B_te = _make_loader(cls_B, False, batch_size, num_workers, False, root)
     return (A_tr, A_te), (B_tr, B_te), set(cls_A) & set(cls_B)

--- a/data/imagenet32.py
+++ b/data/imagenet32.py
@@ -6,13 +6,15 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms
+from utils.data_utils import ClassInfoMixin
 
-class ImageNet32(Dataset):
+class ImageNet32(ClassInfoMixin, Dataset):
     """
     Downsampled ImageNet-32x32 (Chrabaszcz et al.)
     – train_data_batch_{1..10}, valid_data, test_data  (Pickle)
     """
     def __init__(self, root, split="train", transform=None):
+        root = root or os.getenv("DATA_ROOT", "./data")
         assert split in ("train", "val", "test")
         self.split, self.transform = split, transform
 

--- a/eval.py
+++ b/eval.py
@@ -42,6 +42,7 @@ def create_teacher_by_name(
             num_classes=num_classes,
             pretrained=pretrained,
             small_input=small_input,
+            dropout_p=cfg.get("efficientnet_dropout"),
             cfg=cfg,
         )
     else:

--- a/models/mbm.py
+++ b/models/mbm.py
@@ -18,6 +18,8 @@ class IB_MBM(nn.Module):
         logvar_clip: float = 10.0,
         min_std: float = 1e-4,
     ):
+        if d_emb % n_head != 0:
+            raise ValueError("d_emb must be divisible by n_head")
         super().__init__()
         self.q_proj = nn.Linear(q_dim, d_emb)
         self.kv_proj = nn.Linear(kv_dim, d_emb)

--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -1,6 +1,7 @@
 # modules/partial_freeze.py
 
 import torch.nn as nn
+import logging
 
 from utils.freeze import apply_bn_ln_policy, freeze_all, unfreeze_by_regex
 
@@ -101,7 +102,7 @@ def partial_freeze_teacher_resnet(
 
     if train_distill_adapter_only:
         # distillation_adapter 만 학습
-        print("[Freeze] unfreeze distillation_adapter (teacher-side)")
+        logging.debug("[Freeze] unfreeze distillation_adapter (teacher-side)")
         unfreeze_by_regex(model, r"\.distillation_adapter\.")
         apply_bn_ln_policy(model, train_bn=not freeze_bn)
         return
@@ -127,7 +128,7 @@ def partial_freeze_teacher_resnet(
 
     if use_adapter:
         patterns.append(r"\.distillation_adapter\.")
-        print("[partial_freeze_teacher_*] unfreeze distillation_adapter")
+        logging.debug("[partial_freeze_teacher_*] unfreeze distillation_adapter")
 
     unfreeze_by_regex(model, patterns)
 
@@ -155,7 +156,7 @@ def partial_freeze_teacher_efficientnet(
 
     if train_distill_adapter_only:
         # distillation_adapter 만 학습
-        print("[Freeze] unfreeze distillation_adapter (teacher-side)")
+        logging.debug("[Freeze] unfreeze distillation_adapter (teacher-side)")
         unfreeze_by_regex(model, r"\.distillation_adapter\.")
         apply_bn_ln_policy(model, train_bn=not freeze_bn)
         return
@@ -205,7 +206,7 @@ def partial_freeze_teacher_swin(
 
     if train_distill_adapter_only:
         # distillation_adapter 만 학습
-        print("[Freeze] unfreeze distillation_adapter (teacher-side)")
+        logging.debug("[Freeze] unfreeze distillation_adapter (teacher-side)")
         unfreeze_by_regex(model, r"\.distillation_adapter\.")
         apply_bn_ln_policy(model, train_ln=not freeze_ln)
         return

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -6,6 +6,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import torch
+import logging
 import hydra
 from omegaconf import DictConfig, OmegaConf
 from utils.misc import set_random_seed, check_label_range, get_model_num_classes
@@ -88,8 +89,11 @@ def main(cfg: DictConfig):
         cfg["use_partial_freeze"] = False
     teacher_type = cfg.get("teacher_type", cfg.get("default_teacher_type"))
     student_type = cfg.get("student_type", "resnet")
-    print(
-        f">>> [run_single_teacher.py] method={method} teacher={teacher_type} student={student_type}"
+    logging.info(
+        ">>> [run_single_teacher.py] method=%s teacher=%s student=%s",
+        method,
+        teacher_type,
+        student_type,
     )
     device = cfg.get("device", "cuda")
     if device == "cuda" and not torch.cuda.is_available():
@@ -143,7 +147,7 @@ def main(cfg: DictConfig):
             torch.load(teacher_ckpt_path, map_location=device, weights_only=True),
             strict=False,
         )
-        print(f"[run_single_teacher.py] Loaded teacher from {teacher_ckpt_path}")
+        logging.info("[run_single_teacher.py] Loaded teacher from %s", teacher_ckpt_path)
     if cfg.get("use_partial_freeze", True):
         partial_freeze_teacher_auto(
             teacher,
@@ -188,7 +192,7 @@ def main(cfg: DictConfig):
     os.makedirs(ckpt_dir, exist_ok=True)
     ckpt = os.path.join(ckpt_dir, f"final_student_{method}.pth")
     torch.save(student.state_dict(), ckpt)
-    print(f"[run_single_teacher] final_acc={acc:.2f}% -> {ckpt}")
+    logging.info("[run_single_teacher] final_acc=%.2f%% -> %s", acc, ckpt)
 
 
 if __name__ == "__main__":

--- a/scripts/run_sweep.sh
+++ b/scripts/run_sweep.sh
@@ -23,8 +23,9 @@ conda activate tlqkf
 export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 # ---------- W&B 설정 ----------
-export WANDB_ENTITY="kakamy0820-yonsei-university"
-export WANDB_PROJECT="kd_monitor"
+# If not provided, use empty defaults
+export WANDB_ENTITY="${WANDB_ENTITY:-}"
+export WANDB_PROJECT="${WANDB_PROJECT:-}"
 # export WANDB_API_KEY="<원하면_직접_기입>"
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -42,3 +42,10 @@ def test_method_params_propagated():
     out = cu.flatten_hydra_config(dict(cfg))
     assert out["ce_alpha"] == 0.3
     assert out["kd_alpha"] == 0.7
+
+
+def test_cl_block_propagated():
+    cfg = {"cl": {"mode": "split", "num_tasks": 5}}
+    out = cu.flatten_hydra_config(dict(cfg))
+    assert out["cl_mode"] == "split"
+    assert out["num_tasks"] == 5

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -34,6 +34,14 @@ def flatten_hydra_config(cfg: dict) -> dict:
     cfg.setdefault("small_input", dataset.get("small_input"))
     cfg.setdefault("data_aug", dataset.get("data_aug"))
 
+    cl_cfg = cfg.get("cl", {})
+    if isinstance(cl_cfg, dict):
+        cfg.setdefault("cl_mode", cl_cfg.get("mode"))
+        cfg.setdefault("num_tasks", cl_cfg.get("num_tasks"))
+        cfg.setdefault("replay_ratio", cl_cfg.get("replay_ratio"))
+        cfg.setdefault("lambda_ewc", cl_cfg.get("lambda_ewc"))
+        cfg.setdefault("dataset_order_seed", cl_cfg.get("dataset_order_seed"))
+
     schedule = cfg.get("schedule", {})
     cfg.setdefault("lr_schedule", schedule.get("type"))
     cfg.setdefault("lr_warmup_epochs", schedule.get("lr_warmup_epochs"))

--- a/utils/data.py
+++ b/utils/data.py
@@ -2,6 +2,7 @@
 """Utility helpers for continual-learning datasets."""
 
 from typing import List, Tuple
+import os
 
 import torch
 from torchvision.datasets import CIFAR100
@@ -26,6 +27,7 @@ def get_split_cifar100_loaders(
     transform_train = T.Compose(transform_train)
     transform_test = T.Compose([T.ToTensor()])
 
+    root = root or os.getenv("DATA_ROOT", "./data")
     full_train = CIFAR100(root=root, train=True, download=True, transform=transform_train)
     full_test = CIFAR100(root=root, train=False, download=True, transform=transform_test)
 

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,0 +1,5 @@
+class ClassInfoMixin:
+    @property
+    def classes(self):
+        return list(range(self.num_classes))
+


### PR DESCRIPTION
## Summary
- flatten Hydra CL block to expose `cl_mode` and others
- guard MBM constructor against invalid head counts
- tidy debug print statements and use `logging` uniformly
- load EfficientNet dropout from config
- allow dataset root override via `DATA_ROOT`
- parameterize W&B entity/project via environment variables
- expose `ClassInfoMixin` for datasets
- update docs with environment variable guidance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688481ac4bd08321b99431f3c7e28f5a