### PR TITLE
Fix indentation for EfficientNet freeze helper

### DIFF
--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -142,8 +142,8 @@ def partial_freeze_teacher_efficientnet(
     bn_head_only: bool = False,
     freeze_level: int = 1,
     train_distill_adapter_only: bool = False,
-):
-"""Partially freeze an EfficientNet teacher using a numeric level.
+): 
+    """Partially freeze an EfficientNet teacher using a numeric level.
 
     ``freeze_all`` is called first and layers are unfrozen based on
     ``freeze_level``:


### PR DESCRIPTION
## Summary
- fix indentation in `partial_freeze_teacher_efficientnet`
- verify module compilation

## Testing
- `python -m py_compile modules/partial_freeze.py`

------
https://chatgpt.com/codex/tasks/task_e_68849dc297e483218ea9345fa10dbccf