### PR TITLE
Filter comments in setup dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ setup(
     name="asib_kd",
     version="0.2.0",
     packages=find_packages(),
-    install_requires=[line.strip() for line in open("requirements.txt")],
+    install_requires=[
+        ln.strip()
+        for ln in open("requirements.txt")
+        if ln.strip() and not ln.startswith("#")
+    ],
     python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- ignore blank and comment lines when collecting requirements in `setup.py`

## Testing
- `pip install -e .` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68849dc282ec8321a4ae5793f923ec31