### PR TITLE
Fix test imports path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import torch
 import pytest
 


### PR DESCRIPTION
## Summary
- update `tests/conftest.py` to prepend repo root to `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884a35adf248321a34fd451063c733c