### PR TITLE
Fix sys.path for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import torch
 import pytest
 


### PR DESCRIPTION
## Summary
- allow tests to import project modules regardless of cwd

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884a356ad488321b2e0c1f2feba0e1b