### PR TITLE
Fix MBM tuple unpacking

### DIFF
--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -91,10 +91,8 @@ class ASMBDistiller(nn.Module):
         s_feat = feat_dict[key]
 
         # 2) mbm => synergy with query if available
-        if self.la_mode:
-            syn_feat, _, _, _ = self.mbm(s_feat, feats_2d)
-        else:
-            syn_feat = self.mbm(s_feat, feats_2d)
+        # IB_MBM → (z, μ, logvar) 반환 → z만 사용
+        syn_feat, *_ = self.mbm(s_feat, feats_2d)
         zsyn = self.synergy_head(syn_feat)
 
         # CE
@@ -314,11 +312,11 @@ class ASMBDistiller(nn.Module):
 
                     # synergy
                     if self.la_mode:
-                        syn_feat, attn, _, _ = self.mbm(s_feat, f1)
+                        syn_feat, attn, *_ = self.mbm(s_feat, f1)
                         attn_flat = attn.squeeze(1)
                         _, _ = attn_flat[:, 0], attn_flat[:, 1]
                     else:
-                        syn_feat = self.mbm(s_feat, f1)
+                        syn_feat, *_ = self.mbm(s_feat, f1)
                         attn = None
                     zsyn = self.synergy_head(syn_feat)
 
@@ -479,11 +477,11 @@ class ASMBDistiller(nn.Module):
                     s_feat = feat_dict[self.config.get("feat_kd_key", "feat_2d")]
 
                 if self.la_mode:
-                    syn_feat, attn, _, _ = self.mbm(s_feat, f1)
+                    syn_feat, attn, *_ = self.mbm(s_feat, f1)
                     attn_flat = attn.squeeze(1)
                     w1, w2 = attn_flat[:, 0], attn_flat[:, 1]
                 else:
-                    syn_feat = self.mbm(s_feat, f1)
+                    syn_feat, *_ = self.mbm(s_feat, f1)
                     attn = None
                     w1, w2 = None, None
                 zsyn = self.synergy_head(syn_feat)


### PR DESCRIPTION
## Summary
- ensure only the first value from IB_MBM is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884ad70f1e083218f18fdb1bf601a6b