### PR TITLE
Update environment variable interpolation

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -45,8 +45,8 @@ ckpt_dir: "./checkpoints"
 # ---------- W&B ----------
 wandb:
   use: false
-  entity: ${env:WANDB_ENTITY}
-  project: ${env:WANDB_PROJECT}
+  entity: ${oc.env:WANDB_ENTITY}
+  project: ${oc.env:WANDB_PROJECT}
   run_name: ""              # 비우면 exp_id 사용
   api_key: ""               # "" → wandb login 로드
 


### PR DESCRIPTION
## Summary
- fix env var interpolation for Hydra 1.3/omegaconf 2.3 in `base.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884b4481ea48321ae9118cb82d428dd