### PR TITLE
Fix Hydra config when WANDB vars unset

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -45,8 +45,8 @@ ckpt_dir: "./checkpoints"
 # ---------- W&B ----------
 wandb:
   use: false
-  entity: ${oc.env:WANDB_ENTITY}
-  project: ${oc.env:WANDB_PROJECT}
+  entity: ${oc.env:WANDB_ENTITY, default=null}
+  project: ${oc.env:WANDB_PROJECT, default=null}
   run_name: ""              # 비우면 exp_id 사용
   api_key: ""               # "" → wandb login 로드
 


### PR DESCRIPTION
## Summary
- prevent runtime error if `WANDB_ENTITY` or `WANDB_PROJECT` env vars are missing by providing defaults in Hydra config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884b56398c88321b1bc1dd37ef45b6e