### PR TITLE
Fix setup requirements path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
+from pathlib import Path
 from setuptools import setup, find_packages
+
+req_path = Path(__file__).resolve().parent / "requirements.txt"
+with req_path.open() as f:
+    install_requires = [
+        ln.strip()
+        for ln in f
+        if ln.strip() and not ln.startswith("#")
+    ]
 
 setup(
     name="asib_kd",
     version="0.2.0",
     packages=find_packages(),
-    install_requires=[
-        ln.strip()
-        for ln in open("requirements.txt")
-        if ln.strip() and not ln.startswith("#")
-    ],
+    install_requires=install_requires,
     python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- resolve requirements path relative to `setup.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884b81ca2548321954b84a30f604fbc