### PR TITLE
Add logging imports

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 import hydra
 from omegaconf import DictConfig, OmegaConf
+import logging
 from utils.logging_utils import init_logger
 
 from data.cifar100 import get_cifar100_loaders

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -4,6 +4,7 @@ import copy
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import logging
 
 from modules.losses import (
     kd_loss_fn,

--- a/methods/at.py
+++ b/methods/at.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+import logging
 from typing import Optional
 from modules.losses import ce_loss_fn
 from utils.misc import get_amp_components

--- a/methods/crd.py
+++ b/methods/crd.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+import logging
 from typing import Optional
 from modules.losses import ce_loss_fn
 from utils.misc import get_amp_components

--- a/methods/dkd.py
+++ b/methods/dkd.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import logging
 from typing import Optional
 from modules.losses import ce_loss_fn, dkd_loss
 from utils.misc import get_amp_components

--- a/methods/fitnet.py
+++ b/methods/fitnet.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
+import logging
 from typing import Optional
 from modules.losses import ce_loss_fn
 from utils.misc import get_amp_components

--- a/methods/vanilla_kd.py
+++ b/methods/vanilla_kd.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import logging
 from typing import Optional
 
 from modules.losses import kd_loss_fn, ce_loss_fn


### PR DESCRIPTION
## Summary
- include `import logging` for modules that use logging calls
- confirm `ruff` reports no `F821` errors

## Testing
- `ruff check` *(fails: SyntaxError in analysis/plot_results.ipynb but shows no F821)*

------
https://chatgpt.com/codex/tasks/task_e_6884b81e1a2c832182eba228cd57dee0