### PR TITLE
Fix Hydra env resolver syntax for W&B settings

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -45,8 +45,8 @@ ckpt_dir: "./checkpoints"
 # ---------- W&B ----------
 wandb:
   use: false
-  entity: ${oc.env:WANDB_ENTITY, default=null}
-  project: ${oc.env:WANDB_PROJECT, default=null}
+  entity: ${oc.env:WANDB_ENTITY, null}
+  project: ${oc.env:WANDB_PROJECT, null}
   run_name: ""              # 비우면 exp_id 사용
   api_key: ""               # "" → wandb login 로드
 


### PR DESCRIPTION
## Summary
- fix Hydra env resolver syntax in `configs/base.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6884bbf7ac7c8321aa9dcebdcd17be62