### PR TITLE
Fix state_dict mismatch for ResNet teacher

### DIFF
--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -20,7 +20,8 @@ class ResNet152Teacher(BaseKDModel):
         cfg: dict | None = None,
     ):
         backbone = tv.resnet152(
-            weights=tv.ResNet152_Weights.IMAGENET1K_V2 if pretrained else None
+            weights=tv.ResNet152_Weights.IMAGENET1K_V2 if pretrained else None,
+            num_classes=num_classes,
         )
         if small_input:
             backbone.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)


### PR DESCRIPTION
## Summary
- align torchvision ResNet teacher fc with dataset class count

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884c2b692408321a6c8a3e4918aaaca