### PR TITLE
Fix resnet152 teacher initialization

### DIFF
--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -19,10 +19,8 @@ class ResNet152Teacher(BaseKDModel):
         small_input: bool = False,
         cfg: dict | None = None,
     ):
-        backbone = tv.resnet152(
-            weights=tv.ResNet152_Weights.IMAGENET1K_V2 if pretrained else None,
-            num_classes=num_classes,
-        )
+        weights = tv.ResNet152_Weights.IMAGENET1K_V2 if pretrained else None
+        backbone = tv.resnet152(weights=weights)
         if small_input:
             backbone.conv1 = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
             backbone.maxpool = nn.Identity()


### PR DESCRIPTION
## Summary
- avoid passing `num_classes` to torchvision's resnet152 when pretrained

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884c3aa2ac883219a5b2781cdd188d0