### PR TITLE
Fix config path in finetune helper script

### DIFF
--- a/run_finetune_clean.sh
+++ b/run_finetune_clean.sh
@@ -27,7 +27,7 @@ shift || true         # 나머지 인자 → Hydra override
 
 # 4) 실행
 python scripts/fine_tuning.py \
-    --config-path configs/finetune \
+    --config-path ../configs/finetune \
     --config-name "$CFG_NAME" \
     "$@"
 


### PR DESCRIPTION
## Summary
- fix Hydra config path in `run_finetune_clean.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884cd4a0b948321b06d9297c0415e6a