### PR TITLE
Add EfficientNet-L2 checkpointing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ efficientnet_dropout: 0.3  # dropout probability for EfficientNet teachers
 
 Set `efficientnet_dropout` to control the dropout rate used in EfficientNet
 teachers. The default value is **0.3**.
+Set `use_checkpointing: true` in `configs/model/teacher/efficientnet_l2.yaml`
+to activate gradient checkpointing for the EfficientNet teacher. This reduces
+GPU memory usage at the cost of a slower runtime.
 
 #### Fine-tuning a Teacher
 

--- a/configs/model/teacher/efficientnet_l2.yaml
+++ b/configs/model/teacher/efficientnet_l2.yaml
@@ -1,0 +1,11 @@
+# configs/model/teacher/efficientnet_l2.yaml
+model:
+  teacher:
+    name: efficientnet_l2
+    pretrained: true
+    lr: 1e-4
+    weight_decay: 1e-4
+    freeze_level: 0
+    freeze_bn: false
+    use_adapter: false
+    use_checkpointing: false

--- a/eval.py
+++ b/eval.py
@@ -45,6 +45,7 @@ def create_teacher_by_name(
             pretrained=pretrained,
             small_input=small_input,
             dropout_p=cfg.get("efficientnet_dropout"),
+            use_checkpointing=cfg.get("teacher_use_checkpointing", False),
             cfg=cfg,
         )
     else:

--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ def create_teacher_by_name(
             pretrained=pretrained,
             small_input=small_input,
             dropout_p=cfg.get("efficientnet_dropout"),
+            use_checkpointing=cfg.get("teacher_use_checkpointing", False),
             cfg=cfg,
         )
     elif teacher_name in ("convnext_l", "convnext_large"):

--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -26,6 +26,7 @@ def create_efficientnet_l2(
     pretrained: bool = True,
     small_input: bool = False,
     dropout_p: float = 0.4,
+    use_checkpointing: bool = False,
     cfg: Optional[dict] = None,
 ):
     """Create an EfficientNet-L2 (Noisy Student) teacher via timm."""
@@ -36,6 +37,10 @@ def create_efficientnet_l2(
         num_classes=num_classes,
         drop_rate=dropout_p,
     )
+
+    if use_checkpointing:
+        from timm.models.layers import checkpoint_seq
+        backbone.blocks = checkpoint_seq(backbone.blocks)
 
     if small_input:
         stem = backbone.conv_stem

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -93,6 +93,7 @@ def create_teacher_by_name(
             pretrained=pretrained,
             small_input=small_input,
             dropout_p=dropout_p if dropout_p is not None else 0.3,
+            use_checkpointing=cfg.get("teacher_use_checkpointing", False),
             cfg=cfg,
         )
     else:

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -65,6 +65,7 @@ def flatten_hydra_config(cfg: dict) -> dict:
     cfg.setdefault("teacher_freeze_ln", teacher.get("freeze_ln"))
     cfg.setdefault("teacher_use_adapter", teacher.get("use_adapter"))
     cfg.setdefault("teacher_bn_head_only", teacher.get("bn_head_only"))
+    cfg.setdefault("teacher_use_checkpointing", teacher.get("use_checkpointing"))
 
     student = model.get("student", {})
     if isinstance(student, dict) and "model" in student:


### PR DESCRIPTION
## Summary
- support gradient checkpointing in `create_efficientnet_l2`
- propagate `teacher_use_checkpointing` from Hydra configs
- expose option in `configs/model/teacher/efficientnet_l2.yaml`
- document memory/runtime trade-off in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884d8f73d1083218854f8e6115a1153