### PR TITLE
Document EfficientNet-L2 batch size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,12 @@ efficientnet_dropout: 0.3  # dropout probability for EfficientNet teachers
 ```
 
 Set `efficientnet_dropout` to control the dropout rate used in EfficientNet
+
 teachers. The default value is **0.3**.
+
+#### EfficientNet-L2 Batch Size
+
+EfficientNet-L2 requires more memory than ResNet teachers. A 96-image batch from `configs/dataset/cifar100.yaml` can exhaust a 24 GB GPU. Begin fine-tuning with around **32** images per batch and increase only if your card allows.
 
 #### Fine-tuning a Teacher
 

--- a/configs/finetune/efficientnet_l2_cifar32.yaml
+++ b/configs/finetune/efficientnet_l2_cifar32.yaml
@@ -6,6 +6,7 @@ defaults:
 
 teacher_type: efficientnet_l2
 small_input: true
+# Recommended batch sizes for EfficientNet-L2 are noted in README.md
 teacher_pretrained: true
 teacher_ckpt_init: null
 

--- a/configs/finetune/resnet152_cifar32.yaml
+++ b/configs/finetune/resnet152_cifar32.yaml
@@ -3,11 +3,13 @@
 # 32×32 CIFAR-100용 ResNet-152 fine-tune
 defaults:
   - ../dataset/cifar100      # 작은 입력용 dataloader (small_input: true)
+# See README.md section "EfficientNet-L2 Batch Size" for GPU memory tips
   - _self_
 
 # ── 모델(교사-1) ───────────────────────────────
 teacher_type: resnet152
 small_input: true            # 3×3 conv, stride1 (+maxpool 제거)
+# See README.md section "EfficientNet-L2 Batch Size" for GPU memory tips
 teacher_pretrained: true     # ImageNet-1k 가중치 로드
 teacher_ckpt_init: null      # 이어-학습할 ckpt가 있으면 경로 지정
 


### PR DESCRIPTION
## Summary
- mention that EfficientNet-L2 needs a small batch size
- link the recommendation from fine-tuning configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884d8f7a138832198467275551ce3c5