### PR TITLE
Automatically set CUDA expandable segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 
   | Student model                | Feature dim |
   |------------------------------|-------------|
-  | `resnet101_student`            | 2048        |
+-  | `resnet101_student`            | 2048        |
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
+- **Expandable CUDA Segments**: training scripts set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` when CUDA is available
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when
   fine-tuning or evaluating models that modify the conv stem for 32x32 inputs
   (and remove max-pool for ResNet)
@@ -138,6 +139,7 @@ export CONDA_ENV=asmb
 | `WANDB_ENTITY`| Weights & Biases entity name      |
 | `WANDB_PROJECT`| W&B project name                 |
 | `CONDA_ENV`   | Conda environment name           |
+| `PYTORCH_CUDA_ALLOC_CONF` | Set automatically to `expandable_segments:True` when using CUDA |
 
 6. **Run a single experiment**:
 ```bash

--- a/main.py
+++ b/main.py
@@ -333,9 +333,14 @@ def main(cfg: DictConfig):
         wandb.run.summary["overlap_pct"] = cfg_overlap
 
     device = cfg.get("device", "cuda")
-    if device == "cuda" and not torch.cuda.is_available():
-        logging.warning("No CUDA => Using CPU")
-        device = "cpu"
+    if device == "cuda":
+        if torch.cuda.is_available():
+            os.environ.setdefault(
+                "PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"
+            )
+        else:
+            logging.warning("No CUDA => Using CPU")
+            device = "cpu"
 
     # fix seed
     seed = cfg.get("seed", 42)

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -198,9 +198,14 @@ def main(cfg: DictConfig):
     cfg = flatten_hydra_config(cfg)
     init_logger(cfg.get("log_level", "INFO"))
     device = cfg.get("device", "cuda")
-    if device == "cuda" and not torch.cuda.is_available():
-        logging.warning("[FineTune] No CUDA => Using CPU")
-        device = "cpu"
+    if device == "cuda":
+        if torch.cuda.is_available():
+            os.environ.setdefault(
+                "PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"
+            )
+        else:
+            logging.warning("[FineTune] No CUDA => Using CPU")
+            device = "cpu"
 
     seed = cfg.get("seed", 42)
     deterministic = cfg.get("deterministic", True)

--- a/scripts/run_single_teacher.py
+++ b/scripts/run_single_teacher.py
@@ -96,8 +96,13 @@ def main(cfg: DictConfig):
         student_type,
     )
     device = cfg.get("device", "cuda")
-    if device == "cuda" and not torch.cuda.is_available():
-        device = "cpu"
+    if device == "cuda":
+        if torch.cuda.is_available():
+            os.environ.setdefault(
+                "PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"
+            )
+        else:
+            device = "cpu"
 
     set_random_seed(cfg.get("seed", 42))
 

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -110,8 +110,13 @@ def main(cfg: DictConfig):
     init_logger(cfg.get("log_level", "INFO"))
 
     device = cfg.get("device", "cuda")
-    if device == "cuda" and not torch.cuda.is_available():
-        device = "cpu"
+    if device == "cuda":
+        if torch.cuda.is_available():
+            os.environ.setdefault(
+                "PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"
+            )
+        else:
+            device = "cpu"
     set_random_seed(cfg.get("seed", 42))
 
     dataset = cfg.get("dataset_name", "cifar100")


### PR DESCRIPTION
## Summary
- enable `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` when CUDA is available in training scripts
- document this behaviour in the feature list and environment variables table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.2.0+cpu torchvision==0.17.0+cpu -f https://download.pytorch.org/whl/torch_stable.html` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6884d8f7073883218f41a03701dc38ec