### PR TITLE
Update teacher checkpointing and reduce batch size

### DIFF
--- a/configs/dataset/cifar100.yaml
+++ b/configs/dataset/cifar100.yaml
@@ -5,5 +5,5 @@ dataset:
   root: "./data"
   small_input: true       # 32×32
   data_aug: 1             # 0: no aug, 1: 기본 + RandAug
-batch_size: 32
+batch_size: 16
 num_workers: 2

--- a/configs/finetune/efficientnet_l2_cifar32.yaml
+++ b/configs/finetune/efficientnet_l2_cifar32.yaml
@@ -9,6 +9,7 @@ small_input: true
 # Recommended batch sizes for EfficientNet-L2 are noted in README.md
 teacher_pretrained: true
 teacher_ckpt_init: null
+teacher_use_checkpointing: true
 
 finetune_epochs: 10
 finetune_lr: 3e-4


### PR DESCRIPTION
## Summary
- enable teacher checkpointing for EfficientNet-L2 fine-tuning
- lower CIFAR100 batch size to 16

## Testing
- `python scripts/fine_tuning.py --config-name finetune/efficientnet_l2_cifar32` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884df518a588321974d0f8b3658d70c