### PR TITLE
Fix install_requires parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with req_path.open() as f:
     install_requires = [
         ln.strip()
         for ln in f
-        if ln.strip() and not ln.startswith("#")
+        if ln.strip() and not ln.startswith(("#", "-e", "--"))
     ]
 
 setup(


### PR DESCRIPTION
## Summary
- update `setup.py` to filter lines starting with `-e` and `--`

## Testing
- `pip install --no-deps --no-build-isolation .` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_6884df466fa08321a7a02c315fd48323