### PR TITLE
Fix ImageNet32 tensor creation

### DIFF
--- a/data/imagenet32.py
+++ b/data/imagenet32.py
@@ -44,7 +44,7 @@ class ImageNet32(ClassInfoMixin, Dataset):
         return self.data.shape[0]
 
     def __getitem__(self, idx):
-        img = torch.tensor(self.data[idx], dtype=torch.uint8).float().div_(255.0)
+        img = torch.from_numpy(self.data[idx]).float().div_(255.0)
         if self.transform is not None:
             img = self.transform(img)          # e.g. RandomFlip + ToTensor etc.
         target = int(self.labels[idx])         # already 0-based

--- a/tests/test_imagenet32.py
+++ b/tests/test_imagenet32.py
@@ -1,0 +1,17 @@
+import pickle
+import numpy as np
+import torch
+from data.imagenet32 import ImageNet32
+
+
+def test_imagenet32_getitem(tmp_path):
+    data = np.random.randint(0, 256, size=(1, 3, 32, 32), dtype=np.uint8)
+    labels = [1]
+    entry = {"data": data, "labels": labels}
+    with open(tmp_path / "val_data", "wb") as f:
+        pickle.dump(entry, f)
+    ds = ImageNet32(str(tmp_path), split="val", transform=None)
+    img, target = ds[0]
+    assert img.shape == (3, 32, 32)
+    assert img.dtype == torch.float32
+    assert target == 0


### PR DESCRIPTION
## Summary
- use `torch.from_numpy` instead of `torch.tensor` in `ImageNet32.__getitem__`
- add a unit test ensuring returned image tensors are float32 with shape `(3,32,32)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884df463d40832181c339cc0f818476