### PR TITLE
Fix import path for timm checkpoint_seq

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -39,7 +39,7 @@ def create_efficientnet_l2(
     )
 
     if use_checkpointing:
-        from timm.models.layers import checkpoint_seq
+        from timm.layers import checkpoint_seq
         backbone.blocks = checkpoint_seq(backbone.blocks)
 
     if small_input:


### PR DESCRIPTION
## Summary
- fix incorrect import path for `checkpoint_seq` when using EfficientNet-L2 teachers

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884e37126dc832183a25080f36cfd2f