### PR TITLE
Fix fallback import for EfficientNet L2 teacher

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -39,7 +39,10 @@ def create_efficientnet_l2(
     )
 
     if use_checkpointing:
-        from timm.layers import checkpoint_seq
+        try:
+            from timm.layers import checkpoint_seq
+        except ImportError:  # older timm versions
+            from timm.utils import checkpoint_seq
         backbone.blocks = checkpoint_seq(backbone.blocks)
 
     if small_input:


### PR DESCRIPTION
## Summary
- resolve ImportError when timm's `checkpoint_seq` is not exported from `timm.layers`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884e4fb2580832180d03759ae29c1ed