### PR TITLE
Fix gradient checkpoint fallback

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -57,9 +57,12 @@ def create_efficientnet_l2(
                 continue
 
         if checkpoint_seq is None:
-            raise ImportError(
-                "Unable to import 'checkpoint_seq' from timm; please upgrade timm"
-            )
+            try:
+                from torch.utils.checkpoint import checkpoint_sequential as checkpoint_seq
+            except Exception as e:  # noqa: BLE001
+                raise ImportError(
+                    "Unable to import 'checkpoint_seq' from timm or torch; please upgrade dependencies"
+                ) from e
 
         backbone.blocks = checkpoint_seq(backbone.blocks)
 


### PR DESCRIPTION
## Summary
- fall back to torch checkpoint utilities when `checkpoint_seq` missing in timm

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884f0dd93188321bb785e936c68de2d