### PR TITLE
Update checkpoint_seq import

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -39,27 +39,11 @@ def create_efficientnet_l2(
     )
 
     if use_checkpointing:
-        import importlib
-
-        checkpoint_seq = None
-        for module_path in (
-            "timm.layers",
-            "timm.utils",
-            "timm.utils.checkpoint",
-        ):
-            try:
-                checkpoint_seq = getattr(
-                    importlib.import_module(module_path),
-                    "checkpoint_seq",
-                )
-                break
-            except (ImportError, AttributeError):
-                continue
-
-        if checkpoint_seq is None:
-            raise ImportError(
-                "Unable to import 'checkpoint_seq' from timm; please upgrade timm"
-            )
+        try:
+            from timm.layers import checkpoint_seq  # timm >= 1.0
+        except ImportError:
+            # timm 0.9.x fallback
+            from timm.models._factory import checkpoint_seq
 
         backbone.blocks = checkpoint_seq(backbone.blocks)
 

--- a/tests/test_efficientnet_l2_checkpoint.py
+++ b/tests/test_efficientnet_l2_checkpoint.py
@@ -22,46 +22,20 @@ def setup_timm(monkeypatch, modules):
 def test_import_from_layers(monkeypatch):
     layers = types.ModuleType("timm.layers")
     layers.checkpoint_seq = lambda x: "layers"
-    modules = {"timm.layers": layers, "timm.utils": types.ModuleType("timm.utils")}
-    setup_timm(monkeypatch, modules)
+    setup_timm(monkeypatch, {"timm.layers": layers})
     teacher = create_efficientnet_l2(use_checkpointing=True)
     assert teacher.backbone.blocks == "layers"
 
 
-def test_import_from_utils(monkeypatch):
-    layers = types.ModuleType("timm.layers")
-    utils = types.ModuleType("timm.utils")
-    utils.checkpoint_seq = lambda x: "utils"
-    modules = {"timm.layers": layers, "timm.utils": utils}
-    setup_timm(monkeypatch, modules)
+def test_import_from_factory(monkeypatch):
+    factory = types.ModuleType("timm.models._factory")
+    factory.checkpoint_seq = lambda x: "factory"
+    setup_timm(monkeypatch, {"timm.models._factory": factory})
     teacher = create_efficientnet_l2(use_checkpointing=True)
-    assert teacher.backbone.blocks == "utils"
-
-
-def test_import_from_utils_checkpoint(monkeypatch):
-    layers = types.ModuleType("timm.layers")
-    utils = types.ModuleType("timm.utils")
-    utils_checkpoint = types.ModuleType("timm.utils.checkpoint")
-    utils_checkpoint.checkpoint_seq = lambda x: "checkpoint"
-    modules = {
-        "timm.layers": layers,
-        "timm.utils": utils,
-        "timm.utils.checkpoint": utils_checkpoint,
-    }
-    setup_timm(monkeypatch, modules)
-    teacher = create_efficientnet_l2(use_checkpointing=True)
-    assert teacher.backbone.blocks == "checkpoint"
+    assert teacher.backbone.blocks == "factory"
 
 
 def test_import_error(monkeypatch):
-    layers = types.ModuleType("timm.layers")
-    utils = types.ModuleType("timm.utils")
-    utils_checkpoint = types.ModuleType("timm.utils.checkpoint")
-    modules = {
-        "timm.layers": layers,
-        "timm.utils": utils,
-        "timm.utils.checkpoint": utils_checkpoint,
-    }
-    setup_timm(monkeypatch, modules)
+    setup_timm(monkeypatch, {})
     with pytest.raises(ImportError):
         create_efficientnet_l2(use_checkpointing=True)


### PR DESCRIPTION
## Summary
- import checkpoint_seq from `timm.layers` when available
- update fallback to `timm.models._factory`
- adjust tests for the new import logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884f3b3aef48321841be80106a6fe54