### PR TITLE
Fix efficientnet teacher checkpoint import

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -39,27 +39,14 @@ def create_efficientnet_l2(
     )
 
     if use_checkpointing:
-        import importlib
-
-        checkpoint_seq = None
-        for module_path in (
-            "timm.layers",
-            "timm.utils",
-            "timm.utils.checkpoint",
-        ):
-            try:
-                checkpoint_seq = getattr(
-                    importlib.import_module(module_path),
-                    "checkpoint_seq",
-                )
-                break
-            except (ImportError, AttributeError):
-                continue
-
-        if checkpoint_seq is None:
-            raise ImportError(
-                "Unable to import 'checkpoint_seq' from timm; please upgrade timm"
-            )
+        # ------------------------------------------------------------------
+        # timm ≥1.0 ⇒  ``checkpoint_seq`` is located under ``timm.layers``.
+        # timm 0.9.x ⇒  fallback to ``timm.models._factory``.
+        # ------------------------------------------------------------------
+        try:
+            from timm.layers import checkpoint_seq  # timm >= 1.0
+        except ImportError:  # timm 0.9 fallback
+            from timm.models._factory import checkpoint_seq
 
         backbone.blocks = checkpoint_seq(backbone.blocks)
 


### PR DESCRIPTION
## Summary
- prefer `timm.layers.checkpoint_seq` for checkpointing
- keep backwards compatibility with timm 0.9 fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884f3b3aef48321841be80106a6fe54