### PR TITLE
Fix checkpoint_seq import comment

### DIFF
--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -39,10 +39,13 @@ def create_efficientnet_l2(
     )
 
     if use_checkpointing:
+        # ------------------------------------------------------------------
+        # timm ≥1.0  →  checkpoint_seq 가 timm.layers 로 이동
+        # timm 0.9.x →  timm.models._factory 에 존재
+        # ------------------------------------------------------------------
         try:
-            from timm.layers import checkpoint_seq  # timm >= 1.0
-        except ImportError:
-            # timm 0.9.x fallback
+            from timm.layers import checkpoint_seq  # timm ≥1.0
+        except ImportError:  # timm 0.9 fallback
             from timm.models._factory import checkpoint_seq
 
         backbone.blocks = checkpoint_seq(backbone.blocks)


### PR DESCRIPTION
## Summary
- add clarifying comments around `checkpoint_seq` import in EfficientNet teacher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6884f63a38a883219f68231e26ba76b3