### PR TITLE
Add ResNet152 student model and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ This repository provides an **Adaptive Synergy Manifold Bridging (ASMB)** multi-
 
   | Student model                | Feature dim |
   |------------------------------|-------------|
+-  | `resnet50_student`             | 2048        |
 -  | `resnet101_student`            | 2048        |
+-  | `resnet152_student`            | 2048        |
 - **Smart Progress Bars**: progress bars hide automatically when stdout isn't a TTY
 - **Expandable CUDA Segments**: training scripts set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` when CUDA is available
 - **CIFAR-friendly ResNet/EfficientNet stem**: use `--small_input 1` when

--- a/configs/model/student/resnet101_pretrain.yaml
+++ b/configs/model/student/resnet101_pretrain.yaml
@@ -1,0 +1,11 @@
+# configs/model/student/resnet101_pretrain.yaml
+
+model:
+  student:
+    name: resnet101
+    pretrained: true
+    lr: 8e-4
+    weight_decay: 8e-4
+    freeze_level: 1
+    freeze_bn: false
+    use_adapter: true

--- a/configs/model/student/resnet101_scratch.yaml
+++ b/configs/model/student/resnet101_scratch.yaml
@@ -1,0 +1,11 @@
+# configs/model/student/resnet101_scratch.yaml
+
+model:
+  student:
+    name: resnet101
+    pretrained: false
+    lr: 8e-4
+    weight_decay: 8e-4
+    freeze_level: 1
+    freeze_bn: false
+    use_adapter: true

--- a/configs/model/student/resnet50_pretrain.yaml
+++ b/configs/model/student/resnet50_pretrain.yaml
@@ -1,0 +1,11 @@
+# configs/model/student/resnet50_pretrain.yaml
+
+model:
+  student:
+    name: resnet50
+    pretrained: true
+    lr: 8e-4
+    weight_decay: 8e-4
+    freeze_level: 1         # head + layer4
+    freeze_bn: false
+    use_adapter: true

--- a/configs/model/student/resnet50_scratch.yaml
+++ b/configs/model/student/resnet50_scratch.yaml
@@ -1,0 +1,11 @@
+# configs/model/student/resnet50_scratch.yaml
+
+model:
+  student:
+    name: resnet50
+    pretrained: false
+    lr: 8e-4
+    weight_decay: 8e-4
+    freeze_level: 1         # head + layer4
+    freeze_bn: false
+    use_adapter: true

--- a/main.py
+++ b/main.py
@@ -92,6 +92,15 @@ def create_student_by_name(
             cfg=cfg,
         )
 
+    elif student_name in ("resnet152", "resnet_152"):
+        return build_model(
+            "resnet152_student",
+            pretrained=pretrained,
+            num_classes=num_classes,
+            small_input=small_input,
+            cfg=cfg,
+        )
+
     elif student_name in ("effb2", "efficientnet_b2"):
         return build_model(
             "efficientnet_b2_student",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -11,4 +11,3 @@ __all__ = [
 ]
 
 from models.common.base_wrapper import MODEL_REGISTRY
-MODEL_REGISTRY.pop("resnet152_student", None)

--- a/models/students/resnet152_student.py
+++ b/models/students/resnet152_student.py
@@ -1,0 +1,48 @@
+# models/students/resnet152_student.py
+"""ResNet‑152 학생 • layer3 이후 ChannelAdapter 추가"""
+
+import torch
+import torch.nn as nn
+from torchvision.models import resnet152, ResNet152_Weights
+
+from models.common.base_wrapper import BaseKDModel, register
+from models.common.adapter import ChannelAdapter2D
+
+
+@register("resnet152_student")
+class ResNet152Student(BaseKDModel):
+    """ResNet‑152 backbone + 1×1 Adapter + 학설용 classifier(fc)."""
+
+    def __init__(
+        self,
+        *,
+        num_classes: int = 100,
+        pretrained: bool = True,
+        small_input: bool = False,
+        cfg: dict | None = None,
+    ):
+        backbone = resnet152(
+            weights=ResNet152_Weights.IMAGENET1K_V2 if pretrained else None
+        )
+        if small_input:
+            # CIFAR‑size 입력 대응
+            backbone.conv1 = nn.Conv2d(3, 64, 3, 1, 1, bias=False)
+            backbone.maxpool = nn.Identity()
+
+        super().__init__(backbone, num_classes, role="student", cfg=cfg or {})
+
+        # ── ChannelAdapter : layer3 → layer4 사이 ───────────────
+        ch = backbone.layer3[-1].conv3.out_channels        # 1024
+        self.adapter = ChannelAdapter2D(ch)
+
+    # --------------------------------------------------------------
+    def extract_feats(self, x):
+        b = self.backbone
+        x = b.relu(b.bn1(b.conv1(x)))
+        x = b.maxpool(x)
+        x = b.layer1(x)
+        x = b.layer2(x)
+        x = self.adapter(b.layer3(x))      # <-- adapter 적용
+        f4d = b.layer4(x)
+        f2d = torch.flatten(b.avgpool(f4d), 1)
+        return f4d, f2d


### PR DESCRIPTION
## Summary
- add `resnet152_student` implementation
- expose ResNet-152 student in `create_student_by_name`
- keep registry entry for ResNet-152 student
- provide ResNet-50/101 YAML templates
- update README table with available student models

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885bb24cc9483219295d1b22d277e06