### PR TITLE
Add stage-wise freeze schedule for student

### DIFF
--- a/configs/model/student/resnet152_progfreeze.yaml
+++ b/configs/model/student/resnet152_progfreeze.yaml
@@ -1,0 +1,17 @@
+# configs/model/student/resnet152_progfreeze.yaml
+
+model:
+  student:
+    name: resnet152
+    pretrained: true      # ✔️  사전학습
+    lr: 8e-4
+    weight_decay: 8e-4
+    freeze_level: -1      # 초기값 (Stage‑0)
+    freeze_bn: false
+    use_adapter: true
+
+# ---------------- experiment overrides ----------------
+student_freeze_schedule: [-1, 2, 1, 0]    # Stage0~3
+student_epochs_schedule:  [20, 15, 15, 15]  # Stage0 더 길게
+num_stages: 4
+use_partial_freeze: true


### PR DESCRIPTION
## Summary
- support `student_freeze_schedule` and `student_epochs_schedule` for flexible stage training
- create example config `resnet152_progfreeze.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6885cd51eb6483219302ac6ba9022289