### PR TITLE
Update experiment defaults for student/teacher

### DIFF
--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -22,6 +22,17 @@ defaults:
 # ──────────────────────────────────────────────────────────
 #  추가 override (필요한 것만)
 # ──────────────────────────────────────────────────────────
+########################################
+# 필수 하이퍼파라미터 (main.py 의 KeyError 방지)
+########################################
+student_type:          resnet152     # ← 모델 매핑용
+student_lr:            8e-4          # ← optim.AdamW 에 사용
+student_weight_decay:  8e-4
+
+teacher_lr:            1e-4          # ← 두 교사 공통
+teacher_weight_decay:  1e-4
+
+########################################
 teacher1_ckpt: checkpoints/resnet152_cifar32.pth
 teacher2_ckpt: checkpoints/efficientnet_l2_cifar32.pth
 


### PR DESCRIPTION
## Summary
- add mandatory hyperparameters in `res152_effi_l2.yaml` for student and teacher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886169cd03883219082f525d2251a39