### PR TITLE
Set 32x32 input globally

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -30,6 +30,9 @@ teacher2_type: resnet152
 batch_size: 128            # dataset 그룹 값으로 덮어써도 됨
 num_workers: 4
 
+# 모든 모델(교사·학생)에서 32×32 입력 경로(conv1 3×3, max‑pool 제거) 사용
+small_input: true
+
 # ---------- Logging ----------
 log:
   filename: "train.log"

--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -26,6 +26,8 @@ defaults:
 # 필수 하이퍼파라미터 (main.py 의 KeyError 방지)
 ########################################
 student_type:          resnet152     # ← 모델 매핑용
+student_lr:            8e-4          # ← optim.AdamW 에 사용
+student_weight_decay:  8e-4
 teacher_lr:            1e-4          # ← 두 교사 공통
 teacher_weight_decay:  1e-4
 
@@ -33,8 +35,6 @@ teacher_weight_decay:  1e-4
 teacher1_ckpt: checkpoints/resnet152_cifar32.pth
 teacher2_ckpt: checkpoints/efficientnet_l2_cifar32.pth
 
-teacher1_small_input: true
-teacher2_small_input: true
 
 # ───────── Freeze / 스케줄 ─────────
 use_partial_freeze: true
@@ -42,8 +42,7 @@ use_partial_freeze: true
 num_stages: 4                         # freeze/epoch 스케줄 길이와 반드시 일치
 
 # Student (ResNet‑152 pre‑train)
-student_lr:            8e-4          # ← optim.AdamW 에 사용
-student_weight_decay:  8e-4
+# lr/weight_decay는 이미 위쪽 ‘필수 하이퍼파라미터’ 블록에 있으므로 중복 제거
 student_freeze_schedule:  [-1, 2, 1, 0]   # stage0~3
 student_epochs_schedule: [30, 15, 15, 15]
 student_freeze_bn:        false


### PR DESCRIPTION
## Summary
- configure `small_input: true` globally in `base.yaml`
- deduplicate hyperparameters in `res152_effi_l2.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68861ba0cf7483219bdeb001836be645