### PR TITLE
Fix Hydra config alias syntax

### DIFF
--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -6,17 +6,17 @@
 #  Student → ResNet‑152 (pre‑trained, freeze L4)
 #──────────────────────────────────────────────────────────
 defaults:
-  - /base                               # (공통 기본값)
-  - override /dataset: cifar100         # dataset 그룹
+  - base                                   # 공통 기본
+  - dataset=cifar100                       # 데이터셋
 
-  # ── 교사 두 명 (alias) ───────────────────────────────
-  - override /model/teacher@teacher1: resnet152
-  - override /model/teacher@teacher2: efficientnet_l2
+  # ── 교사 두 명 ───────────────────────────
+  - model/teacher@teacher1=resnet152
+  - model/teacher@teacher2=efficientnet_l2
 
-  # ── 학생, 방법, 스케줄 ───────────────────────────────
-  - override /model/student:  resnet152_pretrain
-  - override /method:         asmb
-  - override /schedule:       cosine
+  # ── 학생 · 방법 · 스케줄 ───────────────
+  - model/student=resnet152_pretrain
+  - method=asmb
+  - schedule=cosine
   - _self_
 
 # ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update the `res152_effi_l2.yaml` experiment config
  - remove misuse of `override`
  - simplify group selection with `=`, not `/`
  - add descriptive comments

## Testing
- `python main.py --config-name=res152_effi_l2` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688635b01d708321a17d1fd3a483288f