### PR TITLE
Fix Hydra config paths in res152_effi_l2

### DIFF
--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -6,17 +6,17 @@
 #  Student → ResNet‑152 (pre‑trained, freeze L4)
 #──────────────────────────────────────────────────────────
 defaults:
-  - ../base
-  - ../dataset/cifar100
+  - base
+  - dataset=cifar100
 
   # ── 교사 두 명 ───────────────────────────
-  - ../model/teacher@teacher1=resnet152
-  - ../model/teacher@teacher2=efficientnet_l2
+  - model/teacher@teacher1=resnet152
+  - model/teacher@teacher2=efficientnet_l2
 
   # ── 학생 · 방법 · 스케줄 ───────────────
-  - ../model/student=resnet152_pretrain
-  - ../method/asmb
-  - ../schedule/cosine
+  - model/student=resnet152_pretrain
+  - method=asmb
+  - schedule=cosine
   - _self_
 
 # ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix hydra config paths in experiment/res152_effi_l2

## Testing
- `pip install torch==2.2.1+cpu torchvision==0.17.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688639bfb0b483219ddc42d325b33bb9