### PR TITLE
Fix YAML config notation

### DIFF
--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -6,17 +6,17 @@
 #  Student → ResNet‑152 (pre‑trained, freeze L4)
 #──────────────────────────────────────────────────────────
 defaults:
-  - /base
-  - /dataset=cifar100
+  - /base                           # 공통 기본
+  - /dataset: cifar100              # ← colon 표기
 
   # ── 교사 두 명 (alias) ───────────────────
-  - /model/teacher@teacher1=resnet152
-  - /model/teacher@teacher2=efficientnet_l2
+  - /model/teacher@teacher1: resnet152
+  - /model/teacher@teacher2: efficientnet_l2
 
   # ── 학생 · 방법 · 스케줄 ───────────────
-  - /model/student=resnet152_pretrain
-  - /method=asmb
-  - /schedule=cosine
+  - /model/student: resnet152_pretrain
+  - /method: asmb
+  - /schedule: cosine
   - _self_
 
 # ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix colon notation for Hydra defaults in `res152_effi_l2.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68864dfb584083218d46acba9a9cba1d