### PR TITLE
Enable automatic module imports

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -11,3 +11,15 @@ __all__ = [
 ]
 
 from models.common.base_wrapper import MODEL_REGISTRY
+
+# --------------------------------------------------------------------
+#  모든 *teachers/*.py · *students/*.py 파일을 자동 import 해서
+#  파일 안에 @register("…") 데코레이터가 실행되도록 한다.
+# --------------------------------------------------------------------
+from importlib import import_module
+import pkgutil as _pkgutil
+
+# 현재 패키지(models)의 모든 하위 모듈 순회
+for _finder, _mod_name, _is_pkg in _pkgutil.walk_packages(__path__, prefix=__name__ + "."):
+    if ".teachers." in _mod_name or ".students." in _mod_name:
+        import_module(_mod_name)

--- a/models/teachers/__init__.py
+++ b/models/teachers/__init__.py
@@ -1,1 +1,13 @@
+# models/teachers/__init__.py
+
+# 직접 import 가 필요한 상황(IDE, 테스트 등)을 위해
+# 필요한 클래스만 재-export 해 둔다.
+
+from .resnet152_teacher import ResNet152Teacher  # noqa: F401
+from .efficientnet_l2_teacher import EfficientNetL2Teacher  # noqa: F401
+
+__all__ = [
+    "ResNet152Teacher",
+    "EfficientNetL2Teacher",
+]
 


### PR DESCRIPTION
## Summary
- add automatic discovery for teachers/students modules
- expose teacher classes via `models.teachers` package

## Testing
- `python - <<'PY'
from models.common.base_wrapper import MODEL_REGISTRY
print(sorted(MODEL_REGISTRY.keys()))
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886de1c81f48321a4ca3be68ea9d179