### PR TITLE
Handle optional n_head in IB_MBM

### DIFF
--- a/models/mbm.py
+++ b/models/mbm.py
@@ -18,6 +18,9 @@ class IB_MBM(nn.Module):
         logvar_clip: float = 10.0,
         min_std: float = 1e-4,
     ):
+        # handle None or string inputs from config
+        n_head = int(n_head or 1)
+        d_emb = int(d_emb)
         if d_emb % n_head != 0:
             raise ValueError("d_emb must be divisible by n_head")
         super().__init__()


### PR DESCRIPTION
## Summary
- safeguard against `None` or string values for `mbm_n_head`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886ebeb6f048321bb2c5ef2a3fd435f