### PR TITLE
Fix teacher wrapper output access

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -89,8 +89,10 @@ class SynergyEnsemble(nn.Module):
 
     def forward(self, x):
         with torch.no_grad():
-            f1_dict = self.teacher1(x)
-            f2_dict = self.teacher2(x)
+            f1_out = self.teacher1(x)
+            f2_out = self.teacher2(x)
+            f1_dict = f1_out[0] if isinstance(f1_out, tuple) else f1_out
+            f2_dict = f2_out[0] if isinstance(f2_out, tuple) else f2_out
 
         f1_2d = f1_dict["feat_2d"]
         f2_2d = f2_dict["feat_2d"]

--- a/methods/asmb.py
+++ b/methods/asmb.py
@@ -82,8 +82,10 @@ class ASMBDistiller(nn.Module):
         """
         # 1) teacher feats
         with torch.no_grad():
-            t1 = self.teacher1(x)
-            t2 = self.teacher2(x)
+            t1_out = self.teacher1(x)
+            t2_out = self.teacher2(x)
+            t1 = t1_out[0] if isinstance(t1_out, tuple) else t1_out
+            t2 = t2_out[0] if isinstance(t2_out, tuple) else t2_out
             feats_2d = torch.stack([t1["feat_2d"], t2["feat_2d"]], dim=1)
 
         # 3) student (query feature)
@@ -306,8 +308,10 @@ class ASMBDistiller(nn.Module):
                         feat_dict, s_logit, _ = self.student(x)
                         s_feat = feat_dict[self.config.get("feat_kd_key", "feat_2d")]
                         # teacher feats
-                        t1 = self.teacher1(x)
-                        t2 = self.teacher2(x)
+                        t1_out = self.teacher1(x)
+                        t2_out = self.teacher2(x)
+                        t1 = t1_out[0] if isinstance(t1_out, tuple) else t1_out
+                        t2 = t2_out[0] if isinstance(t2_out, tuple) else t2_out
                         key = "distill_feat" if self.config.get("use_distillation_adapter", False) else "feat_2d"
                         f1 = torch.stack([t1[key], t2[key]], dim=1)
 
@@ -469,8 +473,10 @@ class ASMBDistiller(nn.Module):
                 with autocast_ctx:
                     with torch.no_grad():
                         # teacher feats
-                        t1 = self.teacher1(x)
-                        t2 = self.teacher2(x)
+                        t1_out = self.teacher1(x)
+                        t2_out = self.teacher2(x)
+                        t1 = t1_out[0] if isinstance(t1_out, tuple) else t1_out
+                        t2 = t2_out[0] if isinstance(t2_out, tuple) else t2_out
                         f1 = torch.stack([t1["feat_2d"], t2["feat_2d"]], dim=1)
 
                     # student forward (query)

--- a/modules/disagreement.py
+++ b/modules/disagreement.py
@@ -59,8 +59,12 @@ def compute_disagreement_rate(
         x, y = x.to(device), y.to(device)
 
         with autocast_ctx:
-            logit1 = teacher1(x)["logit"]
-            logit2 = teacher2(x)["logit"]
+            out1 = teacher1(x)
+            out2 = teacher2(x)
+            t1 = out1[0] if isinstance(out1, tuple) else out1
+            t2 = out2[0] if isinstance(out2, tuple) else out2
+            logit1 = t1["logit"]
+            logit2 = t2["logit"]
 
         # argmax predictions
         pred1 = logit1.argmax(dim=1)

--- a/modules/trainer_student.py
+++ b/modules/trainer_student.py
@@ -116,8 +116,10 @@ def student_distillation_update(
                 feat_dict, s_logit, _ = student_model(x_mixed)
 
                 with torch.no_grad():
-                    t1_dict = teacher_wrappers[0](x_mixed)
-                    t2_dict = teacher_wrappers[1](x_mixed)
+                    t1_out = teacher_wrappers[0](x_mixed)
+                    t2_out = teacher_wrappers[1](x_mixed)
+                    t1_dict = t1_out[0] if isinstance(t1_out, tuple) else t1_out
+                    t2_dict = t2_out[0] if isinstance(t2_out, tuple) else t2_out
 
                     feat_key = "distill_feat" if cfg.get("use_distillation_adapter", False) \
                                else "feat_2d"


### PR DESCRIPTION
## Summary
- handle tuple outputs from teacher models
- ensure consistency in teacher/student training and evaluation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886ed106638832190983ed168b81df2