### PR TITLE
Fix MBM query dim auto configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -667,6 +667,13 @@ def main(cfg: DictConfig):
             cfg["mbm_query_dim"] = feat_dim
             if cfg.get("debug_verbose"):
                 logging.debug("[Auto-cfg] mbm_query_dim ← %d", cfg["mbm_query_dim"])
+        elif cfg["mbm_query_dim"] != feat_dim:
+            logging.warning(
+                "mbm_query_dim (%s) does not match the student feature dimension (%s).",
+                cfg["mbm_query_dim"],
+                feat_dim,
+            )
+            cfg["mbm_query_dim"] = feat_dim
 
         # mbm_out_dim 이 query_dim 과 다르면 경고만 뜨는데,
         # 특별한 이유가 없으면 동일하게 맞춰 주는 편이 안전하다.


### PR DESCRIPTION
## Summary
- ensure `mbm_query_dim` always matches the student feature dimension
- warn and adjust when config provides a mismatching value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6886eeaa96a48321a3ce494b5f52b717