### PR TITLE
Fix overlapping config values and add experiment fields

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -19,12 +19,7 @@ use_amp: true
 amp_dtype: float16               # float16 | bfloat16
 
 # ───────── KD 계열 공통 기본값 ─────────
-ce_alpha:            0.3
-kd_alpha:            0.7          # 개별 KL
 kd_ens_alpha:        0.0          # 앙상블 KL
-synergy_ce_alpha:    0.4
-teacher_adapt_alpha_kd: 1.0
-teacher_adapt_kd_warmup: 1
 hybrid_beta:         0.05
 
 # ───────── Data Aug / Mix 계열 ─────────

--- a/configs/experiment/res152_effi_l2.yaml
+++ b/configs/experiment/res152_effi_l2.yaml
@@ -13,6 +13,8 @@ exp_id:        res152_effi_l2
 
 # ───────── Optim & 모델 크기 ─────────
 student_type:   resnet152
+teacher1_type:  resnet152
+teacher2_type:  efficientnet_l2
 teacher_lr:     1.0e-4
 teacher_weight_decay: 1.0e-4
 student_lr:     8.0e-4

--- a/configs/method/asmb.yaml
+++ b/configs/method/asmb.yaml
@@ -3,9 +3,6 @@
 method:
   name: asmb
   ce_alpha: 0.3
-  kd_alpha: 0.7
-  synergy_ce_alpha: 0.4        # Adaptive stage 전용
-  teacher_adapt_kd_warmup: 1
-  hybrid_beta: 0.05
-  cutmix_alpha_distill: 0.3
+  kd_alpha: 0.0
+  kd_ens_alpha: 0.7
   # IB (공통) ⇒ base.mbm 에서 설정


### PR DESCRIPTION
## Summary
- remove duplicate ASMB settings from `base.yaml`
- clarify ASMB method defaults with CE/KD/KD Ensemble ratio
- restore teacher model type fields in `res152_effi_l2` experiment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68873c812f008321a61ff1ee06ac18b3