### PR TITLE
Update finetune configs and log progress

### DIFF
--- a/configs/finetune/convnext_l_cifar32.yaml
+++ b/configs/finetune/convnext_l_cifar32.yaml
@@ -2,23 +2,23 @@
 
 # ConvNeXt‑L 파인튜닝 (CIFAR‑100, 32×32 입력)
 defaults:
-  - ../dataset/cifar100            # 32×32 이미지
+  - /dataset: cifar100
   - _self_
 
-teacher_type:        convnext_l   # registry key
-small_input:         true
+teacher_type:  convnext_l
+small_input:   true
 teacher_pretrained:  true
 teacher_ckpt_init:   null                 # 이어서 학습할 ckpt 경로가 있으면 지정
 
 # ─── 옵티마이저 & 학습 하이퍼파라미터 ──────────────────────────
-finetune_epochs:        90
-finetune_lr:            1e-3
+finetune_epochs:        30        # 30 epoch이면 충분히 수렴 (32×32 데이터셋)
+finetune_lr:            5e-4      # AdamW + cosine
 finetune_weight_decay:  5e-2
-warmup_epochs:          5        # cosine 스케줄용
-min_lr:                 1e-5
-batch_size:             128
-label_smoothing:        0.0
-finetune_use_cutmix:    false   # 필요하면 true + alpha 지정
+warmup_epochs:          3
+min_lr:                 1e-6
+batch_size:             64        # 3090 GPU에서 여유
+label_smoothing:        0.1
+finetune_use_cutmix:    true
 finetune_cutmix_alpha:  1.0
 
 # ─── 출력 경로 ────────────────────────────────────────────────

--- a/configs/finetune/efficientnet_l2_cifar32.yaml
+++ b/configs/finetune/efficientnet_l2_cifar32.yaml
@@ -1,21 +1,24 @@
 # configs/finetune/efficientnet_l2_cifar32.yaml
 
 defaults:
-  - ../dataset/cifar100
+  - /dataset: cifar100
   - _self_
 
-teacher_type: efficientnet_l2
-small_input: true
+teacher_type:        efficientnet_l2
+small_input:         true
 # Recommended batch sizes for EfficientNet-L2 are noted in README.md
 teacher_pretrained: true
 teacher_ckpt_init: null
 
-finetune_epochs: 10
-finetune_lr: 3e-4
-finetune_weight_decay: 1e-4
-finetune_use_cutmix: true
-finetune_cutmix_alpha: 1.0
-label_smoothing: 0.0
+finetune_epochs:        30
+finetune_lr:            3e-4
+finetune_weight_decay:  1e-4
+finetune_use_cutmix:    true
+finetune_cutmix_alpha:  1.0
+label_smoothing:        0.1
+
+warmup_epochs:          3
+min_lr:                 1e-6
 
 seed: 42
 device: cuda
@@ -26,5 +29,5 @@ finetune_ckpt_path: checkpoints/efficientnet_l2_cifar32.pth
 
 dataset_name: cifar100
 data_root: ./data
-batch_size: 32
+batch_size:             64         # convnext 파일과 통일
 use_amp: true

--- a/configs/finetune/resnet152_cifar32.yaml
+++ b/configs/finetune/resnet152_cifar32.yaml
@@ -1,34 +1,37 @@
-# configs/finetune/resnet152_cifar32.yaml
-
-# 32×32 CIFAR-100용 ResNet-152 fine-tune
+# 32×32 CIFAR-100 – ResNet-152 fine-tune
 defaults:
-  - ../dataset/cifar100      # 작은 입력용 dataloader (small_input: true)
-# See README.md section "EfficientNet-L2 Batch Size" for GPU memory tips
+  - /dataset: cifar100      # 작은 입력용 dataloader
   - _self_
 
-# ── 모델(교사-1) ───────────────────────────────
-teacher_type: resnet152
-small_input: true            # 3×3 conv, stride1 (+maxpool 제거)
-# See README.md section "EfficientNet-L2 Batch Size" for GPU memory tips
-teacher_pretrained: true     # ImageNet-1k 가중치 로드
-teacher_ckpt_init: null      # 이어-학습할 ckpt가 있으면 경로 지정
+# ---------- 모델 ----------
+teacher_type:  resnet152          # registry key
+small_input:   true               # 3×3 conv , stride 1
+teacher_pretrained:  true
+teacher_ckpt_init:   null         # 이어서 학습할 ckpt 경로가 있으면 지정
 
-# ── 학습 하이퍼파라미터 ────────────────────────
-finetune_epochs: 10
-finetune_lr: 3e-4
-finetune_weight_decay: 1e-4
-finetune_use_cutmix: true
-finetune_cutmix_alpha: 1.0
-label_smoothing: 0.0
+# ---------- 학습 ----------
+finetune_epochs:        30        # convnext / eff-L2 와 통일
+finetune_lr:            3e-4
+finetune_weight_decay:  1e-4
+warmup_epochs:          3
+min_lr:                 1e-6
+batch_size:             64
+label_smoothing:        0.1
+finetune_use_cutmix:    true
+finetune_cutmix_alpha:  1.0
 
-# ── 기타 ─────────────────────────────────────
-seed: 42
-device: cuda
+# ---------- 출력 ----------
+results_dir:   outputs/resnet152_cifar32_ft
+exp_id:        resnet152_cifar32
+finetune_ckpt_path: checkpoints/resnet152_cifar32.pth
+
+# ---------- 기타 ----------
+use_amp:   true
+device:    cuda
+seed:      42
 log_level: INFO
 deterministic: true
 
-finetune_ckpt_path: checkpoints/resnet152_cifar32.pth
-
-# ─── NEW ─────────────────────────────────────────────
-dataset_name: cifar100        # ← loader 에서 요구
-data_root: ./data             # (경로 바꿀 거면 같이 수정)
+# dataloader 편의용 명시
+dataset_name: cifar100
+data_root:    ./data


### PR DESCRIPTION
## Summary
- tweak CIFAR-32 fine-tuning configs
- print training progress each epoch in `fine_tuning.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68878a810bbc8321af1df370cc8b8951