### PR TITLE
Fix config path for finetune script

### DIFF
--- a/run_finetune_clean.sh
+++ b/run_finetune_clean.sh
@@ -28,8 +28,8 @@ shift || true         # 나머지 인자 → Hydra override
 
 # 4) 실행
 python scripts/fine_tuning.py \
-    --config-path ../configs/finetune \
-    --config-name "$CFG_NAME" \
+    --config-path ../configs \
+    --config-name "finetune/$CFG_NAME" \
     "$@"
 
 echo "[run_finetune_clean.sh] ✅ finished – $CFG_NAME"


### PR DESCRIPTION
## Summary
- update `run_finetune_clean.sh` so Hydra config is loaded from the `configs` root
- include subdirectory name when specifying config file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `ruff check run_finetune_clean.sh` *(fails: SyntaxError because ruff does not parse shell scripts)*

------
https://chatgpt.com/codex/tasks/task_e_688797f8143483219d198c1efd369143