### PR TITLE
Apply robust teacher_type lookup

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -307,7 +307,12 @@ def main(cfg: DictConfig):
         small_input = dataset_name in ("cifar100", "imagenet32")
 
     # 2) teacher
-    teacher_type = cfg.get("teacher_type", cfg.get("default_teacher_type"))
+    # ── robust lookup ──────────────────────────────────────────
+    teacher_type = (
+        cfg.get("teacher_type")                        # ① 루트
+        or cfg.get("finetune", {}).get("teacher_type") # ② finetune 그룹
+        or cfg.get("default_teacher_type")             # ③ 마지막 fallback
+    )
     logging.info(
         "[FineTune] ===== Now fine-tuning teacher: %s =====", teacher_type
     )


### PR DESCRIPTION
## Summary
- patch teacher type fallback logic to search finetune group

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887acf2da9c83219f7750cdf6a4c24d