### PR TITLE
Handle directory-less checkpoint paths

### DIFF
--- a/modules/cutmix_finetune_teacher.py
+++ b/modules/cutmix_finetune_teacher.py
@@ -235,7 +235,9 @@ def finetune_teacher_cutmix(
             best_acc = te_acc
             best_state = copy.deepcopy(teacher_model.state_dict())
             # --- save best checkpoint whenever best accuracy is updated ---
-            os.makedirs(os.path.dirname(ckpt_path), exist_ok=True)
+            ckpt_dir = os.path.dirname(ckpt_path)
+            if ckpt_dir:                      # ← 폴더가 있을 때만 생성
+                os.makedirs(ckpt_dir, exist_ok=True)
             torch.save(best_state, ckpt_path)
 
         if ep > warm_epochs:                              # cosine step


### PR DESCRIPTION
## Summary
- avoid making a directory when checkpoint path has none in `cutmix_finetune_teacher.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6887b31f6074832189d00ae8ac085064