### PR TITLE
Remove flatten_hydra_config usage

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -113,9 +113,7 @@ class SynergyEnsemble(nn.Module):
 
 @hydra.main(config_path="configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
-    cfg = OmegaConf.to_container(cfg, resolve=True)
-    from utils.config_utils import flatten_hydra_config
-    cfg = flatten_hydra_config(cfg)
+    cfg = OmegaConf.to_container(cfg, resolve=True)  # 그대로 두고 flatten 제거
     init_logger(cfg.get("log_level", "INFO"))
 
     # 2) set seed

--- a/main.py
+++ b/main.py
@@ -224,10 +224,7 @@ def partial_freeze_student_auto(
 
 @hydra.main(config_path="configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
-    cfg = OmegaConf.to_container(cfg, resolve=True)
-    from utils.config_utils import flatten_hydra_config
-
-    cfg = flatten_hydra_config(cfg)
+    cfg = OmegaConf.to_container(cfg, resolve=True)  # 그대로 두고 flatten 제거
     init_logger(cfg.get("log_level", "INFO"))
 
     # ──────────────────────────────────────────────────────────────

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -244,9 +244,7 @@ def standard_ce_finetune(
 
 @hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
-    cfg = OmegaConf.to_container(cfg, resolve=True)
-    from utils.config_utils import flatten_hydra_config
-    cfg = flatten_hydra_config(cfg)
+    cfg = OmegaConf.to_container(cfg, resolve=True)  # 그대로 두고 flatten 제거
     init_logger(cfg.get("log_level", "INFO"))
     device = cfg.get("device", "cuda")
     if device == "cuda":

--- a/scripts/train_student_baseline.py
+++ b/scripts/train_student_baseline.py
@@ -104,9 +104,7 @@ def train_student_ce(
 
 @hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
-    cfg = OmegaConf.to_container(cfg, resolve=True)
-    from utils.config_utils import flatten_hydra_config
-    cfg = flatten_hydra_config(cfg)
+    cfg = OmegaConf.to_container(cfg, resolve=True)  # 그대로 두고 flatten 제거
     init_logger(cfg.get("log_level", "INFO"))
 
     device = cfg.get("device", "cuda")


### PR DESCRIPTION
## Summary
- drop obsolete `flatten_hydra_config` import and call when parsing Hydra cfg

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688833f6eaf88321a8b39b79d151a5aa