### PR TITLE
Flatten finetune group

### DIFF
--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -245,6 +245,9 @@ def standard_ce_finetune(
 @hydra.main(config_path="../configs", config_name="base", version_base="1.3")
 def main(cfg: DictConfig):
     cfg = OmegaConf.to_container(cfg, resolve=True)  # 그대로 두고 flatten 제거
+    # ─── NEW: promote cfg["finetune"] → root ──────────────────────────
+    if isinstance(cfg.get("finetune"), dict):
+        cfg.update(cfg["finetune"])
     init_logger(cfg.get("log_level", "INFO"))
     device = cfg.get("device", "cuda")
     if device == "cuda":


### PR DESCRIPTION
## Summary
- promote `finetune` subconfig to main config in `scripts/fine_tuning.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68883b0557088321a2ad9f0066be8f86