### PR TITLE
Enable auto model registry and YAML name lookup

### DIFF
--- a/models/common/base_wrapper.py
+++ b/models/common/base_wrapper.py
@@ -5,13 +5,8 @@ import torch.nn as nn
 from typing import Dict, Tuple, Any
 
 # -------------------------------- Registry ----------------------------------
-MODEL_REGISTRY: dict[str, type[nn.Module]] = {}
-
-def register(name: str):
-    def _wrap(cls):
-        MODEL_REGISTRY[name] = cls
-        return cls
-    return _wrap
+from models.common.registry import register
+from models.common.registry import MODEL_REGISTRY
 
 # ---------------------------   BaseKDModel  ---------------------------------
 class BaseKDModel(nn.Module):

--- a/models/common/registry.py
+++ b/models/common/registry.py
@@ -1,0 +1,53 @@
+from importlib import import_module
+from pathlib import Path
+import re
+
+# ---------------------------------------------------------
+# 0)  공용 레지스트리
+# ---------------------------------------------------------
+MODEL_REGISTRY: dict[str, type] = {}
+
+# ---------------------------------------------------------
+# 1)  하위 패키지 재귀 import  →  클래스 정의 로드
+# ---------------------------------------------------------
+def _import_submodules(pkg_root: str):
+    pkg = import_module(pkg_root)
+    root = Path(pkg.__file__).parent
+    for p in root.glob("**/*.py"):
+        if p.name.startswith("_"):
+            continue
+        rel = p.with_suffix("").relative_to(root)
+        mod = f"{pkg_root}.{rel.as_posix().replace('/', '.')}"
+        import_module(mod)
+
+_import_submodules("models.students")
+_import_submodules("models.teachers")
+
+# ---------------------------------------------------------
+# 2)  선택형 데코레이터  (기존 코드 호환)
+# ---------------------------------------------------------
+def register(key: str):
+    def _wrap(cls):
+        MODEL_REGISTRY[key] = cls
+        return cls
+    return _wrap
+
+# ---------------------------------------------------------
+# 3)  **BaseKDModel 파생 클래스 자동 등록**
+#     ‑ @register() 안 붙여도 작동
+# ---------------------------------------------------------
+from models.common.base_wrapper import BaseKDModel   # pylint: disable=cyclic-import
+
+def _snake(s: str) -> str:
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", s)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+def _auto_register():
+    for cls in BaseKDModel.__subclasses__():
+        camel = cls.__name__
+        snake = _snake(camel)
+        short = snake.replace("_student", "").replace("_teacher", "")
+        for k in (camel, snake, short):
+            MODEL_REGISTRY.setdefault(k, cls)
+
+_auto_register()


### PR DESCRIPTION
## Summary
- add new `models.common.registry` with auto-scan and auto-register
- adjust `BaseKDModel` to use the shared registry
- look inside nested YAML config keys for student/teacher names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888a081bd90832186a9bfdc3650d4ac