### PR TITLE
Apply registry and config validation changes

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -175,8 +175,10 @@ def main(cfg: DictConfig):
     else:
         # synergy mode
         # 1) YAML: teacher1_type, teacher2_type
-        teacher1_type = cfg.get("teacher1_type", "resnet152")
-        teacher2_type = cfg.get("teacher2_type", "resnet152")
+        teacher1_type = cfg.get("teacher1_type")
+        teacher2_type = cfg.get("teacher2_type")
+        if not teacher1_type or not teacher2_type:
+            raise ValueError("`teacher1_type` / `teacher2_type` 을 반드시 지정하세요.")
 
         # 2) create teachers
         teacher1 = create_teacher_by_name(

--- a/main.py
+++ b/main.py
@@ -393,16 +393,18 @@ def main(cfg: DictConfig):
         .get("model", {})
         .get("teacher", {})
         .get("name")
-        or "resnet152"
     )
+    if not teacher1_name:
+        raise ValueError("`teacher1_type` (or teacher1.model.teacher.name) 가 필요합니다.")
     teacher2_name = (
         cfg.get("teacher2_type")
         or cfg.get("teacher2", {})
         .get("model", {})
         .get("teacher", {})
         .get("name")
-        or "resnet152"
     )
+    if not teacher2_name:
+        raise ValueError("`teacher2_type` (or teacher2.model.teacher.name) 가 필요합니다.")
 
     teacher1_ckpt_path = cfg.get(
         "teacher1_ckpt", f"./checkpoints/{teacher1_name}_ft.pth"
@@ -555,6 +557,8 @@ def main(cfg: DictConfig):
         .get("student", {})
         .get("name")
     )
+    if not student_name:
+        raise ValueError("`student_type` (or model.student.model.student.name) 가 필요합니다.")
     student_model = create_student_by_name(
         student_name,
         pretrained=cfg.get("student_pretrained", True),

--- a/models/common/registry.py
+++ b/models/common/registry.py
@@ -1,89 +1,43 @@
-# models/common/registry.py
+"""Simple model registry without automatic scanning.
 
-from importlib import import_module
+Models must be registered using ``@register("key")`` or listed in
+``configs/registry_key.yaml`` for lazy import.
+"""
+
 from pathlib import Path
-import re
+from importlib import import_module
+import yaml
 
-# ------------------------------------------------------------------
-# (A) 선택적 수동 등록 – @register 데코레이터
-# ------------------------------------------------------------------
 MODEL_REGISTRY: dict[str, type] = {}
 
+
 def register(key: str):
+    """Decorator to register a model class under ``key``."""
+
     def _wrap(cls):
+        if key in MODEL_REGISTRY:
+            raise KeyError(f"[registry] duplicate key: {key}")
         MODEL_REGISTRY[key] = cls
         return cls
+
     return _wrap
 
-# ---------------------------------------------------------
-# 1)  하위 패키지 재귀 import  →  클래스 정의 로드
-#     (register 가 이미 존재하므로 안전)
-# ---------------------------------------------------------
-def _import_submodules(pkg_root: str):
-    pkg = import_module(pkg_root)
-    root = Path(pkg.__file__).parent
-    for p in root.glob("**/*.py"):
-        if p.name.startswith("_"):
-            continue
-        rel = p.with_suffix("").relative_to(root)
-        mod = f"{pkg_root}.{rel.as_posix().replace('/', '.')}"
-        import_module(mod)
 
-# 외부에서 늦게 호출하도록 노출
-def scan_submodules():
-    _import_submodules("models.students")
-    _import_submodules("models.teachers")
+_CFG = Path(__file__).resolve().parent.parent.parent / "configs" / "registry_key.yaml"
 
-# ---------------------------------------------------------
-# 2)  선택형 데코레이터  (기존 코드 호환)
-# ---------------------------------------------------------
+if _CFG.is_file():
+    with _CFG.open() as f:
+        _cfg = yaml.safe_load(f) or {}
+    _KEYS = _cfg.get("student_keys", []) + _cfg.get("teacher_keys", [])
 
-# ---------------------------------------------------------
-# 3)  **BaseKDModel 파생 클래스 자동 등록**
-#     ‑ @register() 안 붙여도 작동
-# ---------------------------------------------------------
-def _snake(s: str) -> str:
-    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", s)
-    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
-
-def _auto_register(slim: bool = False):
-    """Register subclasses of :class:`BaseKDModel` using multiple keys."""
-    # BaseKDModel import 는 scan 이후 base_wrapper 쪽에서 호출
-    from models.common.base_wrapper import BaseKDModel  # noqa
-
-    for cls in BaseKDModel.__subclasses__():
-        camel = cls.__name__           # e.g. ResNet152Student
-        snake = _snake(camel)          # -> res_net152_student
-        keys = (camel, snake) if slim else (
-            camel,
-            snake,
-            snake.replace("_student", "").replace("_teacher", ""),
-        )
-        for k in keys:
-            MODEL_REGISTRY.setdefault(k, cls)
-
-# 외부에서 늦게 호출하도록 노출
-import yaml
-import pkg_resources
-
-_CFG_PATH = pkg_resources.resource_filename(
-    __name__, "../../configs/registry_key.yaml"
-)
-if Path(_CFG_PATH).is_file():
-    with open(_CFG_PATH, "r") as f:
-        _key_cfg = yaml.safe_load(f)
-    ALLOW_KEYS = set(
-        _key_cfg.get("student_keys", []) + _key_cfg.get("teacher_keys", [])
-    )
-else:
-    ALLOW_KEYS = set()
-
-
-def auto_register(*, slim: bool = False):
-    """Auto register subclasses, then optionally filter by registry_key.yaml."""
-    _auto_register(slim=slim)
-
-    if ALLOW_KEYS:
-        for k in list(MODEL_REGISTRY.keys()):
-            if k not in ALLOW_KEYS:
-                MODEL_REGISTRY.pop(k)
+    for k in _KEYS:
+        if k.endswith("_teacher"):
+            mod = f"models.teachers.{k}"
+        elif k.endswith("_student"):
+            mod = f"models.students.{k}"
+        else:
+            mod = k
+        try:
+            import_module(mod)
+        except ModuleNotFoundError:
+            pass

--- a/scripts/fine_tuning.py
+++ b/scripts/fine_tuning.py
@@ -294,8 +294,9 @@ def main(cfg: DictConfig):
     teacher_type = (
         cfg.get("teacher_type")                        # ① 루트
         or cfg.get("finetune", {}).get("teacher_type") # ② finetune 그룹
-        or cfg.get("default_teacher_type")             # ③ 마지막 fallback
     )
+    if not teacher_type:
+        raise ValueError("`teacher_type` 을 YAML 또는 CLI override 로 지정해야 합니다.")
     logging.info(
         "[FineTune] ===== Now fine-tuning teacher: %s =====", teacher_type
     )


### PR DESCRIPTION
## Summary
- remove automatic submodule scanning from `MODEL_REGISTRY`
- enforce required model type fields in `main.py`
- require explicit teacher types for synergy eval
- require teacher type for fine-tuning script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888bbbd70288321a661e8332217359f