### PR TITLE
Remove root-level config keys

### DIFF
--- a/configs/experiment/res152_convnext_effi.yaml
+++ b/configs/experiment/res152_convnext_effi.yaml
@@ -13,9 +13,6 @@ results_dir:   outputs/res152_convnext_effi
 exp_id:        res152_convnext_effi
 
 # ─── 모델 & Optim ────────────────────────────────────────────
-student_type:   resnet152_pretrain_student
-teacher1_type:  convnext_l_teacher
-teacher2_type:  efficientnet_l2_teacher
 
 teacher_lr:            2.0e-4
 teacher_weight_decay:  1.0e-4


### PR DESCRIPTION
## Summary
- stop using `teacher*_type` and `student_type` root keys
- rely on nested YAML names instead
- delete redundant fields from example experiment config

## Testing
- `python -m py_compile main.py eval.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888bff3bb9883218bb01946f8b47ca2