### PR TITLE
Deferred registry scanning

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,17 +49,22 @@ from modules.partial_freeze import (
 
 # Teacher creation (factory):
 from models.common.base_wrapper import MODEL_REGISTRY
+from models.common import registry as _reg   # ensure_scanned()
 
 
 # ---------------------------------------------------------------------------
 # Helper – safe factory via registry
 def build_model(name: str, **kwargs):
+    # 필요할 때만 실제 모듈 import → 순환 임포트 방지
+    if name not in MODEL_REGISTRY:
+        _reg.ensure_scanned()           # ← scan_submodules() + auto_register()
     try:
         return MODEL_REGISTRY[name](**kwargs)
     except KeyError as exc:
         known = ", ".join(sorted(MODEL_REGISTRY.keys()))
         raise ValueError(
-            f"[build_model] Unknown model key '{name}'. Available: {known}"
+            f"[build_model] Unknown model key '{name}'. "
+            f"Available: {known}"
         ) from exc
 
 

--- a/models/common/base_wrapper.py
+++ b/models/common/base_wrapper.py
@@ -4,11 +4,6 @@ import torch
 import torch.nn as nn
 from typing import Dict, Tuple, Any
 
-# -------------------------------- Registry ----------------------------------
-from models.common import registry as _reg
-register = _reg.register          # 편의 alias
-MODEL_REGISTRY = _reg.MODEL_REGISTRY
-
 # ---------------------------   BaseKDModel  ---------------------------------
 class BaseKDModel(nn.Module):
     """Teacher/Student 공통 래퍼 - forward 규격 단일화."""
@@ -85,4 +80,7 @@ class BaseKDModel(nn.Module):
 # ------------------------------------------------------------------
 # 레지스트리 등록은 registry 모듈 import 시 구성 파일을 통해 수행됩니다.
 # ------------------------------------------------------------------
+
+# ❶ BaseKDModel 정의가 끝난 뒤에 registry 를 가져온다
+from models.common.registry import register, MODEL_REGISTRY  # noqa: E402
 


### PR DESCRIPTION
## Summary
- prevent circular imports by importing registry at end of `base_wrapper`
- delay submodule scanning until needed and add `ensure_scanned()` helper
- trigger scanning in `build_model` when a model key isn't already registered

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888ebd36c50832190ccdd7a02ae5745