### PR TITLE
Remove redundant registry usage

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -10,16 +10,6 @@ __all__ = [
     "build_from_teachers",
 ]
 
+# 패키지 초기화 단계에 서브모듈을 **자동 import 하지 않는다**.
+# 필요할 때 registry.ensure_scanned() 가 수행됨.
 from models.common.base_wrapper import MODEL_REGISTRY
-
-# --------------------------------------------------------------------
-#  모든 *teachers/*.py · *students/*.py 파일을 자동 import 해서
-#  파일 안에 @register("…") 데코레이터가 실행되도록 한다.
-# --------------------------------------------------------------------
-from importlib import import_module
-import pkgutil as _pkgutil
-
-# 현재 패키지(models)의 모든 하위 모듈 순회
-for _finder, _mod_name, _is_pkg in _pkgutil.walk_packages(__path__, prefix=__name__ + "."):
-    if ".teachers." in _mod_name or ".students." in _mod_name:
-        import_module(_mod_name)

--- a/models/common/registry.py
+++ b/models/common/registry.py
@@ -17,6 +17,9 @@ def register(key: str):
     """Decorator for manual registration."""
 
     def _wrap(cls):
+        # 이미 같은 클래스가 등록돼 있으면 그대로 두고 조용히 return
+        if key in MODEL_REGISTRY and MODEL_REGISTRY[key] is cls:
+            return cls
         if key in MODEL_REGISTRY:
             raise KeyError(f"[registry] duplicate key: {key}")
         MODEL_REGISTRY[key] = cls

--- a/models/teachers/convnext_l_teacher.py
+++ b/models/teachers/convnext_l_teacher.py
@@ -38,5 +38,4 @@ class ConvNeXtLTeacher(BaseKDModel):
         feat_2d = feat_4d.mean([-2, -1])
         return feat_4d, feat_2d
 
-from models.common.base_wrapper import register
-register("convnext_l")(ConvNeXtLTeacher)      # ←★ alias 추가
+

--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -78,11 +78,4 @@ def create_efficientnet_l2(
 #  ‑ 기존 class 엔트리는 그대로 두어도 무방
 # -----------------------------------------------------------------
 
-from models.common.base_wrapper import register
 
-# 클래스 이름 그대로도 남기고
-# 실제 생성은 factory 가 담당하도록 별도 키 추가
-register("efficientnet_l2_teacher")(create_efficientnet_l2)   # ← 핵심
-
-# 편의 alias(선택)
-# register("efficientnet_l2")(create_efficientnet_l2)

--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -72,6 +72,4 @@ def create_resnet152(
 MODEL_REGISTRY["resnet_teacher"] = ResNet152Teacher
 
 
-# ─── Student alias ───────────────────────────────────────────
-from models.common.base_wrapper import register
-register("resnet152_student")(ResNet152Teacher)
+


### PR DESCRIPTION
## Summary
- eliminate manual register alias calls from teacher modules
- ignore duplicate registrations of the same class
- stop auto-importing submodules when `models` is imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6888f6bb9ea8832180898e6041ea2fe9