### PR TITLE
Add ConvNeXt partial freeze support

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,15 @@ def partial_freeze_teacher_auto(
             freeze_level=freeze_level,
             train_distill_adapter_only=train_distill_adapter_only,
         )
+    elif teacher_name in ("convnext_l", "convnext_large", "convnext_l_teacher"):
+        from modules.partial_freeze import partial_freeze_teacher_convnext
+        partial_freeze_teacher_convnext(
+            model,
+            freeze_bn=freeze_bn,
+            freeze_level=freeze_level,
+            use_adapter=use_adapter,
+            train_distill_adapter_only=train_distill_adapter_only,
+        )
     else:
         raise ValueError(
             f"[partial_freeze_teacher_auto] Unknown teacher_name={teacher_name}"


### PR DESCRIPTION
## Summary
- allow partial freezing for ConvNeXt-Large teachers
- expose ConvNeXt option through helper wrappers

## Testing
- `ruff check modules/partial_freeze.py main.py` *(fails: E402 errors)*
- `pytest tests/test_partial_freeze.py::test_apply_partial_freeze -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68896e088ae88321a0082b6b4f92fe79