### PR TITLE
Implement YAML-based registry mapping

### DIFF
--- a/configs/registry_map.yaml
+++ b/configs/registry_map.yaml
@@ -1,0 +1,9 @@
+teachers:
+  convnext_l_teacher:      models.teachers.convnext_l_teacher.create_convnext_l
+  efficientnet_l2_teacher: models.teachers.efficientnet_l2_teacher.create_efficientnet_l2
+  resnet152_teacher:       models.teachers.resnet152_teacher.create_resnet152
+
+students:
+  resnet152_pretrain_student: models.students.resnet152_student.create_resnet152_student
+  resnet101_pretrain_student: models.students.resnet101_student.create_resnet101_student
+  resnet50_scratch_student:   models.students.resnet50_student.create_resnet50_student

--- a/models/common/registry.py
+++ b/models/common/registry.py
@@ -1,16 +1,17 @@
 # models/common/registry.py
 
-"""Minimal registry – **자동 스캔은 사용하지 않습니다**.
-   - ``@register("key")`` 로만 수동 등록
-   - 또는 ``configs/registry_key.yaml`` 에 명시된 모듈만 import 합니다.
+"""Minimal registry with a static YAML map.
+
+Models are registered either via ``@register("key")`` decorators or
+``configs/registry_map.yaml`` which lists callables for each key.
+No automatic directory scanning is performed.
 """
 
-from pathlib import Path
 from importlib import import_module
-import re
+from pathlib import Path
 import yaml
 
-MODEL_REGISTRY: dict[str, type] = {}
+MODEL_REGISTRY: dict[str, callable] = {}
 
 
 def register(key: str):
@@ -29,138 +30,32 @@ def register(key: str):
 
 
 # ---------------------------------------------------------
-# 내부 유틸: 서브모듈 import + BaseKDModel 자동 등록
-#   ‐ 직접 호출 금지, 아래 ensure_scanned() 에서만 사용
+# ❶  Load registry entries from configs/registry_map.yaml
 # ---------------------------------------------------------
-def _import_submodules(pkg_root: str):
-    pkg = import_module(pkg_root)
-    root = Path(pkg.__file__).parent
-    for p in root.glob("**/*.py"):
-        if p.name.startswith("_"):
-            continue
-        rel = p.with_suffix("").relative_to(root)
-        mod = f"{pkg_root}.{rel.as_posix().replace('/', '.')}"
-        import_module(mod)
+
+_MAP_PATH = Path(__file__).parent.parent.parent / "configs" / "registry_map.yaml"
+if not _MAP_PATH.is_file():
+    raise FileNotFoundError(f"[registry] manual map file missing → {_MAP_PATH}")
+
+with open(_MAP_PATH, "r") as f:
+    _MAP = yaml.safe_load(f)
+
+for section in ("teachers", "students"):
+    for key, target in (_MAP.get(section, {}) or {}).items():
+        mod_path, attr = target.rsplit(".", 1)
+        obj = getattr(import_module(mod_path), attr)
+        MODEL_REGISTRY[key] = obj
 
 
 # ---------------------------------------------------------
-# ❶  *자동* alias 생성 **전면 제거**
-#     – BaseKDModel 서브클래스도 “데코레이터로 등록한 키”만 유지
+# ❷  decorator 등록 방식 유지
 # ---------------------------------------------------------
-def _auto_register():
-    """No-op: alias 자동 생성 로직을 완전히 비활성화."""
+
+
+# ---------------------------------------------------------
+# ❸  Compatibility dummy – scanning no longer needed
+# ---------------------------------------------------------
+def ensure_scanned(*, slim: bool = False):  # noqa: D401
+    """Registry is ready at import-time (no auto-scan needed)."""
     return
-
-
-# ---------------------------------------------------------
-# ❷  registry_key.yaml  (허용 키 필터)
-# ---------------------------------------------------------
-import yaml, pkg_resources, json
-_CFG_PATH = pkg_resources.resource_filename(__name__, "../../configs/registry_key.yaml")
-if Path(_CFG_PATH).is_file():
-    with open(_CFG_PATH, "r") as f:
-        _key_cfg = yaml.safe_load(f)
-    _ALLOW_KEYS = set(_key_cfg.get("student_keys", []) + _key_cfg.get("teacher_keys", []))
-else:
-    _ALLOW_KEYS = set()
-
-# ---------------------------------------------------------------------------
-# 호출 여부 플래그와 헬퍼
-_SCANNED = False
-
-
-def ensure_scanned(*, slim: bool = False):
-    """첫 호출 시 students / teachers 서브모듈 import → 자동 등록"""
-    global _SCANNED
-    if _SCANNED:
-        return
-
-    # ------------------------------------------------------------------
-    #  A) 1차:  registry_key.yaml 의 key → 대응 모듈만 import
-    # ------------------------------------------------------------------
-    def _deduce_module(key: str) -> list[str]:
-        """
-        key → import 대상 후보 목록
-
-        - <base>_pretrain_student  →  models.students.<base>_student
-        - <base>_scratch_student   →            "
-        - <base>_student           →  그대로
-        - <base>_teacher           →  그대로
-        - 접미사 없으면 두 군데 모두 시도
-        """
-        if key.endswith("_teacher"):
-            return [f"models.teachers.{key}"]
-
-        if key.endswith("_student"):
-            # pretrain/scratch → student 파일
-            base = key.rsplit("_", 2)[0]   # 'resnet152'
-            return [
-                f"models.students.{base}_student",   # 표준 파일
-                f"models.students.{key}",            # 혹시 동일 파일명도 있을 때
-            ]
-
-        # 접미사 없는 경우
-        return [
-            f"models.students.{key}_student",
-            f"models.teachers.{key}_teacher",
-        ]
-
-    import logging
-
-    for k in _ALLOW_KEYS:
-        ok = False
-        for m in _deduce_module(k):
-            try:
-                import_module(m)
-                ok = True          # 한 번 성공하면 더 시도 X
-                break
-            except ModuleNotFoundError:
-                continue
-        if not ok:                 # 후보 전부 실패했을 때만 경고
-            logging.warning("[registry] import failed for key '%s'", k)
-
-    _auto_register()        # ← 지금은 빈 함수 (alias X)
-
-    # ------------------------------------------------------------------
-    #  B) 2차: allow-list 필터  (scan 후에도 key 누락시 제거)
-    # ------------------------------------------------------------------
-    if _ALLOW_KEYS:
-        # 1-A) 먼저 허용-키에 없는 기존 엔트리는 제거
-        for k in list(MODEL_REGISTRY):
-            if k not in _ALLOW_KEYS:
-                MODEL_REGISTRY.pop(k)
-
-        # 1-B) 허용-키인데 아직 없는 경우 ↔ 자동 alias 보강
-        def _try_alias(key: str, *candidates: str):
-            for c in candidates:
-                if c in MODEL_REGISTRY:
-                    MODEL_REGISTRY[key] = MODEL_REGISTRY[c]
-                    break
-
-        for k in _ALLOW_KEYS:
-            if k in MODEL_REGISTRY:
-                continue
-
-            # ── Student 키 패턴:  base_(pretrain|scratch)
-            m = re.match(r"(.+?)_(pretrain|scratch)$", k)
-            if m:
-                base = m.group(1)
-                _try_alias(
-                    k,
-                    f"{base}_student",
-                    base,
-                    f"{base}student",
-                )
-                continue
-
-            # ── Teacher 키:  base
-            base = k
-            _try_alias(
-                k,
-                f"{base}_teacher",
-                base,
-                f"{base}teacher",
-            )
-
-    _SCANNED = True
 

--- a/models/students/resnet101_student.py
+++ b/models/students/resnet101_student.py
@@ -37,6 +37,21 @@ class ResNetStudent(BaseKDModel):
         f2d = torch.flatten(b.avgpool(f4d), 1)
         return f4d, f2d
 
+
+def create_resnet101_student(
+    pretrained: bool = True,
+    num_classes: int = 100,
+    small_input: bool = False,
+    cfg: dict | None = None,
+) -> ResNetStudent:
+    """Build :class:`ResNetStudent`."""
+    return ResNetStudent(
+        pretrained=pretrained,
+        num_classes=num_classes,
+        small_input=small_input,
+        cfg=cfg,
+    )
+
 # legacy registry key for backward compatibility
 from models.common.base_wrapper import MODEL_REGISTRY
 MODEL_REGISTRY["resnet101_adapter_student"] = ResNetStudent

--- a/models/students/resnet152_student.py
+++ b/models/students/resnet152_student.py
@@ -46,3 +46,18 @@ class ResNet152Student(BaseKDModel):
         f4d = b.layer4(x)
         f2d = torch.flatten(b.avgpool(f4d), 1)
         return f4d, f2d
+
+
+def create_resnet152_student(
+    num_classes: int = 100,
+    pretrained: bool = True,
+    small_input: bool = False,
+    cfg: dict | None = None,
+) -> ResNet152Student:
+    """Build :class:`ResNet152Student`."""
+    return ResNet152Student(
+        num_classes=num_classes,
+        pretrained=pretrained,
+        small_input=small_input,
+        cfg=cfg,
+    )

--- a/models/students/resnet50_student.py
+++ b/models/students/resnet50_student.py
@@ -43,3 +43,18 @@ class ResNet50Student(BaseKDModel):
         feat_2d = torch.flatten(b.avgpool(feat_4d), 1)
         return feat_4d, feat_2d
 
+
+def create_resnet50_student(
+    pretrained: bool = True,
+    num_classes: int = 100,
+    small_input: bool = False,
+    cfg: dict | None = None,
+) -> ResNet50Student:
+    """Build :class:`ResNet50Student`."""
+    return ResNet50Student(
+        pretrained=pretrained,
+        num_classes=num_classes,
+        small_input=small_input,
+        cfg=cfg,
+    )
+

--- a/models/teachers/convnext_l_teacher.py
+++ b/models/teachers/convnext_l_teacher.py
@@ -5,10 +5,9 @@ from typing import Optional
 
 import timm
 
-from models.common.base_wrapper import BaseKDModel, register
+from models.common.base_wrapper import BaseKDModel
 
 
-@register("convnext_l_teacher")
 class ConvNeXtLTeacher(BaseKDModel):
     """ConvNeXt-Large teacher (22K pre-train)."""
 
@@ -37,5 +36,22 @@ class ConvNeXtLTeacher(BaseKDModel):
         feat_4d = self.backbone.forward_features(x)
         feat_2d = feat_4d.mean([-2, -1])
         return feat_4d, feat_2d
+
+# (등록은 registry_map.yaml에서 수행)
+
+
+def create_convnext_l(
+    num_classes: int = 100,
+    pretrained: bool = True,
+    small_input: bool = False,
+    cfg: Optional[dict] = None,
+) -> ConvNeXtLTeacher:
+    """Build :class:`ConvNeXtLTeacher`."""
+    return ConvNeXtLTeacher(
+        num_classes=num_classes,
+        pretrained=pretrained,
+        small_input=small_input,
+        cfg=cfg,
+    )
 
 

--- a/models/teachers/efficientnet_l2_teacher.py
+++ b/models/teachers/efficientnet_l2_teacher.py
@@ -4,10 +4,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from typing import Optional
 import timm
-from models.common.base_wrapper import BaseKDModel, register
+from models.common.base_wrapper import BaseKDModel
 
 
-@register("efficientnet_l2_teacher")
 class EfficientNetL2Teacher(BaseKDModel):
     """EfficientNet-L2 (Noisy Student) Teacher."""
 
@@ -20,6 +19,8 @@ class EfficientNetL2Teacher(BaseKDModel):
         f4d = self.backbone.forward_features(x)
         f2d = F.adaptive_avg_pool2d(f4d, 1).flatten(1)
         return f4d, f2d
+
+# (등록은 registry_map.yaml에서 수행)
 
 
 def create_efficientnet_l2(

--- a/models/teachers/resnet152_teacher.py
+++ b/models/teachers/resnet152_teacher.py
@@ -2,12 +2,11 @@
 
 import torch
 import torch.nn as nn
-from models.common.base_wrapper import BaseKDModel, register, MODEL_REGISTRY
+from models.common.base_wrapper import BaseKDModel, MODEL_REGISTRY
 
 import torchvision.models as tv
 
 
-@register("resnet152_teacher")
 class ResNet152Teacher(BaseKDModel):
     """ResNet-152 Teacher with optional distillation adapter."""
 
@@ -56,6 +55,8 @@ class ResNet152Teacher(BaseKDModel):
         f4d = b.layer4(x)
         f2d = torch.flatten(b.avgpool(f4d), 1)
         return f4d, f2d
+
+# (등록은 registry_map.yaml에서 수행)
 
 
 def create_resnet152(


### PR DESCRIPTION
## Summary
- load manual registry map from `configs/registry_map.yaml`
- simplify registry logic
- remove `register` decorators from teacher models
- add builder helpers for students and convnext teacher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6889c4cf8d0c8321b38cfa3428c6e6ae