### PR TITLE
Improve teacher name handling in freeze_teacher_params

### DIFF
--- a/modules/partial_freeze.py
+++ b/modules/partial_freeze.py
@@ -360,7 +360,18 @@ def freeze_teacher_params(
     freeze_level: int = 1,
     train_distill_adapter_only: bool = False,
 ) -> None:
-    """Wrapper that partially freezes a teacher model by type."""
+    """Wrapper that partially freezes a teacher model by type.
+
+    The caller may pass either ``"convnext_l"`` or ``"convnext_l_teacher"``
+    — we strip a trailing ``"_teacher"`` so that both variants map to the
+    same control branch below.
+    """
+
+    # ----------------------------------------------------------
+    # (★) key normalisation →  convnext_l_teacher → convnext_l
+    # ----------------------------------------------------------
+    if teacher_name.endswith("_teacher"):
+        teacher_name = teacher_name[:-8]       # drop "_teacher"
     if teacher_name == "resnet152":
         partial_freeze_teacher_resnet(
             model,


### PR DESCRIPTION
## Summary
- extend documentation of `freeze_teacher_params`
- normalize teacher names by stripping a trailing `_teacher`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688a4e97a3608321a78e4ee32bbc08b2