### PR TITLE
Add teacher suffix handling in partial_freeze_teacher_auto

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,6 +127,8 @@ def partial_freeze_teacher_auto(
     freeze_level=1,
     train_distill_adapter_only=False,
 ):
+    if teacher_name.endswith("_teacher"):
+        teacher_name = teacher_name[:-8]   # "efficientnet_l2_teacher" → "efficientnet_l2"
     if teacher_name == "resnet152":
         partial_freeze_teacher_resnet(
             model,


### PR DESCRIPTION
## Summary
- normalize `teacher_name` at the start of `partial_freeze_teacher_auto`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688a508270648321b0b5b79ce7fa1847